### PR TITLE
Add coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,26 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+source = kartothek
+# omit = bad_file.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ before_script:
 script:
   - pytest
 
+after_success:
+  - pip install codecov
+  - codecov
+
 deploy:
   provider: pypi
   user: fjetter

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ kartothek
 
 [![Build Status](https://travis-ci.org/JDASoftwareGroup/kartothek.svg?branch=master)](https://travis-ci.org/JDASoftwareGroup/kartothek)
 [![Documentation Status](https://readthedocs.org/projects/kartothek/badge/?version=latest)](https://kartothek.readthedocs.io/en/latest/?badge=latest)
+[![codecov.io](https://codecov.io/github/JDASoftwareGroup/kartothek/coverage.svg?branch=master)](https://codecov.io/github/JDASoftwareGroup/kartothek)
 
 Datasets are a collection of files with the same schema that reside in
 a storage. `kartothek` offers a metadata definition to handle these datasets


### PR DESCRIPTION
This adds a coverage report and publishes on codecov.io

example: https://codecov.io/gh/fjetter/kartothek/branch/add_coverage