### PR TITLE
Update black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,16 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 18.9b0
+    rev: 19.3b0
     hooks:
       - id: black
-        args: [--safe]
-        python_version: python3.6
+        args:
+          - --safe
+          - --target-version=py36
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.2.1
     hooks:
     -   id: flake8
-        rev: 3.6.0
-        python_version: python3.6
 
   - repo: git://github.com/pre-commit/mirrors-isort
     rev: v4.3.18
@@ -19,4 +18,3 @@ repos:
     -   id: isort
         additional_dependencies: [toml]
         verbose: true
-        python_version: python3.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,8 @@ We have pre-commit hooks for all of these tools which take care of formatting
 and checking the code. To set up these hooks, please follow the installation
 instructions on the [pre-commit](https://pre-commit.com) homepage.
 
-If you prefer to perform manual formatting and linting, you can install and run the necessary
-tools like this
+If you prefer to perform manual formatting and linting, you can run the necessary
+toolchain like this
 
 ```bash
 ./format_code.sh

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"kartothek"
+project = "kartothek"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/format_code.sh
+++ b/format_code.sh
@@ -1,4 +1,2 @@
 #!/bin/bash -xe
-black .
-isort -y -rc .
-flake8
+pre-commit run -a

--- a/kartothek/io/testing/read.py
+++ b/kartothek/io/testing/read.py
@@ -133,7 +133,7 @@ def _perform_read_test(
         categoricals=categoricals,
         label_filter=label_filter,
         dates_as_object=dates_as_object,
-        **read_kwargs
+        **read_kwargs,
     )
 
     # The filter should allow only a single partition
@@ -236,7 +236,7 @@ def test_read_dataset_as_dataframes_predicate(
         dataset_uuid=dataset.uuid,
         store=store_session_factory,
         predicates=predicates,
-        **custom_read_parameters
+        **custom_read_parameters,
     )
     core_result = pd.concat([data["core"] for data in result])
 
@@ -285,7 +285,7 @@ def test_read_dataset_as_dataframes_predicate_with_partition_keys(
         store=store_session_factory,
         predicates=predicates,
         tables=["core"],
-        **custom_read_parameters
+        **custom_read_parameters,
     )
 
     core_result = pd.concat([data["core"] for data in result])
@@ -319,7 +319,7 @@ def test_read_dataset_as_dataframes_predicate_empty(
         predicates=[[("P", "==", -42)]],
         tables=["core"],
         columns={"core": ["P", "L", "TARGET"]},
-        **custom_read_parameters
+        **custom_read_parameters,
     )
     assert len(result) == 0
 
@@ -352,7 +352,7 @@ def test_read_dataset_as_dataframes_concat_primary(
         store=store_factory,
         concat_partitions_on_primary_index=True,
         predicates=[[("b", "==", "1")]],
-        **custom_read_parameters
+        **custom_read_parameters,
     )
     result_df = result[0]["data"].sort_values(by="c")
 

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -129,7 +129,7 @@ def validate_partition_keys(
     ds_factory,
     default_metadata_version,
     partition_on,
-    **load_kwargs
+    **load_kwargs,
 ):
     if ds_factory or DatasetMetadata.exists(dataset_uuid, _instantiate_store(store)):
         ds_factory = _ensure_factory(

--- a/kartothek/serialization/_csv.py
+++ b/kartothek/serialization/_csv.py
@@ -37,7 +37,7 @@ class CsvSerializer(DataFrameSerializer):
         columns=None,
         categories=None,
         predicates=None,
-        **kwargs
+        **kwargs,
     ):
         check_predicates(predicates)
 

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -161,8 +161,8 @@ class ParquetSerializer(DataFrameSerializer):
             missing_columns = set(columns) - set(table.schema.names)
             if missing_columns:
                 raise ValueError(
-                    u"Columns cannot be found in stored dataframe: {missing}".format(
-                        missing=u", ".join(sorted(missing_columns))
+                    "Columns cannot be found in stored dataframe: {missing}".format(
+                        missing=", ".join(sorted(missing_columns))
                     )
                 )
 

--- a/kartothek/serialization/testing.py
+++ b/kartothek/serialization/testing.py
@@ -23,7 +23,7 @@ BINARY_COLUMNS = [
     "4".encode("utf-32"),
     # this is a type1 UUID
     b"\x8f\xb6\xe5@\x90\xdc\x11\xe8\xa0\xae\x02B\xac\x12\x01\x06",
-    u"🙈".encode("utf-8"),
+    "🙈".encode("utf-8"),
     _to_binary(chr(128)),
 ]
 

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -21,7 +21,5 @@ sphinx_rtd_theme
 IPython
 
 # Formatting / Checking
-black[d]==18.9b0
-flake8-mutable==1.2.0
-flake8==3.6.0
-isort[pyproject]==4.3.18
+pre-commit
+flake8-mutable

--- a/tests/core/test_common_metadata.py
+++ b/tests/core/test_common_metadata.py
@@ -360,7 +360,7 @@ def test_validate_different_cats_same_type():
 
 def test_validate_different_cats_different_type():
     input_df = pd.DataFrame(
-        {"categories": pd.Series([u"a", u"b", u"c", u"a"], dtype="category")}
+        {"categories": pd.Series(["a", "b", "c", "a"], dtype="category")}
     )
     input_df_2 = pd.DataFrame(
         {"categories": pd.Series([b"f", b"e", b"e", b"f"], dtype="category")}

--- a/tests/io/dask/dataframe/test_read.py
+++ b/tests/io/dask/dataframe/test_read.py
@@ -19,7 +19,7 @@ def _read_as_ddf(
     categoricals=None,
     tables=None,
     dataset_has_index=False,
-    **kwargs
+    **kwargs,
 ):
     table = tables or "core"
     if categoricals:
@@ -30,7 +30,7 @@ def _read_as_ddf(
         factory=factory,
         categoricals=categoricals,
         table=table,
-        **kwargs
+        **kwargs,
     )
     if categoricals:
         assert ddf._meta.dtypes["P"] == pd.api.types.CategoricalDtype(

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -38,7 +38,7 @@ def _update_dataset(partitions, secondary_indices=None, *args, **kwargs):
         *args,
         table=table_name,
         secondary_indices=secondary_indices,
-        **kwargs
+        **kwargs,
     ).compute()
 
 

--- a/tests/io_components/test_mutate.py
+++ b/tests/io_components/test_mutate.py
@@ -161,22 +161,22 @@ def test_align_datasets_right(dataset, evaluation_dataset, store_session):
 
     mp_list = list_metapartitions[0]
     assert len(mp_list) == 3, [mp.label for mp in mp_list]
-    expected = [u"cluster_1_1", u"cluster_1", u"cluster_2"]
+    expected = ["cluster_1_1", "cluster_1", "cluster_2"]
     assert [mp.label for mp in mp_list] == expected
 
     mp_list = list_metapartitions[1]
     assert len(mp_list) == 3, [mp.label for mp in mp_list]
-    expected = [u"cluster_1_2", u"cluster_1", u"cluster_2"]
+    expected = ["cluster_1_2", "cluster_1", "cluster_2"]
     assert [mp.label for mp in mp_list] == expected
 
     mp_list = list_metapartitions[2]
     assert len(mp_list) == 3, [mp.label for mp in mp_list]
-    expected = [u"cluster_2_1", u"cluster_1", u"cluster_2"]
+    expected = ["cluster_2_1", "cluster_1", "cluster_2"]
     assert [mp.label for mp in mp_list] == expected
 
     mp_list = list_metapartitions[3]
     assert len(mp_list) == 3, [mp.label for mp in mp_list]
-    expected = [u"cluster_2_2", u"cluster_1", u"cluster_2"]
+    expected = ["cluster_2_2", "cluster_1", "cluster_2"]
     assert [mp.label for mp in mp_list] == expected
 
 

--- a/tests/io_components/test_read.py
+++ b/tests/io_components/test_read.py
@@ -88,7 +88,7 @@ def test_dispatch_metapartitions_query_partition_on(
     )
     partitions = list(generator)
     assert len(partitions) == 1
-    assert partitions[0].label == u"P=2/cluster_2"
+    assert partitions[0].label == "P=2/cluster_2"
 
 
 @pytest.mark.min_metadata_version(4)

--- a/tests/serialization/test_dataframe.py
+++ b/tests/serialization/test_dataframe.py
@@ -257,7 +257,7 @@ def test_predicate_pushdown(
         key,
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         predicates=predicates,
-        **read_kwargs
+        **read_kwargs,
     )
     assert_frame_almost_equal(result, expected)
 
@@ -271,7 +271,7 @@ def test_predicate_pushdown(
         key,
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         predicates=predicates,
-        **read_kwargs
+        **read_kwargs,
     )
     assert_frame_almost_equal(result, expected)
 
@@ -283,7 +283,7 @@ def test_predicate_pushdown(
         key,
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         predicates=predicates,
-        **read_kwargs
+        **read_kwargs,
     )
     assert_frame_almost_equal(result, expected)
 
@@ -295,7 +295,7 @@ def test_predicate_pushdown(
         key,
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         predicates=predicates,
-        **read_kwargs
+        **read_kwargs,
     )
     assert_frame_almost_equal(result, expected)
 
@@ -307,7 +307,7 @@ def test_predicate_pushdown(
         key,
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         predicates=predicates,
-        **read_kwargs
+        **read_kwargs,
     )
     assert_frame_almost_equal(result, expected)
 
@@ -319,7 +319,7 @@ def test_predicate_pushdown(
         key,
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         predicates=predicates,
-        **read_kwargs
+        **read_kwargs,
     )
     assert_frame_almost_equal(result, expected)
 
@@ -331,7 +331,7 @@ def test_predicate_pushdown(
         key,
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         predicates=predicates,
-        **read_kwargs
+        **read_kwargs,
     )
     assert_frame_almost_equal(result, expected)
 
@@ -343,7 +343,7 @@ def test_predicate_pushdown(
         key,
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         predicates=predicates,
-        **read_kwargs
+        **read_kwargs,
     )
     assert_frame_almost_equal(result, expected)
 
@@ -355,7 +355,7 @@ def test_predicate_pushdown(
             key,
             predicate_pushdown_to_io=predicate_pushdown_to_io,
             predicates=predicates,
-            **read_kwargs
+            **read_kwargs,
         )
     assert str(exc.value) == "Malformed predicates"
 
@@ -367,7 +367,7 @@ def test_predicate_pushdown(
             key,
             predicate_pushdown_to_io=predicate_pushdown_to_io,
             predicates=predicates,
-            **read_kwargs
+            **read_kwargs,
         )
     assert str(exc.value) == "Malformed predicates"
 
@@ -379,7 +379,7 @@ def test_predicate_pushdown(
             key,
             predicate_pushdown_to_io=predicate_pushdown_to_io,
             predicates=predicates,
-            **read_kwargs
+            **read_kwargs,
         )
     assert str(exc.value) == "Malformed predicates"
 

--- a/tests/serialization/test_parquet.py
+++ b/tests/serialization/test_parquet.py
@@ -148,8 +148,8 @@ def _validate_predicate_pushdown(df, column, value, store, chunk_size):
     [
         (3, None),
         (3.0, TypeError),
-        (u"3", TypeError),
-        (u"3.0", TypeError),
+        ("3", TypeError),
+        ("3.0", TypeError),
         (b"3", TypeError),
         (b"3.0", TypeError),
     ],
@@ -175,8 +175,8 @@ def test_predicate_evaluation_integer(
     [
         (3, None),
         (3.0, TypeError),
-        (u"3", TypeError),
-        (u"3.0", TypeError),
+        ("3", TypeError),
+        ("3.0", TypeError),
         (b"3", TypeError),
         (b"3.0", TypeError),
     ],
@@ -202,8 +202,8 @@ def test_predicate_evaluation_unsigned_integer(
     [
         (3, TypeError),
         (3.0, None),
-        (u"3", TypeError),
-        (u"3.0", TypeError),
+        ("3", TypeError),
+        ("3.0", TypeError),
         (b"3", TypeError),
         (b"3.0", TypeError),
     ],
@@ -225,7 +225,7 @@ def test_predicate_evaluation_float(
 
 @pytest.mark.parametrize("column", _STR_TYPES)
 @pytest.mark.parametrize(
-    "input_values", [(3, TypeError), (3.0, TypeError), (u"3", None), (b"3", None)]
+    "input_values", [(3, TypeError), (3.0, TypeError), ("3", None), (b"3", None)]
 )
 def test_predicate_evaluation_string(
     store, dataframe_not_nested, column, input_values, chunk_size
@@ -248,13 +248,13 @@ def test_predicate_evaluation_string(
     [
         # it's the fifth due to the day % 31 in the testdata
         (date(2018, 1, 5), None),
-        (u"2018-01-05", None),
+        ("2018-01-05", None),
         (b"2018-01-05", None),
         (datetime(2018, 1, 1, 1, 1), TypeError),
         (3, TypeError),
         (3.0, TypeError),
-        (u"3", ValueError),
-        (u"3.0", ValueError),
+        ("3", ValueError),
+        ("3.0", ValueError),
         (b"3", ValueError),
         (b"3.0", ValueError),
     ],
@@ -286,7 +286,7 @@ def test_predicate_evaluation_date(
         (np.datetime64(datetime(2018, 1, 5), "us"), None),
         (np.datetime64(datetime(2018, 1, 5), "ns"), None),
         (date(2018, 1, 4), TypeError),
-        (u"2018-01-04", TypeError),
+        ("2018-01-04", TypeError),
         (b"2018-01-04", TypeError),
         (1, TypeError),
         (1.0, TypeError),

--- a/tests/serialization/test_util.py
+++ b/tests/serialization/test_util.py
@@ -6,7 +6,7 @@ from kartothek.serialization._util import ensure_unicode_string_type
 
 
 @pytest.mark.parametrize(
-    "obj,expected", [(u"tüst", u"tüst"), (u"tüst".encode("utf8"), u"tüst")]
+    "obj,expected", [("tüst", "tüst"), ("tüst".encode("utf8"), "tüst")]
 )
 def test_ensure_unicode_string_types(obj, expected):
     actual = ensure_unicode_string_type(obj)


### PR DESCRIPTION
The only notable change here is that the `format_code` script calls the pre-commit hooks. This way we can keep everything aligned. This is also how we do it in the CI pipeline.

I also updated the minimal python version for the formatting, hence the large diff