### PR TITLE
Implement efficient partial index serialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Version 3.1.0 (2019-XX-XX)
     + ``io.eager.index.build_dataset_indices``
     + ``io.eager.update_dataset_from_dataframes``
 - fix ``_apply_partition_key_predicates`` ``FutureWarning``
+- serialize :class:`~kartothek.core.index.ExplicitSecondaryIndex` to parquet
 
 **Breaking:**
 

--- a/asv_bench/benchmarks/index.py
+++ b/asv_bench/benchmarks/index.py
@@ -2,7 +2,9 @@
 # See "Writing benchmarks" in the asv docs for more information.
 
 
+import pickle
 import shutil
+import sys
 import tempfile
 
 import numpy as np
@@ -61,6 +63,15 @@ class Index(AsvBenchmarkConfig):
         self, number_values, number_partitions, arrow_type
     ):
         self.ktk_index.as_flat_series(partitions_as_index=True)
+
+    def track_mem_serialized(self, number_values, number_partitions, arrow_type):
+        # Use `sys.getsizeof` as asv's `mem_*` just reports `0` if memory usage is low
+        # enough
+        return sys.getsizeof(pickle.dumps(self.ktk_index))
+
+    def time_serialization(self, number_values, number_partitions, arrow_type):
+        # Time serialization of indices
+        pickle.loads(pickle.dumps(self.ktk_index))
 
 
 class BuildIndex(AsvBenchmarkConfig):

--- a/kartothek/core/index.py
+++ b/kartothek/core/index.py
@@ -521,7 +521,12 @@ class ExplicitSecondaryIndex(IndexBase):
             return False
         if self.index_storage_key != other.index_storage_key:
             return False
-        return super(ExplicitSecondaryIndex, self).__eq__(other)
+        try:
+            return super(ExplicitSecondaryIndex, self).__eq__(other)
+        except TypeError:  # an `index_dct == None`
+            if self.index_dct != other.index_dct:
+                return False
+            return True
 
     @staticmethod
     def from_v2(column, dct_or_str):

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -2,6 +2,7 @@
 cloudpickle
 dill
 distributed
+pytz
 toolz
 
 # Test Framework

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -707,3 +707,15 @@ def test_serialization_normalization(key):
     assert index.normalize_value(index.dtype, key) == index2.normalize_value(
         index2.dtype, key
     )
+
+
+def test_serialization_no_indices(store):
+    index = ExplicitSecondaryIndex(column="col", index_dct={1: ["part_1"]})
+    storage_key = index.store(store=store, dataset_uuid="uuid")
+
+    # Create index without `index_dct`
+    index = ExplicitSecondaryIndex(column="col", index_storage_key=storage_key)
+
+    index2 = pickle.loads(pickle.dumps(index))
+
+    assert index == index2

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pytest
+import pytz
 from hypothesis import assume, given
 from pandas.testing import assert_series_equal
 
@@ -367,16 +368,26 @@ def test_index_as_flat_series_date():
     assert_series_equal(ser, expected)
 
 
-def test_index_store_roundtrip_ts(store):
+@pytest.mark.parametrize(
+    "dtype, timestamps",
+    [
+        (pa.timestamp("ns"), [pd.Timestamp("2017-01-01"), pd.Timestamp("2017-01-02")]),
+        (
+            pa.timestamp("ns"),
+            [
+                pd.Timestamp("2017-01-01", tzinfo=pytz.timezone("EST")),
+                pd.Timestamp("2017-01-02", tzinfo=pytz.timezone("EST")),
+            ],
+        ),
+    ],
+)
+def test_index_store_roundtrip_ts(store, dtype, timestamps):
     storage_key = "dataset_uuid/some_index.parquet"
     index1 = ExplicitSecondaryIndex(
         column="col",
-        index_dct={
-            pd.Timestamp("2017-01-01"): ["part_1", "part_2"],
-            pd.Timestamp("2017-01-02"): ["part_3"],
-        },
+        index_dct=dict(zip(timestamps, [["part_1", "part_2"], ["part_3"]])),
         index_storage_key=storage_key,
-        dtype=pa.timestamp("ns"),
+        dtype=dtype,
     )
     key1 = index1.store(store, "dataset_uuid")
 
@@ -448,6 +459,18 @@ def test_index_raises_null_dtype():
         ),
         (pa.timestamp("ns"), "2018-01-01", pd.Timestamp("2018-01-01").to_datetime64()),
         (pa.date32(), "2018-01-01", datetime.date(2018, 1, 1)),
+        (
+            pa.timestamp("ns", tz=pytz.timezone("Europe/Berlin")),
+            pd.Timestamp("2018-01-01", tzinfo=pytz.timezone("Europe/Berlin")),
+            pd.Timestamp(
+                "2018-01-01", tzinfo=pytz.timezone("Europe/Berlin")
+            ).to_datetime64(),
+        ),
+        (
+            pa.timestamp("ns", tz=pytz.timezone("Europe/Berlin")),
+            "2018-01-01",  # Naive date, is interpreted as being UTC
+            pd.Timestamp("2018-01-01", tzinfo=pytz.timezone("UTC")).to_datetime64(),
+        ),
     ],
 )
 def test_index_normalize_value(dtype, value, expected):


### PR DESCRIPTION
Command used to run benchmarks: `asv run --python=same --show-stderr --bench=Index.track_mem_serialized`

Diff of benchmark results (`diff old.txt new.txt`) :
```
< [100.00%] ··· =============== =================== =================================== ==========
<                number_values   number_partitions                 dtype
<               --------------- ------------------- ----------------------------------- ----------
<                      10                10           (<class 'int'>, DataType(int64))     1145
<                      10                10          (<class 'str'>, DataType(string))     1206
<                      10               1000          (<class 'int'>, DataType(int64))    128558
<                      10               1000         (<class 'str'>, DataType(string))    128649
<                     1000               10           (<class 'int'>, DataType(int64))    120304
<                     1000               10          (<class 'str'>, DataType(string))    130451
<                     1000              1000          (<class 'int'>, DataType(int64))   12900304
<                     1000              1000         (<class 'str'>, DataType(string))   12910451
<               =============== =================== =================================== ==========
---
> [100.00%] ··· =============== =================== =================================== ========
>                number_values   number_partitions                 dtype
>               --------------- ------------------- ----------------------------------- --------
>                      10                10           (<class 'int'>, DataType(int64))    792
>                      10                10          (<class 'str'>, DataType(string))    707
>                      10               1000          (<class 'int'>, DataType(int64))    6681
>                      10               1000         (<class 'str'>, DataType(string))    6596
>                     1000               10           (<class 'int'>, DataType(int64))    6349
>                     1000               10          (<class 'str'>, DataType(string))    6272
>                     1000              1000          (<class 'int'>, DataType(int64))   109994
>                     1000              1000         (<class 'str'>, DataType(string))   109917
>               =============== =================== =================================== ========
```