### PR TITLE
Ensure column names are read as `str`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ Version 3.1.0 (2019-XX-XX)
 - fix ``_apply_partition_key_predicates`` ``FutureWarning``
 - serialize :class:`~kartothek.core.index.ExplicitSecondaryIndex` to parquet
 - improve messages for schema violation errors
+- Ensure binary column names are read as type ``str``:
+
+    - Ensure dataframe columns are of type ``str`` in :func:`~kartothek.core.common_metadata.empty_dataframe_from_schema`
+    - Testing: create :func:`~kartothek.io.testing.read.test_binary_column_metadata` which checks column names stored as
+      ``bytes`` objects are read as type ``str``
 
 **Breaking:**
 

--- a/kartothek/core/common_metadata.py
+++ b/kartothek/core/common_metadata.py
@@ -15,7 +15,7 @@ import simplejson
 
 from kartothek.core import naming
 from kartothek.core._compat import load_json
-from kartothek.core.utils import _ensure_string_type
+from kartothek.core.utils import ensure_string_type
 
 from ._compat import ARROW_LARGER_EQ_0130
 
@@ -789,7 +789,7 @@ def empty_dataframe_from_schema(schema, columns=None, date_as_object=False):
         )
         df = table.to_pandas(date_as_object=date_as_object)
 
-    df.columns = df.columns.map(_ensure_string_type)
+    df.columns = df.columns.map(ensure_string_type)
     if columns is not None:
         df = df[columns]
 

--- a/kartothek/core/common_metadata.py
+++ b/kartothek/core/common_metadata.py
@@ -15,6 +15,7 @@ import simplejson
 
 from kartothek.core import naming
 from kartothek.core._compat import load_json
+from kartothek.core.utils import _ensure_string_type
 
 from ._compat import ARROW_LARGER_EQ_0130
 
@@ -787,6 +788,8 @@ def empty_dataframe_from_schema(schema, columns=None, date_as_object=False):
             arrays=arrays, names=names, metadata=schema.metadata
         )
         df = table.to_pandas(date_as_object=date_as_object)
+
+    df.columns = df.columns.map(_ensure_string_type)
     if columns is not None:
         df = df[columns]
 

--- a/kartothek/core/utils.py
+++ b/kartothek/core/utils.py
@@ -24,3 +24,10 @@ def _verify_metadata_version(metadata_version):
 
 def verify_metadata_version(*args, **kwargs):
     return _verify_metadata_version(*args, **kwargs)
+
+
+def _ensure_string_type(obj):
+    if isinstance(obj, bytes):
+        return obj.decode()
+    else:
+        return str(obj)

--- a/kartothek/core/utils.py
+++ b/kartothek/core/utils.py
@@ -26,7 +26,22 @@ def verify_metadata_version(*args, **kwargs):
     return _verify_metadata_version(*args, **kwargs)
 
 
-def _ensure_string_type(obj):
+def ensure_string_type(obj):
+    """
+    Parse object passed to the function to `str`.
+
+    If the object is of type `bytes`, it is decoded, otherwise a generic string representation of the object is
+    returned.
+
+    Parameters
+    ----------
+    obj: Any
+        object which is to be parsed to `str`
+
+    Returns
+    -------
+    str_obj: String
+    """
     if isinstance(obj, bytes):
         return obj.decode()
     else:

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -28,7 +28,7 @@ from kartothek.core.index import merge_indices as merge_indices_algo
 from kartothek.core.naming import get_partition_file_prefix
 from kartothek.core.partition import Partition
 from kartothek.core.urlencode import decode_key, quote_indices
-from kartothek.core.utils import _ensure_string_type, verify_metadata_version
+from kartothek.core.utils import ensure_string_type, verify_metadata_version
 from kartothek.core.uuid import gen_uuid
 from kartothek.io_components.utils import _instantiate_store, combine_metadata
 from kartothek.serialization import (
@@ -714,7 +714,7 @@ class MetaPartition(Iterable):
                 date_as_object=dates_as_object,
             )
 
-            df.columns = df.columns.map(_ensure_string_type)
+            df.columns = df.columns.map(ensure_string_type)
             if table_columns is not None:
                 # TODO: When the write-path ensures that all partitions have the same column set, this check can be
                 #       moved before `DataFrameSerializer.restore_dataframe`. At the position of the current check we

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -28,7 +28,7 @@ from kartothek.core.index import merge_indices as merge_indices_algo
 from kartothek.core.naming import get_partition_file_prefix
 from kartothek.core.partition import Partition
 from kartothek.core.urlencode import decode_key, quote_indices
-from kartothek.core.utils import verify_metadata_version
+from kartothek.core.utils import _ensure_string_type, verify_metadata_version
 from kartothek.core.uuid import gen_uuid
 from kartothek.io_components.utils import _instantiate_store, combine_metadata
 from kartothek.serialization import (
@@ -714,7 +714,7 @@ class MetaPartition(Iterable):
                 date_as_object=dates_as_object,
             )
 
-            df.columns = df.columns.map(_ensure_native_string_type)
+            df.columns = df.columns.map(_ensure_string_type)
             if table_columns is not None:
                 # TODO: When the write-path ensures that all partitions have the same column set, this check can be
                 #       moved before `DataFrameSerializer.restore_dataframe`. At the position of the current check we
@@ -1492,13 +1492,6 @@ def partition_labels_from_mps(mps):
             if not mp.is_sentinel:
                 partition_labels.append(mp.label)
     return partition_labels
-
-
-def _ensure_native_string_type(obj):
-    if isinstance(obj, bytes):
-        return obj.decode()
-    else:
-        return str(obj)
 
 
 def parse_input_to_metapartition(obj, metadata_version=None):


### PR DESCRIPTION
Pandas schema metadata saved using python2 stores column names as type `bytes` given that that is how Python2 implements strings by default.
When this schema metadata is loaded using Python3, `kartothek.core.common_metadata.empty_dataframe_from_schema`retrieves these column names as if they were `bytes` objects. However, the column names in Parquet are still strings, so when kartothek  attempts to retrieve these `bytes` object columns it return nulls as there is no data stored for `bytes` columns. 
AFAIK this only affects `io.eager.read_table`.

For `pyarrow>=0.13`, we can create an empty pandas dataframe without using this pandas metadata. By doing so, kartothek remains compatible with schemas created in Python2.

