### PR TITLE
Fix #16 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Version 3.1.0 (2019-XX-XX)
     - Testing: create :func:`~kartothek.io.testing.read.test_binary_column_metadata` which checks column names stored as
       ``bytes`` objects are read as type ``str``
 
+- fix issue where it was possible to add an index to an existing dataset by using update functions and partition indices
+  (https://github.com/JDASoftwareGroup/kartothek/issues/16).
+
 **Breaking:**
 
 - categorical normalization was moved from :meth:`~kartothek.core.common_metadata.make_meta` to

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -66,7 +66,9 @@ def _update_dask_partitions_one_to_one(
     sort_partitions_by,
 ):
     input_to_mps = partial(
-        parse_input_to_metapartition, metadata_version=metadata_version
+        parse_input_to_metapartition,
+        metadata_version=metadata_version,
+        expected_secondary_indices=secondary_indices,
     )
     mps = map_delayed(delayed_tasks, input_to_mps)
 

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -664,7 +664,11 @@ def update_dataset_from_dataframes(
 
     secondary_indices = _ensure_compatible_indices(ds_factory, secondary_indices)
 
-    mp = parse_input_to_metapartition(df_list, metadata_version=metadata_version)
+    mp = parse_input_to_metapartition(
+        df_list,
+        metadata_version=metadata_version,
+        expected_secondary_indices=secondary_indices,
+    )
 
     if sort_partitions_by:
         mp = mp.apply(partial(sort_values_categorical, column=sort_partitions_by))

--- a/kartothek/io/iter.py
+++ b/kartothek/io/iter.py
@@ -219,7 +219,11 @@ def update_dataset_from_dataframes__iter(
 
     new_partitions = []
     for df in df_generator:
-        mp = parse_input_to_metapartition(df, metadata_version=metadata_version)
+        mp = parse_input_to_metapartition(
+            df,
+            metadata_version=metadata_version,
+            expected_secondary_indices=secondary_indices,
+        )
 
         if sort_partitions_by:
             mp = mp.apply(sort_partitions_by_fn)

--- a/kartothek/io/testing/update.py
+++ b/kartothek/io/testing/update.py
@@ -590,3 +590,48 @@ def test_raises_on_invalid_input(store_factory, bound_update_dataset):
     # Check no new partitions have been written to storage
     mps = read_dataset_as_metapartitions(store=store_factory, dataset_uuid=dataset_uuid)
     assert len(mps) == len(dataset.partitions)
+
+
+@pytest.mark.parametrize("define_indices_on_partition", (False, True))
+def test_raises_on_new_index_creation(
+    backend_identifier, store_factory, bound_update_dataset, define_indices_on_partition
+):
+    if backend_identifier == "dask.dataframe" and define_indices_on_partition:
+        pytest.skip()  # Constructs a dataframe which ignores index information passed as dict
+
+    dataset_uuid = "dataset_uuid"
+    index_column = "p"
+    partitions = [
+        {"label": "cluster_1", "data": [("core", pd.DataFrame({index_column: [1, 2]}))]}
+    ]
+
+    new_partition = {
+        "label": "cluster_2",
+        "data": [("core", pd.DataFrame({index_column: [2, 3]}))],
+    }
+
+    dataset_update_secondary_indices = [index_column]
+    if define_indices_on_partition:
+        dataset_update_secondary_indices = None
+        new_partition["indices"] = {
+            index_column: ExplicitSecondaryIndex(
+                index_column,
+                {
+                    k: [new_partition["label"]]
+                    for k in new_partition["data"][0][1][index_column].unique()
+                },
+            )
+        }
+
+    # Create dataset without secondary indices
+    store_dataframes_as_dataset(
+        dfs=partitions, store=store_factory, dataset_uuid=dataset_uuid
+    )
+
+    with pytest.raises(Exception, match="Incorrect indices provided for dataset"):
+        bound_update_dataset(
+            [new_partition],
+            store=store_factory,
+            dataset_uuid=dataset_uuid,
+            secondary_indices=dataset_update_secondary_indices,
+        )

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1494,7 +1494,9 @@ def partition_labels_from_mps(mps):
     return partition_labels
 
 
-def parse_input_to_metapartition(obj, metadata_version=None):
+def parse_input_to_metapartition(
+    obj, metadata_version=None, expected_secondary_indices=False
+):
     """
     Parses given user input and returns a MetaPartition
 
@@ -1550,6 +1552,11 @@ def parse_input_to_metapartition(obj, metadata_version=None):
     obj : Union[Dict, pd.DataFrame, kartothek.io_components.metapartition.MetaPartition]
     metadata_version : int, optional
         The kartothek dataset specification version
+    expected_secondary_indices : Optional[Union[Iterable[str], Literal[False]]]
+        Iterable of strings containing expected columns on which indices are created. An empty iterable indicates no
+        indices are expected.
+        The default is `False`, which, indicates no checking will be done (`None` behaves the same way).
+        This is only used in mode "Dictionary with partition information".
 
     Raises
     ------
@@ -1568,12 +1575,16 @@ def parse_input_to_metapartition(obj, metadata_version=None):
             return MetaPartition(label=None, metadata_version=metadata_version)
         first_element = obj.pop()
         mp = parse_input_to_metapartition(
-            obj=first_element, metadata_version=metadata_version
+            obj=first_element,
+            metadata_version=metadata_version,
+            expected_secondary_indices=expected_secondary_indices,
         )
         for mp_in in obj:
             mp = mp.add_metapartition(
                 parse_input_to_metapartition(
-                    obj=mp_in, metadata_version=metadata_version
+                    obj=mp_in,
+                    metadata_version=metadata_version,
+                    expected_secondary_indices=expected_secondary_indices,
                 )
             )
     elif isinstance(obj, dict):
@@ -1581,11 +1592,19 @@ def parse_input_to_metapartition(obj, metadata_version=None):
             data = dict(obj["data"])
         else:
             data = obj["data"]
+
+        indices = obj.get("indices", {})
+        if expected_secondary_indices not in (False, None):
+            # Validate explicit input of indices
+            _ensure_valid_indices(
+                secondary_indices=expected_secondary_indices, mp_indices=indices
+            )
+
         mp = MetaPartition(
             # TODO: Deterministic hash for the input?
             label=obj.get("label", gen_uuid()),
             data=data,
-            indices=obj.get("indices", {}),
+            indices=indices,
             metadata_version=metadata_version,
         )
     elif isinstance(obj, pd.DataFrame):
@@ -1600,3 +1619,24 @@ def parse_input_to_metapartition(obj, metadata_version=None):
         raise ValueError("Unexpected type: {}".format(type(obj)))
 
     return mp
+
+
+def _ensure_valid_indices(secondary_indices, mp_indices):
+    if not secondary_indices:
+        if mp_indices:
+            raise ValueError(
+                "Incorrect indices provided for dataset.\n"
+                f"Expected index columns: {secondary_indices}"
+                f"Provided index: {mp_indices}"
+            )
+    else:
+        secondary_indices = set(secondary_indices)
+        # If the dataset has `secondary_indices` defined, then these indices will be build later so there is no need to
+        # ensure that they are also defined here (on a partition level).
+        # Hence,  we just check that no new indices are defined on the partition level.
+        if not secondary_indices.issuperset(mp_indices.keys()):
+            raise ValueError(
+                "Incorrect indices provided for dataset.\n"
+                f"Expected index columns: {secondary_indices}"
+                f"Provided index: {mp_indices}"
+            )

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1510,7 +1510,8 @@ def parse_input_to_metapartition(
                         is generated using :func:`kartothek.core.uuid.gen_uuid`.
             * **data** - A dict or list of tuples. The keys represent the table name \
                         and the values are the actual payload data as a pandas.DataFrame.
-            * **indices** - A dictionary to describe the dataset indices. All \
+            * **indices** - Deprecated, see the keyword argument `secondary_indices` to create indices.
+                            A dictionary to describe the dataset indices. All \
                             partition level indices are finally merged using \
                             :func:`kartothek.io_components.metapartition.MetaPartition.merge_indices` \
                             into a single dataset index
@@ -1594,6 +1595,12 @@ def parse_input_to_metapartition(
             data = obj["data"]
 
         indices = obj.get("indices", {})
+        if indices:
+            warnings.warn(
+                "The explicit input of indices using the `indices` key is deprecated."
+                'Use the `secondary_indices` keyword argument of "write" and "update" functions instead.',
+                DeprecationWarning,
+            )
         if expected_secondary_indices not in (False, None):
             # Validate explicit input of indices
             _ensure_valid_indices(

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -119,7 +119,10 @@ def _ensure_compatible_indices(dataset, secondary_indices):
             )
         return ds_secondary_indices
     else:
-        return secondary_indices
+        # We return `False` if there is no dataset in storage and `secondary_indices` is undefined
+        # (`secondary_indices` is normalized to `[]` by default).
+        # In consequence, `parse_input_to_metapartition` will not check indices at the partition level.
+        return secondary_indices or False
 
 
 def validate_partition_keys(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,14 +115,16 @@ def mock_default_metadata_version(mocker, backend_identifier):
     )
 
     # Mock `kartothek.io_components.metapartition.parse_input_to_metapartition`
-    def patched__parse_input_to_metapartition(obj, metadata_version=None):
+    def patched__parse_input_to_metapartition(
+        obj, metadata_version=None, *args, **kwargs
+    ):
         if metadata_version == mock_metadata_version:
             table, data = obj  # Tuple
             return MetaPartition(
                 label=gen_uuid(), data={table: data}, metadata_version=metadata_version
             )
         try:
-            return parse_input_to_metapartition(obj, metadata_version)
+            return parse_input_to_metapartition(obj, metadata_version, *args, **kwargs)
         except ValueError as e:
             # Raise a "custom" error to distinguish this error from the error raised
             # by `parse_input_to_metapartition` when the object has not previously

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -23,7 +23,7 @@ def _unwrap_partition(part):
     return next(iter(dict(part["data"]).values()))
 
 
-def _update_dataset(partitions, secondary_indices=None, *args, **kwargs):
+def _update_dataset(partitions, *args, **kwargs):
     if any(partitions):
         table_name = next(iter(dict(partitions[0]["data"]).keys()))
         delayed_partitions = [
@@ -33,13 +33,7 @@ def _update_dataset(partitions, secondary_indices=None, *args, **kwargs):
     else:
         table_name = "core"
         partitions = None
-    ddf = update_dataset_from_ddf(
-        partitions,
-        *args,
-        table=table_name,
-        secondary_indices=secondary_indices,
-        **kwargs,
-    )
+    ddf = update_dataset_from_ddf(partitions, *args, table=table_name, **kwargs)
 
     s = pickle.dumps(ddf, pickle.HIGHEST_PROTOCOL)
     ddf = pickle.loads(s)

--- a/tests/io/dask/delayed/test_update.py
+++ b/tests/io/dask/delayed/test_update.py
@@ -17,7 +17,7 @@ def _unwrap_partition(part):
     return next(iter(dict(part["data"]).values()))
 
 
-def _update_dataset(partitions, secondary_indices=None, *args, **kwargs):
+def _update_dataset(partitions, *args, **kwargs):
     tasks = update_dataset_from_delayed(partitions, *args, **kwargs)
 
     s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)


### PR DESCRIPTION
I have implemented a test to check whether the issue #16 takes place as described.

This test checks that kartothek raises an exception when a user tries to update a dataset and create a new index on that dataset, where the original dataset was created without an index. 
