### PR TITLE
Pickle hardening / improvements

### DIFF
--- a/kartothek/io/testing/update.py
+++ b/kartothek/io/testing/update.py
@@ -21,9 +21,8 @@ from kartothek.io.iter import read_dataset_as_dataframes__iterator
 
 @pytest.mark.min_metadata_version(4)
 def test_update_dataset_with_partitions__reducer(
-    store, metadata_version, bound_update_dataset, mocker
+    store_factory, metadata_version, bound_update_dataset, mocker, store
 ):
-
     partitions = [
         {
             "label": "cluster_1",
@@ -38,7 +37,7 @@ def test_update_dataset_with_partitions__reducer(
     ]
     dataset = bound_update_dataset(
         partitions,
-        store=lambda: store,
+        store=store_factory,
         metadata={"dataset": "metadata"},
         dataset_uuid="dataset_uuid",
         default_metadata_version=metadata_version,
@@ -54,7 +53,7 @@ def test_update_dataset_with_partitions__reducer(
 
     dataset_updated = bound_update_dataset(
         [part3],
-        store=lambda: store,
+        store=store_factory,
         delete_scope=[{"p": 1}],
         metadata={"extra": "metadata"},
         dataset_uuid="dataset_uuid",
@@ -100,7 +99,7 @@ def test_update_dataset_with_partitions__reducer(
 
 @pytest.mark.min_metadata_version(4)
 def test_update_dataset_with_partitions_no_index_input_info(
-    store, metadata_version, bound_update_dataset
+    store_factory, metadata_version, bound_update_dataset, store
 ):
     partitions = [
         {
@@ -116,7 +115,7 @@ def test_update_dataset_with_partitions_no_index_input_info(
     ]
     dataset = store_dataframes_as_dataset(
         dfs=partitions,
-        store=lambda: store,
+        store=store_factory,
         metadata={"dataset": "metadata"},
         dataset_uuid="dataset_uuid",
         metadata_version=metadata_version,
@@ -127,7 +126,7 @@ def test_update_dataset_with_partitions_no_index_input_info(
     part3 = {"label": "cluster_3", "data": [("core", pd.DataFrame({"p": [3]}))]}
     dataset_updated = bound_update_dataset(
         [part3],
-        store=lambda: store,
+        store=store_factory,
         dataset_uuid=dataset.uuid,
         delete_scope=[{"p": 1}],
         metadata={"extra": "metadata"},
@@ -140,7 +139,7 @@ def test_update_dataset_with_partitions_no_index_input_info(
 
 @pytest.mark.min_metadata_version(4)
 def test_update_dataset_with_partitions__reducer_delete_only(
-    store, metadata_version, frozen_time_em, bound_update_dataset
+    store_factory, metadata_version, frozen_time_em, bound_update_dataset, store
 ):
     partitions = [
         {
@@ -156,7 +155,7 @@ def test_update_dataset_with_partitions__reducer_delete_only(
     ]
     dataset = store_dataframes_as_dataset(
         dfs=partitions,
-        store=lambda: store,
+        store=store_factory,
         metadata={"dataset": "metadata"},
         dataset_uuid="dataset_uuid",
         metadata_version=metadata_version,
@@ -166,7 +165,7 @@ def test_update_dataset_with_partitions__reducer_delete_only(
     empty_part = []
     dataset_updated = bound_update_dataset(
         [empty_part],
-        store=lambda: store,
+        store=store_factory,
         dataset_uuid="dataset_uuid",
         delete_scope=[{"p": 1}],
         metadata={"extra": "metadata"},
@@ -295,7 +294,7 @@ def test_update_dataset_with_partitions__reducer_partitions(
 
 @pytest.mark.min_metadata_version(4)
 def test_update_dataset_with_partitions__reducer_nonexistent(
-    store, metadata_version, frozen_time_em, bound_update_dataset
+    store_factory, metadata_version, frozen_time_em, bound_update_dataset, store
 ):
 
     part3 = {
@@ -305,7 +304,7 @@ def test_update_dataset_with_partitions__reducer_nonexistent(
     }
     dataset_updated = bound_update_dataset(
         [part3],
-        store=lambda: store,
+        store=store_factory,
         dataset_uuid="dataset_uuid",
         delete_scope=[{"p": 1}],
         metadata={"extra": "metadata"},

--- a/kartothek/io/testing/utils.py
+++ b/kartothek/io/testing/utils.py
@@ -2,6 +2,8 @@ import string
 
 import numpy as np
 import pandas as pd
+import storefact
+from simplekv.decorator import StoreDecorator
 
 from kartothek.io.eager import store_dataframes_as_dataset
 
@@ -34,3 +36,13 @@ def create_dataset(dataset_uuid, store_factory, metadata_version):
         dataset_uuid=dataset_uuid,
         metadata_version=metadata_version,
     )
+
+
+class NoPickleDecorator(StoreDecorator):
+    def __getstate__(self):
+        raise RuntimeError("do NOT pickle this object!")
+
+
+def no_pickle_store_from_url(url):
+    store = storefact.get_store_from_url(url)
+    return NoPickleDecorator(store)

--- a/requirements.in
+++ b/requirements.in
@@ -6,5 +6,6 @@ numpy!=1.15.0,!=1.16.0
 pandas>=0.23.0
 pyarrow>=0.11.1, <0.14.0 # Keep upper bound pinned until we see non-breaking releases in the future
 simplejson
+simplekv
 storefact
 zstandard

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from functools import partial
 
 import pandas as pd
 import pytest
-import storefact
 
 from kartothek.core.common_metadata import make_meta
 from kartothek.core.factory import DatasetFactory
@@ -19,6 +18,7 @@ from kartothek.core.testing import (
     get_dataframe_alltypes,
     get_dataframe_not_nested,
 )
+from kartothek.io.testing.utils import no_pickle_store_from_url
 from kartothek.io_components.metapartition import (
     MetaPartition,
     gen_uuid,
@@ -62,21 +62,21 @@ def store_session_factory(tmpdir_factory):
     path = tmpdir_factory.mktemp("fsstore_test")
     path = path.realpath()
     url = "hfs://{}".format(path)
-    return partial(storefact.get_store_from_url, url)
+    return partial(no_pickle_store_from_url, url)
 
 
 @pytest.fixture
 def store_factory(tmpdir):
     path = tmpdir.join("store").strpath
     url = "hfs://{}".format(path)
-    return partial(storefact.get_store_from_url, url)
+    return partial(no_pickle_store_from_url, url)
 
 
 @pytest.fixture
 def store_factory2(tmpdir):
     path = tmpdir.join("store2").strpath
     url = "hfs://{}".format(path)
-    return partial(storefact.get_store_from_url, url)
+    return partial(no_pickle_store_from_url, url)
 
 
 @pytest.fixture(scope="session")

--- a/tests/io/dask/bag/test_write.py
+++ b/tests/io/dask/bag/test_write.py
@@ -1,3 +1,5 @@
+import pickle
+
 import dask.bag as db
 import pytest
 
@@ -6,7 +8,10 @@ from kartothek.io.testing.write import *  # noqa
 
 
 def _store_dataframes(df_list, *args, **kwargs):
-    return store_bag_as_dataset(db.from_sequence(df_list), *args, **kwargs).compute()
+    bag = store_bag_as_dataset(db.from_sequence(df_list), *args, **kwargs)
+    s = pickle.dumps(bag, pickle.HIGHEST_PROTOCOL)
+    bag = pickle.loads(s)
+    return bag.compute()
 
 
 @pytest.fixture()

--- a/tests/io/dask/dataframe/test_read.py
+++ b/tests/io/dask/dataframe/test_read.py
@@ -1,3 +1,4 @@
+import pickle
 from functools import partial
 
 import pandas as pd
@@ -44,6 +45,9 @@ def _read_as_ddf(
             assert ddf._meta.dtypes["L"] == pd.api.types.CategoricalDtype(
                 categories=["__UNKNOWN_CATEGORIES__"], ordered=False
             )
+
+    s = pickle.dumps(ddf, pickle.HIGHEST_PROTOCOL)
+    ddf = pickle.loads(s)
 
     ddf = ddf.compute().reset_index(drop=True)
 

--- a/tests/io/dask/delayed/test_delete.py
+++ b/tests/io/dask/delayed/test_delete.py
@@ -1,3 +1,5 @@
+import pickle
+
 import dask
 import pytest
 
@@ -7,6 +9,8 @@ from kartothek.io.testing.delete import *  # noqa
 
 def _delete(*args, **kwargs):
     tasks = delete_dataset__delayed(*args, **kwargs)
+    s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)
+    tasks = pickle.loads(s)
     dask.compute(tasks)
 
 

--- a/tests/io/dask/delayed/test_gc.py
+++ b/tests/io/dask/delayed/test_gc.py
@@ -1,3 +1,5 @@
+import pickle
+
 import dask
 import pytest
 
@@ -7,6 +9,8 @@ from kartothek.io.testing.gc import *  # noqa
 
 def _run_garbage_collect(*args, **kwargs):
     tasks = garbage_collect_dataset__delayed(*args, **kwargs)
+    s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)
+    tasks = pickle.loads(s)
     dask.compute(tasks)
 
 

--- a/tests/io/dask/delayed/test_merge.py
+++ b/tests/io/dask/delayed/test_merge.py
@@ -1,3 +1,5 @@
+import pickle
+
 import dask
 import pytest
 
@@ -7,6 +9,8 @@ from kartothek.io.testing.merge import *  # noqa
 
 def _merge_datasets(*args, **kwargs):
     df_list = merge_datasets_as_delayed(*args, **kwargs)
+    s = pickle.dumps(df_list, pickle.HIGHEST_PROTOCOL)
+    df_list = pickle.loads(s)
     return dask.compute(df_list)[0]
 
 

--- a/tests/io/dask/delayed/test_read.py
+++ b/tests/io/dask/delayed/test_read.py
@@ -1,3 +1,4 @@
+import pickle
 from functools import partial
 
 import pytest
@@ -25,6 +26,10 @@ def _load_dataframes(output_type, *args, **kwargs):
             kwargs.pop("tables")
         func = partial(read_table_as_delayed, table="core")
     tasks = func(*args, **kwargs)
+
+    s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)
+    tasks = pickle.loads(s)
+
     result = [task.compute() for task in tasks]
     return result
 

--- a/tests/io/dask/delayed/test_update.py
+++ b/tests/io/dask/delayed/test_update.py
@@ -1,3 +1,5 @@
+import pickle
+
 import dask
 import pytest
 
@@ -16,4 +18,9 @@ def _unwrap_partition(part):
 
 
 def _update_dataset(partitions, secondary_indices=None, *args, **kwargs):
-    return update_dataset_from_delayed(partitions, *args, **kwargs).compute()
+    tasks = update_dataset_from_delayed(partitions, *args, **kwargs)
+
+    s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)
+    tasks = pickle.loads(s)
+
+    return tasks.compute()

--- a/tests/io/dask/delayed/test_write.py
+++ b/tests/io/dask/delayed/test_write.py
@@ -1,3 +1,4 @@
+import pickle
 from functools import partial
 
 import dask.bag as db
@@ -10,11 +11,19 @@ from kartothek.io.testing.write import *  # noqa
 
 def _store_dataframes(execution_mode, df_list, *args, **kwargs):
     if execution_mode == "dask.bag":
-        return store_bag_as_dataset(
-            db.from_sequence(df_list), *args, **kwargs
-        ).compute()
+        bag = store_bag_as_dataset(db.from_sequence(df_list), *args, **kwargs)
+
+        s = pickle.dumps(bag, pickle.HIGHEST_PROTOCOL)
+        bag = pickle.loads(s)
+
+        return bag.compute()
     elif execution_mode == "dask.delayed":
-        return store_delayed_as_dataset(df_list, *args, **kwargs).compute()
+        tasks = store_delayed_as_dataset(df_list, *args, **kwargs)
+
+        s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)
+        tasks = pickle.loads(s)
+
+        return tasks.compute()
     else:
         raise ValueError("Unknown execution mode: {}".format(execution_mode))
 

--- a/tests/io_components/test_dataset_metadata_factory.py
+++ b/tests/io_components/test_dataset_metadata_factory.py
@@ -1,4 +1,5 @@
 import pickle
+from copy import copy
 from functools import partial
 
 import pytest
@@ -33,6 +34,11 @@ class CountFactory(object):
         result = self.inner()
         self.last = result
         return result
+
+    def __getstate__(self):
+        state = copy(self.__dict__)
+        state["last"] = None
+        return state
 
 
 def _create_count_store(store_factory):


### PR DESCRIPTION
1. Do never ever pickle stores (this is dangerous depending on the store
   implementation due to open connections / file handles).
2. Ensure dask bags/tasks/ddf can be stock-pickled. Distributed tries to
   use stock (c)pickle first and only falls back to slow cloudpickle if
   this doesn't work. For production usage, let's ensure that we can use
   stock pickle for all our computation graphs.