### PR TITLE
improve schema origin handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,11 +15,13 @@ Version 3.1.0 (2019-XX-XX)
     + ``io.eager.update_dataset_from_dataframes``
 - fix ``_apply_partition_key_predicates`` ``FutureWarning``
 - serialize :class:`~kartothek.core.index.ExplicitSecondaryIndex` to parquet
+- improve messages for schema violation errors
 
 **Breaking:**
 
 - categorical normalization was moved from :meth:`~kartothek.core.common_metadata.make_meta` to
   :meth:`~kartothek.core.common_metadata.normalize_type`.
+- :meth:`kartothek.core.common_metadata.SchemaWrapper.origin` is now a set of of strings instead of a single string
 
 
 Version 3.0.0 (2019-05-02)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,11 @@ Version 3.1.0 (2019-XX-XX)
 - fix ``FutureWarning`` in ``filter_array_like``
 - remove ``funcsigs`` requirement
 - Implement reference ``io.eager`` implementation, adding the functions:
-    + ``io.eager.garbage_collect_dataset``
-    + ``io.eager.index.build_dataset_indices``
-    + ``io.eager.update_dataset_from_dataframes``
+
+    - :meth:`~kartothek.io.eager.garbage_collect_dataset`
+    - :meth:`~kartothek.io.eager.build_dataset_indices`
+    - :meth:`~kartothek.io.eager.update_dataset_from_dataframes`
+
 - fix ``_apply_partition_key_predicates`` ``FutureWarning``
 - serialize :class:`~kartothek.core.index.ExplicitSecondaryIndex` to parquet
 - improve messages for schema violation errors

--- a/kartothek/core/common_metadata.py
+++ b/kartothek/core/common_metadata.py
@@ -504,8 +504,7 @@ def _determine_schemas_to_compare(schemas, ignore_pandas):
                 null_cols_in_reference.remove(col)
             schemas_to_evaluate.append((current, null_columns))
 
-    if reference is None and schemas_to_evaluate:
-        reference = schemas_to_evaluate.pop()[0]
+    assert (reference is not None) or (not schemas_to_evaluate)
 
     return reference, schemas_to_evaluate
 

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1266,7 +1266,9 @@ class MetaPartition(Iterable):
                 metadata_version=self.metadata_version,
                 indices={},
                 table_meta={
-                    table: normalize_column_order(schema, partition_on)
+                    table: normalize_column_order(schema, partition_on).with_origin(
+                        "{}/{}".format(table, label)
+                    )
                     for table, schema in self.table_meta.items()
                 },
                 partition_keys=partition_on,

--- a/kartothek/io_components/write.py
+++ b/kartothek/io_components/write.py
@@ -72,7 +72,10 @@ def persist_common_metadata(partition_list, update_dataset, store, dataset_uuid)
             )
 
     result = {}
-    for table, schemas in tm_dct.items():
+
+    # sort tables and schemas to have reproducible error messages
+    for table in sorted(tm_dct.keys()):
+        schemas = sorted(tm_dct[table], key=lambda s: sorted(s.origin))
         try:
             result[table] = validate_compatible(schemas)
         except ValueError as e:


### PR DESCRIPTION
For a very common usecase where different computation branches (e.g.
dask items, iterator elements) produce different partitions, let's try
to be more helpful for the user and tell them which part of the dataset
are not compatible.