### PR TITLE
update pytest version to `4.5.0` to support "--strict-markers"

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -5,7 +5,7 @@ toolz
 
 # Test Framework
 hypothesis
-pytest
+pytest>=4.5.0
 pytest-cov
 pytest-flake8
 pytest-mock


### PR DESCRIPTION
Using `pytest==4.4.0` I was getting `pytest: error: unrecognized arguments: --strict-markers` on master.

This flag is only supported starting from pytest 4.5.0, see: https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst.