### PR TITLE
Call garbage collection in delete pipelines

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Version 3.1.0 (2019-XX-XX)
 - fix issue where it was possible to add an index to an existing dataset by using update functions and partition indices
   (https://github.com/JDASoftwareGroup/kartothek/issues/16).
 
+- fix issue where unreferenced files were not being removed when deleting an entire dataset
+
 **Breaking:**
 
 - categorical normalization was moved from :meth:`~kartothek.core.common_metadata.make_meta` to

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -117,7 +117,10 @@ def garbage_collect_dataset__delayed(
         chunk_size=chunk_size,
         factory=factory,
     )
-    return [delayed(delete_files)(files, store_factory=store) for files in nested_files]
+    return [
+        delayed(delete_files)(files, store_factory=store or factory.store_factory)
+        for files in nested_files
+    ]
 
 
 def _load_and_merge_mps(mp_list, store, label_merger, metadata_merger, merge_tasks):

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -111,14 +111,19 @@ def garbage_collect_dataset__delayed(
     -------
     tasks: list of dask.delayed
     """
-    nested_files = dispatch_files_to_gc(
+
+    ds_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
-        store_factory=store,
-        chunk_size=chunk_size,
+        store=store,
         factory=factory,
+        load_dataset_metadata=False,
+    )
+
+    nested_files = dispatch_files_to_gc(
+        dataset_uuid=None, store_factory=None, chunk_size=chunk_size, factory=ds_factory
     )
     return [
-        delayed(delete_files)(files, store_factory=store or factory.store_factory)
+        delayed(delete_files)(files, store_factory=ds_factory.store_factory)
         for files in nested_files
     ]
 

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -70,6 +70,8 @@ def delete_dataset__delayed(dataset_uuid=None, store=None, factory=None):
         load_dataset_metadata=False,
     )
 
+    gc = garbage_collect_dataset__delayed(factory=dataset_factory)
+
     mps = dispatch_metapartitions_from_factory(dataset_factory)
 
     delayed_dataset_uuid = delayed(_delete_all_additional_metadata)(
@@ -83,7 +85,7 @@ def delete_dataset__delayed(dataset_uuid=None, store=None, factory=None):
         dataset_uuid=delayed_dataset_uuid,
     )
 
-    return delayed(_delete_tl_metadata)(dataset_factory, mps)
+    return delayed(_delete_tl_metadata)(dataset_factory, mps, gc)
 
 
 def garbage_collect_dataset__delayed(

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -746,4 +746,6 @@ def garbage_collect_dataset(dataset_uuid=None, store=None, factory=None):
 
     # Given that `nested_files` is a generator with a single element, just
     # return the output of `delete_files` on that element.
-    return delete_files(next(nested_files), store_factory=store)
+    return delete_files(
+        next(nested_files), store_factory=store or factory.store_factory
+    )

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -63,6 +63,9 @@ def delete_dataset(dataset_uuid=None, store=None, factory=None):
         load_dataset_metadata=False,
     )
 
+    # Remove possibly unreferenced files
+    garbage_collect_dataset(factory=ds_factory)
+
     # Delete indices first since they do not affect dataset integrity
     delete_indices(dataset_factory=ds_factory)
 

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -740,12 +740,18 @@ def garbage_collect_dataset(dataset_uuid=None, store=None, factory=None):
     Parameters
     ----------
     """
+
+    ds_factory = _ensure_factory(
+        dataset_uuid=dataset_uuid,
+        store=store,
+        factory=factory,
+        load_dataset_metadata=False,
+    )
+
     nested_files = dispatch_files_to_gc(
-        dataset_uuid=dataset_uuid, store_factory=store, chunk_size=None, factory=factory
+        dataset_uuid=None, store_factory=None, chunk_size=None, factory=ds_factory
     )
 
     # Given that `nested_files` is a generator with a single element, just
     # return the output of `delete_files` on that element.
-    return delete_files(
-        next(nested_files), store_factory=store or factory.store_factory
-    )
+    return delete_files(next(nested_files), store_factory=ds_factory.store_factory)

--- a/kartothek/io/testing/delete.py
+++ b/kartothek/io/testing/delete.py
@@ -69,3 +69,21 @@ def test_delete_missing_dataset(store_factory, store_factory2, bound_delete_data
 
         bound_delete_dataset("dataset", store_factory2)
         assert len(list(store2.keys())) == 0
+
+
+def test_delete_dataset_unreferenced_files(
+    store_factory, metadata_version, bound_delete_dataset
+):
+    """
+    Ensure that unreferenced files of a dataset are also removed when a dataset is deleted
+    """
+    uuid = "dataset"
+    create_dataset(uuid, store_factory, metadata_version)
+
+    store = store_factory()
+    store.put(f"{uuid}/core/trash.parquet", b"trash")
+
+    assert len(list(store.keys())) > 0
+    bound_delete_dataset(uuid, store_factory)
+
+    assert len(list(store.keys())) == 0

--- a/kartothek/io_components/gc.py
+++ b/kartothek/io_components/gc.py
@@ -12,6 +12,7 @@ def dispatch_files_to_gc(dataset_uuid, store_factory, chunk_size, factory):
         factory=factory,
         load_dataset_metadata=False,
     )
+    dataset_uuid = dataset_uuid or ds_factory.uuid
 
     index_path = "{dataset_uuid}/indices/".format(dataset_uuid=dataset_uuid)
     remove_index_files = set(ds_factory.store.iter_keys(prefix=index_path))


### PR DESCRIPTION
Continuation of: https://github.com/JDASoftwareGroup/kartothek/pull/64

Summary: call GC in functions which delete the entire dataset to remove possible unreferenced files.

Added the test `kartothek.io.testing.delete.test_delete_dataset_unreferenced_files`.

Two minor bugs where found in GC functions, when passed a `ds_factory` instead of a `store` and `dataset_uuid`. These were fixed

Original author: @mganesh1308 