### PR TITLE
Fix #40

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,10 @@ Version 3.1.0 (2019-XX-XX)
 
 - fix issue where unreferenced files were not being removed when deleting an entire dataset
 
+- support nested :class:`~kartothek.io_components.metapartition.MetaPartition`
+  in :meth:`~kartothek.io_components.metapartition.MetaPartition.add_metapartition`.
+  This fixes issue https://github.com/JDASoftwareGroup/kartothek/issues/40 .
+
 **Breaking:**
 
 - categorical normalization was moved from :meth:`~kartothek.core.common_metadata.make_meta` to

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1575,13 +1575,13 @@ def parse_input_to_metapartition(
     if isinstance(obj, list):
         if len(obj) == 0:
             return MetaPartition(label=None, metadata_version=metadata_version)
-        first_element = obj.pop()
+        first_element = obj[0]
         mp = parse_input_to_metapartition(
             obj=first_element,
             metadata_version=metadata_version,
             expected_secondary_indices=expected_secondary_indices,
         )
-        for mp_in in obj:
+        for mp_in in obj[1:]:
             mp = mp.add_metapartition(
                 parse_input_to_metapartition(
                     obj=mp_in,

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -271,6 +271,78 @@ def test_eq():
     assert not meta_partition == "abc"
 
 
+def test_add_nested_to_plain():
+    mp = MetaPartition(
+        label="label_1",
+        files={"core": "file"},
+        data={"core": pd.DataFrame({"test": [1, 2, 3]})},
+        indices={"test": [1, 2, 3]},
+        dataset_metadata={"dataset": "metadata"},
+    )
+
+    to_nest = [
+        MetaPartition(
+            label="label_2",
+            data={"core": pd.DataFrame({"test": [4, 5, 6]})},
+            indices={"test": [4, 5, 6]},
+        ),
+        MetaPartition(
+            label="label_22",
+            data={"core": pd.DataFrame({"test": [4, 5, 6]})},
+            indices={"test": [4, 5, 6]},
+        ),
+    ]
+    mp_nested = to_nest[0].add_metapartition(to_nest[1])
+
+    mp_add_nested = mp.add_metapartition(mp_nested)
+    mp_iter = mp.add_metapartition(to_nest[0]).add_metapartition(to_nest[1])
+
+    assert mp_add_nested == mp_iter
+
+
+def test_add_nested_to_nested():
+    mps1 = [
+        MetaPartition(
+            label="label_1",
+            files={"core": "file"},
+            data={"core": pd.DataFrame({"test": [1, 2, 3]})},
+            indices={"test": [1, 2, 3]},
+            dataset_metadata={"dataset": "metadata"},
+        ),
+        MetaPartition(
+            label="label_33",
+            files={"core": "file"},
+            data={"core": pd.DataFrame({"test": [1, 2, 3]})},
+            indices={"test": [1, 2, 3]},
+            dataset_metadata={"dataset": "metadata"},
+        ),
+    ]
+
+    mpn_1 = mps1[0].add_metapartition(mps1[1])
+
+    mps2 = [
+        MetaPartition(
+            label="label_2",
+            data={"core": pd.DataFrame({"test": [4, 5, 6]})},
+            indices={"test": [4, 5, 6]},
+        ),
+        MetaPartition(
+            label="label_22",
+            data={"core": pd.DataFrame({"test": [4, 5, 6]})},
+            indices={"test": [4, 5, 6]},
+        ),
+    ]
+    mpn_2 = mps2[0].add_metapartition(mps2[1])
+
+    mp_nested_merge = mpn_1.add_metapartition(mpn_2)
+
+    mp_iter = mps1.pop()
+    for mp_ in [*mps1, *mps2]:
+        mp_iter = mp_iter.add_metapartition(mp_)
+
+    assert mp_nested_merge == mp_iter
+
+
 def test_eq_nested():
     mp = MetaPartition(
         label="label_1",


### PR DESCRIPTION
First commit addresses a side-effect caused by `parse_input_to_metapartition`
The third commit adds support for nested metapartitions in `add_metapartition`, which was the root cause of error in #40. 