### PR TITLE
Dask index build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Version 3.1.0 (2019-XX-XX)
   in :meth:`~kartothek.io_components.metapartition.MetaPartition.add_metapartition`.
   This fixes issue https://github.com/JDASoftwareGroup/kartothek/issues/40 .
 
+- Add :meth:`~karothek.io.dask.bag.build_dataset_indices__bag`
+
 **Breaking:**
 
 - categorical normalization was moved from :meth:`~kartothek.core.common_metadata.make_meta` to

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -698,9 +698,7 @@ def update_dataset_from_dataframes(
 
 
 @default_docs
-def build_dataset_indices(
-    store, dataset_uuid, columns, output_blocksize=0, factory=None
-):
+def build_dataset_indices(store, dataset_uuid, columns, factory=None):
     """
     Function which builds a :class:`~kartothek.core.index.ExplicitSecondaryIndex`.
 

--- a/tests/io/dask/bag/test_index.py
+++ b/tests/io/dask/bag/test_index.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import pickle
+
+import pytest
+
+from kartothek.io.dask.bag import build_dataset_indices__bag
+from kartothek.io.testing.index import *  # noqa: F4
+
+
+def _build_indices(*args, **kwargs):
+    bag = build_dataset_indices__bag(*args, **kwargs)
+
+    # pickle roundtrip to ensure we don't need the inefficient cloudpickle fallback
+    s = pickle.dumps(bag, pickle.HIGHEST_PROTOCOL)
+    bag = pickle.loads(s)
+
+    bag.compute()
+
+
+@pytest.fixture()
+def bound_build_dataset_indices():
+    return _build_indices


### PR DESCRIPTION
We could argue if the function should be placed in `delayed` or in `bag`. While it is internally implemented using `Dask.Bag`, the return type just behaves as a usual delayed computation, so I would opt for "implementation detail".