### PR TITLE
store_bag_as_dataset now returns dask.bag.Item

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Version 3.1.0 (2019-XX-XX)
 
 - Add :meth:`~karothek.io.dask.bag.build_dataset_indices__bag`
 
+- Return :class:`~dask.bag.Item` object from :meth:`~kartothek.io.dask.bag.store_bag_as_dataset` to avoid misoptimization
+
 **Breaking:**
 
 - categorical normalization was moved from :meth:`~kartothek.core.common_metadata.make_meta` to

--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -57,7 +57,7 @@ def store_bag_as_dataset(
 
     Returns
     -------
-    A dask.delayed dataset object.
+    A dask.bag.Item dataset object.
     """
     _check_callable(store)
     if dataset_uuid is None:
@@ -93,9 +93,7 @@ def store_bag_as_dataset(
         metadata_storage_format=metadata_storage_format,
     )
 
-    result = mps.reduction(perpartition=list, aggregate=aggregate, split_every=False)
-
-    return result.to_delayed()
+    return mps.reduction(perpartition=list, aggregate=aggregate, split_every=False)
 
 
 @default_docs


### PR DESCRIPTION
Earlier, we called `.to_delayed()` on the `Item` object to convert it to
a `dask.Delayed` object. This however is more than just a conversion but
also calls the optimizer. If the `Item` is used in a broader context,
this optimization is too early and can lead to unexpected behavior as
demonstrated in the following example:

Imagine a bag that with 2 single-sized partitions:

    bag := read_from_db_{0,1}

These partitions are now pre-processed twice for 2 calls to
`store_bag_as_dataset`:

    bag_a := bag->pluck("a")
    bag_b := bag->pluck("b")

Then, `store_bag_as_dataset` is called twice and a final reduction is
added:

    ds_a = bag_a->store_bag_as_dataset("a")
    ds_b = bag_b->store_bag_as_dataset("b")
    result = reduce([ds_a, ds_b])

The user would very likely expect the following computation graph:

    [read_from_db_0]-+->[pluck("a")]--+
                     |                |
                     +->[pluck("b")]-----+
                                      |  |
    [read_from_db_1]-+->[pluck("a")]--+  |
                     |                |  |
                     +->[pluck("b")]-----+
                                      |  |
                                      +----[store_bag_as_dataset("a")]-+
                                         |                             +-[reduce]
                                         +-[store_bag_as_dataset("b")]-+

However, what was happening is the following:

    [read_from_db_0]->[pluck("a")]-+
                                   +-[store_bag_as_dataset("a")]-+
    [read_from_db_1]->[pluck("a")]-+                             |
                                                                 +-[reduce]
    [read_from_db_0]->[pluck("b")]-+                             |
                                   +-[store_bag_as_dataset("b")]-+
    [read_from_db_1]->[pluck("b")]-+

Note that the payload functions (`read_from_db`) are called twice per
bag. The reason is that the optimization was done too early and
therefore Dask forgets that the inputs are actually identical, since the
linear fusion of `[read_from_db_0]->[pluck("a")]` and
`[read_from_db_0]->[pluck("b")]` lead to different node IDs in the
computation graph.

Not converting the `Item` too early solves this issue and provides Dask
with more helpful data.