### PR TITLE
Enable filter_array_like properly for categoricals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+- Predicate pushdown and :func:`~kartothek.serialization.filter_array_like` will now properly handle pandas Categoricals
+
 
 Version 3.1.1 (2019-07-12)
 ==========================

--- a/kartothek/io_components/docs.py
+++ b/kartothek/io_components/docs.py
@@ -120,6 +120,15 @@ _PARAMETER_MAPPING = {
         larger predicate. The most outer list then combines all predicates
         with a disjunction (OR). By this, we should be able to express all
         kinds of predicates that are possible using boolean logic.
+
+        Available operators are: `==`, `!=`, `<=`, `>=`, `<`, `>` and `in`.
+
+        .. admonition:: Categorical data
+
+            When using order sensitive operators on categorical data we will
+            assume that the categories obey a lexicographical ordering.
+            This filtering may result in less than optimal performance and may
+            be slower than the evaluation on non-categorical data.
 """,
     "secondary_indices": """
     secondary_indices: List[str]

--- a/tests/serialization/test_filter.py
+++ b/tests/serialization/test_filter.py
@@ -1,0 +1,68 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from kartothek.serialization import filter_array_like
+
+
+@pytest.fixture(
+    params=[
+        np.array(range(10)),
+        np.array(range(10)).astype(float),
+        pd.Series(np.array(range(10))),
+        pd.Series(np.array(range(10)).astype(float)),
+        pd.Series(np.array([str(x) for x in range(10)])),
+        pd.Series(np.array([str(x) for x in range(10)])).astype("category"),
+    ]
+)
+def array_like(request):
+    return request.param
+
+
+def test_filter_array_like_eq(array_like):
+    ix = 3
+    value = array_like[ix]
+    res = filter_array_like(array_like, "==", value)
+
+    assert all(array_like[res] == array_like[ix])
+
+
+def test_filter_array_like_larger_eq(array_like):
+    ix = 3
+    value = array_like[ix]
+    res = filter_array_like(array_like, ">=", value)
+
+    assert all(array_like[res] == array_like[ix:])
+
+
+def test_filter_array_like_lower_eq(array_like):
+    ix = 3
+    value = array_like[ix]
+    res = filter_array_like(array_like, "<=", value)
+
+    assert all(array_like[res] == array_like[: ix + 1])
+
+
+@pytest.mark.parametrize(
+    "op, expected",
+    [
+        (">", [False, True, False]),
+        (">=", [True, True, False]),
+        ("<=", [True, False, True]),
+        ("<", [False, False, True]),
+    ],
+)
+@pytest.mark.parametrize(
+    "cat_type",
+    [
+        "category",
+        pd.CategoricalDtype(["A", "B", "C"]),
+        pd.CategoricalDtype(["B", "C", "A"]),
+        pd.CategoricalDtype(["A", "B", "C"], ordered=True),
+    ],
+)
+def test_filter_array_like_categoricals(op, expected, cat_type):
+    ser = pd.Series(["B", "C", "A"]).astype(cat_type)
+    res = filter_array_like(ser, op, "B")
+
+    assert all(res == expected)


### PR DESCRIPTION
Categoricals have an issue with the numpy issubdtype, hence the mapping to the kind attribute of the arrays/type

To properly support the predicate eval range, I added a section about the handling of the categoricals. IMHO we should support it but highlight that it may come with undesired negative side effects. 