### PR TITLE
Do not execute coverage reports locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - python setup.py docs
 
 script:
-  - pytest
+  - pytest --cov kartothek --cov-report xml --cov-report html
 
 after_success:
   - pip install codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,6 @@ license_files = LICENSE.txt
 
 [tool:pytest]
 addopts =
-    --cov kartothek
-    --cov-report xml
-    --cov-report html
     --strict-markers
 
 filterwarnings =


### PR DESCRIPTION
No need to run coverage for every local test execution. When I run this in docker this adds >30s to test runtime at the end to collect the files, etc.

Executing it on travis should be sufficient