### PR TITLE
Add keyword for controlling partition size for dask bag

### DIFF
--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -55,6 +55,7 @@ def read_dataset_as_metapartitions_bag(
     predicates=None,
     factory=None,
     dispatch_by=None,
+    npartitions=None,
 ):
     """
     Retrieve dataset as `dask.bag` of `MetaPartition` objects.
@@ -73,7 +74,7 @@ def read_dataset_as_metapartitions_bag(
         predicates=predicates,
         dispatch_by=dispatch_by,
     )
-    mps = db.from_sequence(mps)
+    mps = db.from_sequence(mps, npartitions=npartitions)
 
     if concat_partitions_on_primary_index or dispatch_by:
         mps = mps.map(
@@ -128,6 +129,7 @@ def read_dataset_as_dataframe_bag(
     predicates=None,
     factory=None,
     dispatch_by=None,
+    npartitions=None,
 ):
     """
     Retrieve data as dataframe from a `dask.bag` of `MetaPartition` objects
@@ -146,6 +148,7 @@ def read_dataset_as_dataframe_bag(
         load_dataset_metadata=False,
         predicates=predicates,
         dispatch_by=dispatch_by,
+        npartitions=npartitions,
     )
     return mps.map(_get_data)
 

--- a/tests/io/dask/bag/test_read.py
+++ b/tests/io/dask/bag/test_read.py
@@ -1,13 +1,44 @@
 import pickle
 from functools import partial
 
+import pandas as pd
 import pytest
 
 from kartothek.io.dask.bag import (
     read_dataset_as_dataframe_bag,
     read_dataset_as_metapartitions_bag,
 )
+from kartothek.io.iter import store_dataframes_as_dataset__iter
 from kartothek.io.testing.read import *  # noqa
+
+
+def test_read_dataset_as_dataframes_npartitions(store_factory, metadata_version):
+    cluster1 = pd.DataFrame(
+        {"A": [1, 1], "B": [10, 10], "C": [1, 2], "Content": ["cluster1", "cluster1"]}
+    )
+    cluster2 = pd.DataFrame(
+        {"A": [1, 1], "B": [10, 10], "C": [2, 3], "Content": ["cluster2", "cluster2"]}
+    )
+    cluster3 = pd.DataFrame({"A": [1], "B": [20], "C": [1], "Content": ["cluster3"]})
+    cluster4 = pd.DataFrame(
+        {"A": [2, 2], "B": [10, 10], "C": [1, 2], "Content": ["cluster4", "cluster4"]}
+    )
+    clusters = [cluster1, cluster2, cluster3, cluster4]
+    partitions = [{"data": [("data", c)]} for c in clusters]
+
+    store_dataframes_as_dataset__iter(
+        df_generator=partitions,
+        store=store_factory,
+        dataset_uuid="partitioned_uuid",
+        metadata_version=metadata_version,
+    )
+    for func in [read_dataset_as_dataframe_bag, read_dataset_as_metapartitions_bag]:
+        bag = func(
+            dataset_uuid="partitioned_uuid", store=store_factory, npartitions=None
+        )
+        assert bag.npartitions == 4
+        bag = func(dataset_uuid="partitioned_uuid", store=store_factory, npartitions=2)
+        assert bag.npartitions == 2
 
 
 @pytest.fixture(params=["dataframe", "metapartition"])


### PR DESCRIPTION
Adding a keyword `npartition` to the read functionalities for dask's bag
backend makes it possible to fix the number of partitions when creating
the bag `db.from_sequence(some_sequence, npartitions)`.