### PR TITLE
Use a pip version less than 19.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 before_install:
   # https://github.com/JDASoftwareGroup/kartothek/issues/94
-  - pip install --upgrade pip!=19.2
+  - pip install --upgrade pip==19.1.*
   - pip install pip-tools
   - ./compile_requirements.sh
   - python setup.py bdist_wheel


### PR DESCRIPTION
pip 19.2.1 was released yesterday but the issue with `find_links` while using `pip-compile` shows up there too so specifying that `pip` be upgraded to the latest `19.1.*` version. 