### PR TITLE
Add keyword for controlling partitions size for dask bag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 Changelog
 =========
 
+- Make the size of partitions controllable by introducing the `partition_size` parameter in `kartothek.io.dask.bag.read_dataset_as_metapartitions_bag` and `karothek.io.dask.bag.read_dataset_as_dataframes_bag`
 - Predicate pushdown and :func:`~kartothek.serialization.filter_array_like` will now properly handle pandas Categoricals
 - Add :meth:`~karothek.io.dask.bag.read_dataset_as_dataframes_bag`
 - Add :meth:`~karothek.io.dask.bag.read_dataset_as_metapartitions_bag`

--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -59,6 +59,13 @@ def read_dataset_as_metapartitions_bag(
 ):
     """
     Retrieve dataset as `dask.bag` of `MetaPartition` objects.
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    A dask.bag object containing the metapartions.
     """
     ds_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
@@ -133,6 +140,14 @@ def read_dataset_as_dataframe_bag(
 ):
     """
     Retrieve data as dataframe from a `dask.bag` of `MetaPartition` objects
+
+    Parameters
+    ----------
+
+    Returns
+    -------
+    dask.bag
+        A dask.bag which contains the metapartitions and mapped to a function for retrieving the data.
     """
     mps = read_dataset_as_metapartitions_bag(
         dataset_uuid=dataset_uuid,

--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -55,6 +55,7 @@ def read_dataset_as_metapartitions_bag(
     predicates=None,
     factory=None,
     dispatch_by=None,
+    partition_size=None,
 ):
     """
     Retrieve dataset as `dask.bag` of `MetaPartition` objects.
@@ -73,7 +74,7 @@ def read_dataset_as_metapartitions_bag(
         predicates=predicates,
         dispatch_by=dispatch_by,
     )
-    mps = db.from_sequence(mps)
+    mps = db.from_sequence(mps, partition_size=partition_size)
 
     if concat_partitions_on_primary_index or dispatch_by:
         mps = mps.map(
@@ -128,6 +129,7 @@ def read_dataset_as_dataframe_bag(
     predicates=None,
     factory=None,
     dispatch_by=None,
+    partition_size=None,
 ):
     """
     Retrieve data as dataframe from a `dask.bag` of `MetaPartition` objects
@@ -146,6 +148,7 @@ def read_dataset_as_dataframe_bag(
         load_dataset_metadata=False,
         predicates=predicates,
         dispatch_by=dispatch_by,
+        partition_size=partition_size,
     )
     return mps.map(_get_data)
 

--- a/kartothek/io_components/docs.py
+++ b/kartothek/io_components/docs.py
@@ -142,6 +142,10 @@ _PARAMETER_MAPPING = {
     factory: kartothek.core.factory.DatasetFactory
         A DatasetFactory holding the store and UUID to the source dataset.
 """,
+    "partition_size": """
+    partition_size: int
+        Amount of metapartitions to cluster into one dask partition.
+""",
 }
 
 

--- a/tests/io/dask/bag/test_read.py
+++ b/tests/io/dask/bag/test_read.py
@@ -1,12 +1,14 @@
 import pickle
 from functools import partial
 
+import pandas as pd
 import pytest
 
 from kartothek.io.dask.bag import (
     read_dataset_as_dataframe_bag,
     read_dataset_as_metapartitions_bag,
 )
+from kartothek.io.iter import store_dataframes_as_dataset__iter
 from kartothek.io.testing.read import *  # noqa
 
 
@@ -32,3 +34,34 @@ def _load_dataframes(output_type, *args, **kwargs):
 @pytest.fixture()
 def bound_load_dataframes(output_type):
     return partial(_load_dataframes, output_type)
+
+
+def test_read_dataset_as_dataframes_partition_size(store_factory, metadata_version):
+    cluster1 = pd.DataFrame(
+        {"A": [1, 1], "B": [10, 10], "C": [1, 2], "Content": ["cluster1", "cluster1"]}
+    )
+    cluster2 = pd.DataFrame(
+        {"A": [1, 1], "B": [10, 10], "C": [2, 3], "Content": ["cluster2", "cluster2"]}
+    )
+    cluster3 = pd.DataFrame({"A": [1], "B": [20], "C": [1], "Content": ["cluster3"]})
+    cluster4 = pd.DataFrame(
+        {"A": [2, 2], "B": [10, 10], "C": [1, 2], "Content": ["cluster4", "cluster4"]}
+    )
+    clusters = [cluster1, cluster2, cluster3, cluster4]
+    partitions = [{"data": [("data", c)]} for c in clusters]
+
+    store_dataframes_as_dataset__iter(
+        df_generator=partitions,
+        store=store_factory,
+        dataset_uuid="partitioned_uuid",
+        metadata_version=metadata_version,
+    )
+    for func in [read_dataset_as_dataframe_bag, read_dataset_as_metapartitions_bag]:
+        bag = func(
+            dataset_uuid="partitioned_uuid", store=store_factory, partition_size=None
+        )
+        assert bag.npartitions == 4
+        bag = func(
+            dataset_uuid="partitioned_uuid", store=store_factory, partition_size=2
+        )
+        assert bag.npartitions == 2


### PR DESCRIPTION
Adding a keyword `partition_size` to the read functionalities for dask's bag
backend makes it possible to control the size of dask partitions when creating
the bag `db.from_sequence(some_sequence, partition_size)`. For example,`mps
= db.from_sequence(metapartitions, partition_size=100)` would create
dask partitions containing 100 elements of `metapartitions`.