### PR TITLE
Threading with back pressure handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 3.4.0 (Unreleased)
+==========================
+
+- Add keyword argument `nthreads` for `eager` and `iter` reading interfaces
+  which controls how many threads are being used to fetch partitions
+  concurrently.
+
 Version 3.3.0 (2019-08-15)
 ==========================
 - Fix rejection of bool predicates in :func:`~kartothek.serialization.filter_array_like` when bool columns contains

--- a/kartothek/io/_storepool.py
+++ b/kartothek/io/_storepool.py
@@ -9,7 +9,9 @@ class MapStorepoolThreaded:
     def __init__(self, nthreads, store_factory):
         """
         Context manager providing a map function which parallelizes the tasks
-        using threads. The implementation guarantees that at most nthreads partitions are held in memory. If the pool is saturated, all threads will sleep until a results is done processing and control flow is returned to the generator.
+        using threads. The implementation guarantees that at most nthreads partitions are held in memory.
+        If the pool is saturated, all threads will sleep until a results is done processing and control
+        flow is returned tothe generator.
 
         To avoid the opening a connection to a store for every thread
         individually, initialized stores are pooled and the threads can re-use
@@ -70,7 +72,9 @@ class MapStorepoolThreaded:
         return iter(self)
 
     def __exit__(self, exc_type, exc_val, tb):
-        # If the ctx is left ungracefully we need to clean up the scheduled tasks since otherwise the threadpool cannot properly close and will block. The logic will cancel all scheduled futures and sets the abort flag. All sleeping threads are then woken and are allowed to gracefully finish before the ThreadPool shuts down.
+        # If the ctx is left ungracefully we need to clean up the scheduled tasks since otherwise the threadpool
+        # cannot properly close and will block. The logic will cancel all scheduled futures and sets the abort flag.
+        # All sleeping threads are then woken and are allowed to gracefully finish before the ThreadPool shuts down.
         for fut in self._futures:
             fut.cancel()
         with self.cond:
@@ -109,7 +113,8 @@ class MapStorepoolThreaded:
 class MapStorepool:
     def __init__(self, store_factory):
         """
-        A contextmanager which offers a specialized map function which pool initialized stores/connections and allows them to be reused for every item in the map.
+        A contextmanager which offers a specialized map function which pool initialized stores/connections and allows
+        them to be reused for every item in the map.
 
         Usage::
 

--- a/kartothek/io/_storepool.py
+++ b/kartothek/io/_storepool.py
@@ -1,0 +1,157 @@
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import partial
+from queue import Queue
+from threading import Condition
+
+
+class MapStorepoolThreaded:
+    def __init__(self, nthreads, store_factory):
+        """
+        Context manager providing a map function which parallelizes the tasks
+        using threads. The implementation guarantees that at most nthreads partitions are held in memory. If the pool is saturated, all threads will sleep until a results is done processing and control flow is returned to the generator.
+
+        To avoid the opening a connection to a store for every thread
+        individually, initialized stores are pooled and the threads can re-use
+        stores/connection.
+        The initialized store object don't need to be thread safe.
+
+        Usage::
+
+            with MapStorepoolThreaded(5, store_factory) as map_threaded:
+                mps = map_threaded(
+                    MetaPartition.load_dataframes,
+                    mps,
+                    # pass arguments for load_dataframes
+                    columns=columns,
+                    ...
+                )
+                for mp in mps:
+                    # If pool is saturated, no more partitions will be fetched
+                    yield mp
+                    # after yield returns control one thread will awake and fetch a new partition
+
+        note::
+
+            This class is for internal use only, doesn't offer a stable API and
+            may be removed or changed without further warning!
+
+        Parameters
+        ----------
+        nthreads: int
+            The number of threads to be spawned and maximum number of results in memory.
+        store_factory: callable
+            A callable creating a simpleKV store object
+        """
+        self.nthreads = nthreads
+        self.thread_pool = None
+        self._futures = []
+        self.cond = Condition()
+        self.result_queue = Queue()
+        self.store_factory = store_factory
+        self.store_pool = deque()
+        self._abort = False
+
+    def __enter__(self):
+        self.thread_pool = ThreadPoolExecutor(self.nthreads)
+        return self
+
+    def __call__(self, func, iterable, *args, **kwargs):
+        self._futures = [
+            self.thread_pool.submit(
+                self._process_job_with_storepool, func, mp, *args, **kwargs
+            )
+            for mp in iterable
+        ]
+        with self.cond:
+            # This controls how many results are allowed to be concurrently
+            # fetched
+            self.cond.notify(self.nthreads)
+        return iter(self)
+
+    def __exit__(self, exc_type, exc_val, tb):
+        # If the ctx is left ungracefully we need to clean up the scheduled tasks since otherwise the threadpool cannot properly close and will block. The logic will cancel all scheduled futures and sets the abort flag. All sleeping threads are then woken and are allowed to gracefully finish before the ThreadPool shuts down.
+        for fut in self._futures:
+            fut.cancel()
+        with self.cond:
+            self._abort = False
+            self.cond.notify_all()
+        self.thread_pool.shutdown()
+
+    def __iter__(self):
+        for fut in as_completed(self._futures):
+            exc = fut.exception()
+            if exc:
+                raise exc
+            yield self.result_queue.get()
+            with self.cond:
+                self.cond.notify()
+
+    def _process_job_with_storepool(self, method, mp, *args, **kwargs):
+        with self.cond:
+            self.cond.wait()
+            # If an exception is raised while this thread was asleep and the
+            # pool is shut down, don't execute any logic
+            if self._abort:
+                return
+            # The check for available stores in the pool
+            # needs to be within the lock context
+            if len(self.store_pool):
+                store = self.store_pool.pop()
+            else:
+                store = self.store_factory()
+
+        res = method(mp, store=store, *args, **kwargs)
+        self.store_pool.append(store)
+        self.result_queue.put(res)
+
+
+class MapStorepool:
+    def __init__(self, store_factory):
+        """
+        A contextmanager which offers a specialized map function which pool initialized stores/connections and allows them to be reused for every item in the map.
+
+        Usage::
+
+            with MapStorepool(store_factory) as _map:
+                mps = _map(
+                    MetaPartition.load_dataframes,
+                    mps,
+                    # pass arguments for load_dataframes
+                    columns=columns,
+                    ...
+                )
+                for mp in mps:
+                    # Do somethint with the result. A new thread will only start running once the yield returns control to the generator
+                    yield mp
+
+        note::
+
+            This class is for internal use only, doesn't offer a stable API and
+            may be removed or changed without further warning!
+
+        Parameters
+        ----------
+        store_factory: callable
+            Callable to create a simplekv store
+        """
+        self.store = store_factory()
+        self._results = []
+
+    def __enter__(self):
+        return self
+
+    def __call__(self, func, iterable, *args, **kwargs):
+        self._results = map(
+            partial(self._process_job_with_storepool, func, *args, **kwargs), iterable
+        )
+        return iter(self)
+
+    def __exit__(self, exc_type, exc_val, tb):
+        pass
+
+    def __iter__(self):
+        return iter(self._results)
+
+    def _process_job_with_storepool(self, method, mp, *args, **kwargs):
+        return method(mp, store=self.store, *args, **kwargs)

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -95,6 +95,7 @@ def read_dataset_as_dataframes(
     predicates=None,
     factory=None,
     dispatch_by=None,
+    nthreads=0,
 ):
     """
     Read a dataset as a list of dataframes.
@@ -142,6 +143,7 @@ def read_dataset_as_dataframes(
         predicates=predicates,
         factory=ds_factory,
         dispatch_by=dispatch_by,
+        nthreads=nthreads,
     )
     return [mp.data for mp in mps]
 
@@ -161,6 +163,7 @@ def read_dataset_as_metapartitions(
     predicates=None,
     factory=None,
     dispatch_by=None,
+    nthreads=0,
 ):
     """
     Read a dataset as a list of :class:`kartothek.io_components.metapartition.MetaPartition`.
@@ -209,6 +212,7 @@ def read_dataset_as_metapartitions(
         predicates=predicates,
         factory=ds_factory,
         dispatch_by=dispatch_by,
+        nthreads=nthreads,
     )
     return list(ds_iter)
 
@@ -247,6 +251,7 @@ def read_table(
     dates_as_object=False,
     predicates=None,
     factory=None,
+    nthreads=0,
 ):
     """
     A utility function to load a single table with multiple partitions as a single dataframe in one go.
@@ -312,6 +317,7 @@ def read_table(
         dates_as_object=dates_as_object,
         predicates=predicates,
         factory=ds_factory,
+        nthreads=nthreads,
     )
 
     empty_df = empty_dataframe_from_schema(

--- a/kartothek/io_components/docs.py
+++ b/kartothek/io_components/docs.py
@@ -146,6 +146,11 @@ _PARAMETER_MAPPING = {
     partition_size: int
         Amount of metapartitions to cluster into one dask partition.
 """,
+    "nthreads": """
+    nthreads: Union[int, None]
+        If non-zero use a ThreadPool to fetch partitions concurrently.
+        If `None` use NUM_CPUS * 5 worker threads.
+""",
 }
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ filterwarnings =
     once::DeprecationWarning
     once::PendingDeprecationWarning
     ignore:.*(Generated\sarray\selement).*:FutureWarning:hypothesis.extra.numpy
+    ignore:.*(RangeIndex.*\sis\sdeprecated).*:DeprecationWarning:pyarrow.pandas_compat
 
 markers =
     min_metadata_version(version): specify minimum metadata version this test applies to

--- a/tests/io/test_storepool.py
+++ b/tests/io/test_storepool.py
@@ -1,0 +1,126 @@
+import time
+import weakref
+from functools import partial
+
+import pytest
+
+from kartothek.io._storepool import MapStorepool, MapStorepoolThreaded
+
+
+@pytest.mark.parametrize(
+    "klass",
+    [
+        partial(MapStorepoolThreaded, nthreads=1),
+        partial(MapStorepoolThreaded, nthreads=10),
+        MapStorepool,
+    ],
+)
+def test_storepool(klass):
+    side_effects = []
+
+    def f(x, store):
+        side_effects.append(x)
+        return x
+
+    stores = []
+
+    def store_factory():
+        stores.append(None)
+
+    num_jobs = 10
+    with klass(store_factory=store_factory) as map_threaded:
+        list(map_threaded(f, range(num_jobs)))
+    assert len(stores) == 1
+    assert len(side_effects) == num_jobs
+
+
+@pytest.mark.parametrize("nthreads", range(1, 10))
+def test_limit_concurrent_fetches(nthreads):
+    side_effects = []
+
+    def f(x, store):
+        side_effects.append(x)
+        return x
+
+    num_jobs = 10
+    with MapStorepoolThreaded(
+        store_factory=lambda: None, nthreads=nthreads  # No need for a store here
+    ) as map_threaded:
+        res = map_threaded(f, range(num_jobs))
+        next(res)
+        sleep_time = 0.005
+        # Give the function some time to execute. The side effects will be filled
+        time.sleep(sleep_time)
+        assert len(side_effects) == nthreads
+        # Even when waiting for longer time no further function will be executed
+        # A new function will only be called once a result is finished and a new one is fetched
+        time.sleep(2 * sleep_time)
+        assert len(side_effects) == nthreads
+        next(res)
+        time.sleep(sleep_time)
+        assert len(side_effects) == nthreads + 1
+        next(res)
+        time.sleep(sleep_time)
+        assert len(side_effects) == min(num_jobs, nthreads + 2)
+
+        res = list(res)
+        # In the end, all jobs are processed
+        assert len(side_effects) == num_jobs
+
+
+def test_propagate_exceptions():
+    def f(x, store):
+        if x == 5:
+            raise RuntimeError("Intentional")
+        elif x == 8:
+            raise ValueError(
+                "This should not happen because the tasks are killed before that"
+            )
+
+    nthreads = 2
+    num_jobs = 10
+    with pytest.raises(RuntimeError, match="Intentional"):
+        with MapStorepoolThreaded(
+            store_factory=lambda: None, nthreads=nthreads  # No need for a store here
+        ) as map_threaded:
+            list(map_threaded(f, range(num_jobs)))
+
+
+@pytest.mark.parametrize("nthreads", range(1, 10))
+def test_results_kept_after_usage(nthreads):
+    links = weakref.WeakValueDictionary()
+
+    class A:
+        def __init__(self, val):
+            self.val = val
+
+    def f(x, store):
+        # cannot weakref an integer
+        obj = A(x)
+        links[x] = obj
+        return obj
+
+    num_jobs = 10
+    with MapStorepoolThreaded(
+        store_factory=lambda: None, nthreads=nthreads  # No need for a store here
+    ) as map_threaded:
+        # need to trigger the generator
+        sleep_time = 0.005
+        for ix in map_threaded(f, range(num_jobs)):
+            time.sleep(sleep_time)
+            assert len(links) <= nthreads + 1
+
+
+def test_threadpool_closes_on_exc():
+    """
+    Test that the threadpool and generator properly temrinate and don't block.
+    This test should always be green but the test execution will deadlock during shutdown if there is an issue.
+    """
+    with MapStorepoolThreaded(
+        store_factory=lambda: None, nthreads=10  # No need for a store here
+    ) as map_threaded:
+        try:
+            for ix in map_threaded(lambda mp, store: None, range(10)):
+                raise RuntimeError
+        except Exception:
+            pass


### PR DESCRIPTION
I wanted to introduce this a long time ago and dug out the code again. Back then there was the concern that we do not have any guarantee about the thread safety of the stores which is why I introduced this `StorePool` class which would allow us to use distinct store object but don't need to recreate the connections and objects for every thread.
(please, don't be picky about the implementation details, I haven't spend much time on this)

Nice thing about this approach is that we benefit in all eager and iter read implementations.

Refinement options:
* Global theadpool
* Global store pool (possibly even throughout ktk but private / non public API)


Please give me your thoughts. If this is something we feel comfortable with, I'll clean up the code