### PR TITLE
Downpin simplekv so docs don't break

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pandas>=0.23.0
 # pyarrow==0.14.0 breaks kartothek
 pyarrow>=0.11.1, !=0.14.0, <0.14.1 # Keep upper bound pinned until we see non-breaking releases in the future
 simplejson
-simplekv
+simplekv<0.13
 storefact
 zstandard


### PR DESCRIPTION
New version of `simplekv` dropped on the 26th which doesn't seem to have `pickle_azure_store` anymore, so downpinning it to `<0.13`