### PR TITLE
Streamline behavior of `update_dataset_from_ddf` with empty ddf.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Version 3.2.1 (2019-XX-XX)
 ==========================
 - Fix rejection of bool predicates in :func:`~kartothek.serialization.filter_array_like` when bool columns contains
   ``None``
+- Streamline behavior of `store_dataset_from_ddf` when passing empty ddf.
 - Fix an issue where a segmentation fault may be raised when comparing MetaPartition instances
 
 

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -27,6 +27,9 @@ def _update_dask_partitions_shuffle(
     num_buckets,
     sort_partitions_by,
 ):
+    if ddf.npartitions == 0:
+        return ddf
+
     splits = np.array_split(
         np.arange(ddf.npartitions), min(ddf.npartitions, num_buckets)
     )

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -204,3 +204,16 @@ def test_update_shuffle_buckets(
     tasks = pickle.loads(s)
 
     tasks.compute()
+
+
+@pytest.mark.parametrize("shuffle", [True, False])
+def test_update_dataset_from_ddf_empty(store_factory, shuffle):
+    with pytest.raises(ValueError, match="Cannot store empty datasets"):
+        update_dataset_from_ddf(
+            dask.dataframe.from_delayed([], meta=(("a", int),)),
+            store_factory,
+            dataset_uuid="output_dataset_uuid",
+            table="core",
+            shuffle=shuffle,
+            partition_on=["a"],
+        ).compute()


### PR DESCRIPTION
# Description:

Makes `update_dataset_from_ddf` behave the same if called with empty ddf regardless of `shuffle` setting.

Closes #109 