### PR TITLE
Do not bundle tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def setup_package():
         author="Blue Yonder GmbH",
         install_requires=get_install_requirements("requirements.txt"),
         tests_require=get_install_requirements("test-requirements.txt"),
-        packages=find_packages(exclude=["tests"]),
+        packages=find_packages(exclude=["tests*"]),
         classifiers=[
             "Development Status :: 5 - Production/Stable",
             "Programming Language :: Python",


### PR DESCRIPTION
# Description:

When building python distributions (e.g. wheels), some test packages where also bundled, although clearly that was not the intention of the code in `setup.py`, which only excluded the toplevel `tests` package. Changed to exclude *all* test packages.
