### PR TITLE
`store_dataframes_as_dataset` accepts dicts and list of tuples equivalents

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 3.X.X (2019-09-XX)
 ==========================
 - ``MetaPartition.load_dataframes`` now raises if table in ``columns`` argument doesn't exist
 - require ``urlquote>=1.1.0`` (where ``urlquote.quoting`` was introduced)
+- ``MetaPartition.parse_input_to_metapartition`` accepts dicts and list of tuples equivalents as ``obj`` input
 
 
 Version 3.4.0 (2019-09-17)

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -482,9 +482,6 @@ def store_dataframes_as_dataset(
     if dataset_uuid is None:
         dataset_uuid = gen_uuid()
 
-    if isinstance(dfs, dict):
-        dfs = {"data": [(table, df) for table, df in dfs.items()]}
-
     if not overwrite:
         raise_if_dataset_exists(dataset_uuid=dataset_uuid, store=store)
 

--- a/tests/io/eager/test_write.py
+++ b/tests/io/eager/test_write.py
@@ -177,6 +177,23 @@ def test_store_dataframes_as_dataset_no_pipeline(metadata_version, store):
     assert dataset == stored_dataset
 
 
+def test_store_dataframes_as_dataset_dfs_input_formats(store):
+    df1 = pd.DataFrame({"B": [pd.Timestamp("2019")]})
+    df2 = pd.DataFrame({"A": [1.4]})
+    formats = [
+        {"data": {"D": df1, "S": df2}},
+        {"D": df1, "S": df2},
+        {"data": [("D", df1), ("S", df2)]},
+        [("D", df1), ("S", df2)],
+    ]
+    for input_format in formats:
+        dataset = store_dataframes_as_dataset(
+            store=store, dataset_uuid="dataset_uuid", dfs=input_format, overwrite=True
+        )
+        stored_dataset = DatasetMetadata.load_from_store("dataset_uuid", store)
+        assert dataset == stored_dataset
+
+
 def test_store_dataframes_as_dataset_mp(metadata_version, store):
     df = pd.DataFrame(
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1627,3 +1627,16 @@ def test_parse_nested_input_schema_compatible_but_different():
     mp = parse_input_to_metapartition(df_input, metadata_version=4)
     expected_schema = make_meta(pd.DataFrame({"A": ["str"]}), origin="expected")
     assert mp.table_meta["table"] == expected_schema
+
+
+def test_parse_input_schema_formats():
+    df = pd.DataFrame({"B": [pd.Timestamp("2019")]})
+    formats_obj = [
+        {"data": {"table1": df}},
+        {"table1": df},
+        {"data": [("table1", df)]},
+        [("table1", df)],
+    ]
+    for obj in formats_obj:
+        mp = parse_input_to_metapartition(obj=obj, metadata_version=4)
+        assert mp.data == {"table1": df}


### PR DESCRIPTION
# Description:

This PR makes `io/eager/store_dataframes_as_dataset` accept `dfs` arguments in the following formats:
`{"data": {"table": df}}, {"table": df}, {"data": [("table", df)]}` and `[("table", df)]`.

Docstrings have not been adapted yet.

- [x] Closes #63 
- [x] Tests added / passed
- [x] Passes `./format_code.sh`
- [x] Changelog entry
