### PR TITLE
Improve predicate performance for `in` operator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 3.X.X (2019-09-XX)
 ==========================
 - ``MetaPartition.load_dataframes`` now raises if table in ``columns`` argument doesn't exist
 - require ``urlquote>=1.1.0`` (where ``urlquote.quoting`` was introduced)
+- Improve performance for some cases where predicates are used with the `in` operator.
 
 
 Version 3.4.0 (2019-09-17)


### PR DESCRIPTION
Benchmark code (on local filesystem):
```
from functools import partial
from tempfile import TemporaryDirectory

import numpy as np
import pandas as pd
import pyarrow.parquet as pq
import storefact

from kartothek.io.eager import store_dataframes_as_dataset
from kartothek.serialization import ParquetSerializer

tmpdir = TemporaryDirectory().name
store_factory = partial(storefact.get_store_from_url, f"hfs://{tmpdir}")

df = pd.DataFrame({"x": np.tile([17, 18], 10 ** 6)})

uuid = "test"
dm = store_dataframes_as_dataset(store=store_factory, dataset_uuid=uuid, dfs=df)

storage_key = dm.partitions[list(dm.partitions.keys())[0]].files["table"]
filepath = f"{tmpdir}/{storage_key}"

parquet_file = pq.ParquetFile(filepath)

ps = ParquetSerializer()

%timeit ps.restore_dataframe(store_factory(), storage_key, predicates=[[("x", "in", (13, 15, 20))]])
```

Original: `44.9 ms ± 1.61 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`
New: `4.18 ms ± 303 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)`
- [x] Tests added / passed
- [x] Changelog entry
