### PR TITLE
Make load_dataframes raise, if non-existent table in columns argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changelog
 =========
 
 
+Version 3.X.X (2019-09-XX)
+==========================
+- ``MetaPartition.load_dataframes`` now raises if table in ``columns`` argument doesn't exist
+
+
 Version 3.4.0 (2019-09-17)
 ==========================
 - Add support for pyarrow 0.14.1

--- a/kartothek/io_components/docs.py
+++ b/kartothek/io_components/docs.py
@@ -31,7 +31,8 @@ _PARAMETER_MAPPING = {
     "columns": """
     columns : dict of list of string, optional
         A dictionary mapping tables to list of columns. Only the specified
-        columns are loaded for the corresponding table.""",
+        columns are loaded for the corresponding table. If a specfied table or column is
+        not present in the dataset, a ValueError is raised.""",
     "dispatch_by": """
     dispatch_by: list of strings, optional
         List of index columns to group and partition the dataframe by.""",

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -646,6 +646,15 @@ class MetaPartition(Iterable):
         """
         if columns is None:
             columns = {}
+        elif set(columns).difference(self.tables):
+            raise (
+                ValueError(
+                    "You are trying to read columns from invalid table(s): {}".format(
+                        set(columns).difference(self.tables)
+                    )
+                )
+            )
+
         if categoricals is None:
             categoricals = {}
 

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -271,6 +271,28 @@ def test_load_dataframes_columns_raises_missing(
     assert str(e.value) == "Columns cannot be found in stored dataframe: bar, foo"
 
 
+def test_load_dataframes_columns_table_missing(
+    meta_partitions_evaluation_files_only, store_session
+):
+    # test behavior of load_dataframes for columns argument given
+    # specifying table that doesn't exist
+    mp = meta_partitions_evaluation_files_only[0]
+    assert len(mp.files) > 0
+    assert len(mp.data) == 0
+    with pytest.raises(
+        ValueError,
+        match=r"You are trying to read columns from invalid table\(s\). .*PRED_typo.*",
+    ):
+        mp.load_dataframes(
+            store=store_session,
+            columns={"PRED_typo": ["P", "L", "HORIZON", "foo", "bar"]},
+        )
+
+    # ensure typo in tables argument doesn't raise, as specified in docstring
+    dfs = mp.load_dataframes(store=store_session, tables=["PRED_typo"])
+    assert len(dfs) > 0
+
+
 def test_from_dict():
     df = pd.DataFrame({"a": [1]})
     dct = {"data": {"core": df}, "label": "test_label"}


### PR DESCRIPTION
# Description:

This PR makes `io_components/metapartiton.py -> load_dataframes` raise a `ValueError` in case at least one table specified in the `columns` argument dict doesn't exist. 
The behavior to ignore a non-existent table specified in the `tables` argument remains unchanged.

- [x] Closes #128
- [x] Tests added / passed
- [x] Passes `./format_code.sh`
- [x] Changelog entry
