### PR TITLE
Add explicit readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+    - requirements: test-requirements.txt


### PR DESCRIPTION
By default, readthedocs will use setuptools install to set up the doc build.
This may lead to build errors for non-python dependencies since we get some
coupling to their packaging implementations (e.g. without this it was tried
to compile a rust package). This way we can force it to explicitly use pre
packaged wheels.
