### PR TITLE
Remove obsolete checkboxes from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,4 @@ Briefly describe the change of behavior
 
 
 - [ ] Closes #xxxx
-- [ ] Tests added / passed
-- [ ] Passes `./format_code.sh`
 - [ ] Changelog entry


### PR DESCRIPTION
The two checkboxes are a bit redundant. The `Closes` is good because it's a keyword GitHub recognises and automatically closes the connected issue and the changelog is a nice reminder. Th other two are covered by the CI