### PR TITLE
Added secondary_indices as a default arg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,13 +2,13 @@
 Changelog
 =========
 
-
 Version 3.X.X (2019-09-XX)
 ==========================
 - ``MetaPartition.load_dataframes`` now raises if table in ``columns`` argument doesn't exist
 - require ``urlquote>=1.1.0`` (where ``urlquote.quoting`` was introduced)
 - ``MetaPartition.parse_input_to_metapartition`` accepts dicts and list of tuples equivalents as ``obj`` input
 - Improve performance for some cases where predicates are used with the `in` operator.
+- Added `secondary_indices` as a default argument to the `write` pipelines
 
 
 Version 3.4.0 (2019-09-17)

--- a/docs/further_useful_features.rst
+++ b/docs/further_useful_features.rst
@@ -98,7 +98,7 @@ column all get written to the same partition. To do this, we use the
 .. ipython:: python
 
     dm = store_dataframes_as_dataset(
-        store_factory, "partitioned_dataset", df, partition_on="B"
+        store_factory, "partitioned_dataset", [df], partition_on="B"
     )
 
 Partitioning based on a date column ussually makes sense for timeseries data.
@@ -184,7 +184,7 @@ with ``kartothek``. Specifically, we'll reuse the ``df`` dataframe that we'd cre
 
 .. ipython:: python
 
-    dm = store_dataframes_as_dataset(store_factory, "a_unique_dataset_identifier", df)
+    dm = store_dataframes_as_dataset(store_factory, "a_unique_dataset_identifier", [df])
     sorted(dm.partitions.keys())
 
 
@@ -386,7 +386,7 @@ with one update:
     df  # Column B includes 2 values for '2013-01-02' and another 2 for '2013-01-03'
 
     dm = store_dataframes_as_dataset(
-        store_factory, "replace_partition", df, partition_on="B"
+        store_factory, "replace_partition", [df], partition_on="B"
     )
     sorted(dm.partitions.keys())  # two partitions, one for each value of `B`
 

--- a/docs/io/examples.rst
+++ b/docs/io/examples.rst
@@ -34,7 +34,7 @@ Setup a store
     }
 
     store_dataframes_as_dataset(
-        store=store_factory, dataset_uuid=dataset_uuid, dfs=df, metadata=metadata
+        store=store_factory, dataset_uuid=dataset_uuid, dfs=[df], metadata=metadata
     )
 
     # Load your data

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -345,6 +345,7 @@ def commit_dataset(
     default_metadata_version=DEFAULT_METADATA_VERSION,
     partition_on=None,
     factory=None,
+    secondary_indices=None,
 ):
     """
     Update an existing dataset with new, already written partitions. This should be used in combination with
@@ -411,6 +412,9 @@ def commit_dataset(
         new_partitions, metadata_version=metadata_version
     )
 
+    if secondary_indices:
+        mps = mps.build_indices(columns=secondary_indices)
+
     mps = [_maybe_infer_files_attribute(mp, dataset_uuid) for mp in mps]
 
     dmd = update_dataset_from_partitions(
@@ -461,6 +465,7 @@ def store_dataframes_as_dataset(
     partition_on=None,
     df_serializer=None,
     overwrite=False,
+    secondary_indices=None,
     metadata_storage_format=DEFAULT_METADATA_STORAGE_FORMAT,
     metadata_version=DEFAULT_METADATA_VERSION,
 ):
@@ -489,6 +494,9 @@ def store_dataframes_as_dataset(
 
     if partition_on:
         mp = MetaPartition.partition_on(mp, partition_on)
+
+    if secondary_indices:
+        mp = mp.build_indices(columns=secondary_indices)
 
     mps = mp.store_dataframes(
         store=store, dataset_uuid=dataset_uuid, df_serializer=df_serializer
@@ -578,6 +586,7 @@ def write_single_partition(
     metadata_version=DEFAULT_METADATA_VERSION,
     partition_on=None,
     factory=None,
+    secondary_indices=None,
 ):
     """
     Write the parquet file(s) for a single partition. This will **not** update the dataset header and can therefore
@@ -621,6 +630,9 @@ def write_single_partition(
     mp = parse_input_to_metapartition(obj=data, metadata_version=ds_metadata_version)
     if partition_on:
         mp = mp.partition_on(partition_on)
+
+    if secondary_indices:
+        mp = mp.build_indices(columns=secondary_indices)
 
     mp = mp.validate_schema_compatible(dataset_uuid=dataset_uuid, store=store)
 


### PR DESCRIPTION
# Description:

Added a consistant arg `secondary_indices' to all writing pipelines


- [x] Closes #46 
- [x] Tests added / passed
- [x] Passes `./format_code.sh`
- [x] Changelog entry
