### PR TITLE
require urlquote>=1.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 Version 3.X.X (2019-09-XX)
 ==========================
 - ``MetaPartition.load_dataframes`` now raises if table in ``columns`` argument doesn't exist
+- require ``urlquote>=1.1.0`` (where ``urlquote.quoting`` was introduced)
 
 
 Version 3.4.0 (2019-09-17)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pyarrow>=0.11.1, !=0.14.0, <0.15.0 # Keep upper bound pinned until we see non-br
 simplejson
 simplekv
 storefact
-urlquote
+urlquote>=1.1.0
 zstandard


### PR DESCRIPTION
this version is required because we use urlquote.quoting, introduced in 1.1


- [ ] Closes #xxxx
- [X] Tests added / passed
- [x] Passes `./format_code.sh`
- [X] Changelog entry
