### PR TITLE
Add minimal version requirement for urlquote

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pyarrow>=0.11.1, !=0.14.0, <0.15.0 # Keep upper bound pinned until we see non-br
 simplejson
 simplekv
 storefact
-urlquote
+urlquote>=1.1.1
 zstandard


### PR DESCRIPTION
Only version 1.1 offers the urlquote.quoting module which is used in Kartothek