### PR TITLE
Input to `normalize_args` is properly normalized to `list`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 
 Version 3.X.X (2019-09-XX)
 ==========================
+- Input to ``normalize_args`` is properly normalized to ``list``
 - ``MetaPartition.load_dataframes`` now raises if table in ``columns`` argument doesn't exist
 - require ``urlquote>=1.1.0`` (where ``urlquote.quoting`` was introduced)
 - ``MetaPartition.parse_input_to_metapartition`` accepts dicts and list of tuples equivalents as ``obj`` input

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -167,7 +167,15 @@ _ARGS_TO_TYPE = {"partition_on": list, "delete_scope": list, "secondary_indices"
 
 
 def normalize_arg(arg_name, old_value):
-    def _make_list(*_args):
+    def _make_list(_args):
+        if isinstance(_args, (str, bytes, int, float)):
+            return [_args]
+        if _args is None:
+            return []
+        if isinstance(_args, (set, frozenset, dict)):
+            raise ValueError(
+                "{} is incompatible for normalisation.".format(type(_args))
+            )
         return list(_args)
 
     type_to_normalize = {list: _make_list}
@@ -179,7 +187,7 @@ def normalize_arg(arg_name, old_value):
     if isinstance(old_value, _ARGS_TO_TYPE[arg_name]):
         return old_value
     elif old_value is None:
-        new_value = args_to_normalize[arg_name]()
+        new_value = _ARGS_TO_TYPE[arg_name]()
     elif not isinstance(old_value, _ARGS_TO_TYPE[arg_name]):
         new_value = args_to_normalize[arg_name](old_value)
     else:

--- a/tests/io_components/test_utils.py
+++ b/tests/io_components/test_utils.py
@@ -71,6 +71,7 @@ def testcombine_metadata_lists():
         (("a", "abc", None), ("a", ["abc"], [])),
         (("a", None, "abc"), ("a", [], ["abc"])),
         (("a", None, None), ("a", [], [])),
+        (("a", (1, 2), ("a", "b")), ("a", [1, 2], ["a", "b"])),
     ],
 )
 def test_normalize_args(test_input, expected):
@@ -83,6 +84,19 @@ def test_normalize_args(test_input, expected):
         test_arg1, test_partition_on, delete_scope=test_delete_scope
     )
     assert (expected[0], expected[1], []) == func(test_arg1, test_partition_on)
+
+
+@pytest.mark.parametrize(
+    "test_input", [("a", {"a"}, "c"), ("a", frozenset("a"), None), ("abc", {"c": 6}, 4)]
+)
+def test_normalize_args__incompatible_types(test_input):
+    @normalize_args
+    def func(arg1, partition_on, delete_scope=None):
+        return arg1, partition_on, delete_scope
+
+    test_arg1, test_partition_on, test_delete_scope = test_input
+    with pytest.raises(ValueError):
+        func(test_arg1, test_partition_on, delete_scope=test_delete_scope)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description:

Normalise properly to lists within normalise_arg
Duplicate of PR #138 but due to its messed up commit history, this new PR

- [x] Closes #56 
- [x] Changelog entry
