### PR TITLE
Provide default table name for kartothek.io.*read_table* methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Version 3.X.X (2019-09-XX)
 - Added `secondary_indices` as a default argument to the `write` pipelines
 - Correctly preserve :class:`~kartothek.core.index.ExplicitSecondaryIndex` dtype when index is empty
 - Fixed DeprecationWarning in pandas ``CategoricalDtype``
-
+- Make ``kartothek.io.*read_table*`` methods use default table name if unspecified
 
 Version 3.4.0 (2019-09-17)
 ==========================

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -21,6 +21,7 @@ from kartothek.io_components.docs import default_docs
 from kartothek.io_components.gc import delete_files, dispatch_files_to_gc
 from kartothek.io_components.merge import align_datasets
 from kartothek.io_components.metapartition import (
+    SINGLE_TABLE,
     MetaPartition,
     parse_input_to_metapartition,
 )
@@ -386,7 +387,7 @@ def read_dataset_as_delayed(
 def read_table_as_delayed(
     dataset_uuid=None,
     store=None,
-    table=None,
+    table=SINGLE_TABLE,
     columns=None,
     concat_partitions_on_primary_index=False,
     predicate_pushdown_to_io=True,
@@ -415,9 +416,9 @@ def read_table_as_delayed(
 
     Parameters
     ----------
+    table: str, optional
+    The table to be loaded. If none is specified, the default 'table' is used.
     """
-    if table is None:
-        raise TypeError("Parameter `table` is not optional.")
     if not isinstance(columns, dict):
         columns = {table: columns}
     mps = read_dataset_as_delayed_metapartitions(

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -28,6 +28,7 @@ from kartothek.io_components.docs import default_docs
 from kartothek.io_components.gc import delete_files, dispatch_files_to_gc
 from kartothek.io_components.index import update_indices_from_partitions
 from kartothek.io_components.metapartition import (
+    SINGLE_TABLE,
     MetaPartition,
     parse_input_to_metapartition,
 )
@@ -235,7 +236,7 @@ def _check_compatible_list(table, obj, argument_name=""):
 def read_table(
     dataset_uuid=None,
     store=None,
-    table=None,
+    table=SINGLE_TABLE,
     columns=None,
     concat_partitions_on_primary_index=False,
     predicate_pushdown_to_io=True,
@@ -253,8 +254,8 @@ def read_table(
 
     Parameters
     ----------
-    table: str
-        The table to be loaded
+    table: str, optional
+        The table to be loaded. If none is specified, the default 'table' is used.
     columns: List[str]
         The columns to be loaded
     categoricals: List[str]
@@ -285,8 +286,6 @@ def read_table(
             DeprecationWarning,
         )
 
-    if table is None:
-        raise TypeError("Parameter `table` is not optional.")
     if not isinstance(table, str):
         raise TypeError("Argument `table` needs to be a string")
 

--- a/kartothek/io/testing/delete.py
+++ b/kartothek/io/testing/delete.py
@@ -81,7 +81,7 @@ def test_delete_dataset_unreferenced_files(
     create_dataset(uuid, store_factory, metadata_version)
 
     store = store_factory()
-    store.put(f"{uuid}/core/trash.parquet", b"trash")
+    store.put(f"{uuid}/table/trash.parquet", b"trash")
 
     assert len(list(store.keys())) > 0
     bound_delete_dataset(uuid, store_factory)

--- a/kartothek/io/testing/gc.py
+++ b/kartothek/io/testing/gc.py
@@ -18,7 +18,7 @@ def _test_gc(uuid, store_factory, garbage_collect_callable):
     keys_before = set(store.keys())
 
     # Add a non-tracked table file
-    store.put("{}/core/trash.parquet".format(uuid), b"trash")
+    store.put("{}/table/trash.parquet".format(uuid), b"trash")
 
     # Add a non-tracked index file
     store.put("{}/indices/trash.parquet".format(uuid), b"trash")

--- a/kartothek/io/testing/merge.py
+++ b/kartothek/io/testing/merge.py
@@ -4,9 +4,11 @@ from datetime import date
 import pandas as pd
 import pandas.util.testing as pdt
 
+from kartothek.io_components.metapartition import SINGLE_TABLE
+
 MERGE_TASKS = [
     {
-        "left": "core",
+        "left": SINGLE_TABLE,
         "right": "helper",
         "merge_kwargs": {"how": "left", "sort": False, "copy": False},
         "output_label": "first_output",

--- a/kartothek/io/testing/read.py
+++ b/kartothek/io/testing/read.py
@@ -42,7 +42,7 @@ import pytest
 from kartothek.core.uuid import gen_uuid
 from kartothek.io.eager import store_dataframes_as_dataset
 from kartothek.io.iter import store_dataframes_as_dataset__iter
-from kartothek.io_components.metapartition import MetaPartition
+from kartothek.io_components.metapartition import SINGLE_TABLE, MetaPartition
 
 
 @pytest.fixture(
@@ -124,7 +124,7 @@ def _perform_read_test(
         read_kwargs = {}
     if use_categoricals:
         # dataset_with_index has an index on L but not on P
-        categoricals = {"core": ["P", "L"]}
+        categoricals = {SINGLE_TABLE: ["P", "L"]}
     else:
         categoricals = None
 
@@ -151,7 +151,7 @@ def _perform_read_test(
         result = [mp.data for mp in result]
 
         def sort_by(obj):
-            return obj["core"].P.iloc[0]
+            return obj[SINGLE_TABLE].P.iloc[0]
 
     elif output_type == "table":
 
@@ -163,11 +163,11 @@ def _perform_read_test(
 
     else:
         assert isinstance(result[0], dict)
-        assert "core" in result[0]
-        assert "P" in result[0]["core"]
+        assert SINGLE_TABLE in result[0]
+        assert "P" in result[0][SINGLE_TABLE]
 
         def sort_by(obj):
-            return obj["core"].P.iloc[0]
+            return obj[SINGLE_TABLE].P.iloc[0]
 
     result = sorted(result, key=sort_by)
 
@@ -202,7 +202,7 @@ def _perform_read_test(
                 check_like=True,
             )
         else:
-            actual_core = _strip_unused_categoricals(res["core"])
+            actual_core = _strip_unused_categoricals(res[SINGLE_TABLE])
             actual_helper = _strip_unused_categoricals(res["helper"])
             assert len(res) == 2
             pdt.assert_frame_equal(
@@ -240,7 +240,7 @@ def test_read_dataset_as_dataframes_predicate(
         predicates=predicates,
         **custom_read_parameters,
     )
-    core_result = pd.concat([data["core"] for data in result])
+    core_result = pd.concat([data[SINGLE_TABLE] for data in result])
 
     expected_core = pd.DataFrame(
         {
@@ -285,11 +285,11 @@ def test_read_dataset_as_dataframes_predicate_with_partition_keys(
         dataset_uuid=dataset_partition_keys.uuid,
         store=store_session_factory,
         predicates=predicates,
-        tables=["core"],
+        tables=[SINGLE_TABLE],
         **custom_read_parameters,
     )
 
-    core_result = pd.concat([data["core"] for data in result])
+    core_result = pd.concat([data[SINGLE_TABLE] for data in result])
 
     expected_core = pd.DataFrame(
         {
@@ -317,8 +317,8 @@ def test_read_dataset_as_dataframes_predicate_empty(
         dataset_uuid=dataset_partition_keys.uuid,
         store=store_session_factory,
         predicates=[[("P", "==", -42)]],
-        tables=["core"],
-        columns={"core": ["P", "L", "TARGET"]},
+        tables=[SINGLE_TABLE],
+        columns={SINGLE_TABLE: ["P", "L", "TARGET"]},
         **custom_read_parameters,
     )
     assert len(result) == 0
@@ -516,7 +516,7 @@ def test_load_dataset_metadata(
 def test_read_dataset_as_dataframes_columns_projection(
     store_factory, bound_load_dataframes, metadata_version
 ):
-    table_name = "core"
+    table_name = SINGLE_TABLE
 
     def _f(b_c):
         b, c = b_c
@@ -555,7 +555,7 @@ def test_read_dataset_as_dataframes_columns_projection(
 def test_read_dataset_as_dataframes_columns_primary_index_only(
     store_factory, bound_load_dataframes, metadata_version
 ):
-    table_name = "core"
+    table_name = SINGLE_TABLE
 
     def _f(b_c):
         b, c = b_c
@@ -592,7 +592,7 @@ def test_read_dataset_as_dataframes_columns_primary_index_only(
 def test_empty_predicate_pushdown_empty_col_projection(
     dataset, store_session_factory, bound_load_dataframes, backend_identifier
 ):
-    table_name = "core"
+    table_name = SINGLE_TABLE
     result = bound_load_dataframes(
         dataset_uuid=dataset.uuid,
         tables=table_name,
@@ -629,7 +629,7 @@ def test_datetime_predicate_with_dates_as_object(
     datetype,
     comp,
 ):
-    table_name = "core"
+    table_name = SINGLE_TABLE
 
     def _f(b_c):
         b, c = b_c
@@ -667,7 +667,7 @@ def test_datetime_predicate_with_dates_as_object(
 
 
 def test_binary_column_metadata(store_factory, bound_load_dataframes):
-    table_name = "core"
+    table_name = SINGLE_TABLE
     df = {
         "label": "part1",
         "data": [(table_name, pd.DataFrame({b"int_col": [1], "🙈".encode(): [2]}))],

--- a/kartothek/io/testing/utils.py
+++ b/kartothek/io/testing/utils.py
@@ -6,6 +6,7 @@ import storefact
 from simplekv.decorator import StoreDecorator
 
 from kartothek.io.eager import store_dataframes_as_dataset
+from kartothek.io_components.metapartition import SINGLE_TABLE
 
 
 def create_dataset(dataset_uuid, store_factory, metadata_version):
@@ -20,13 +21,17 @@ def create_dataset(dataset_uuid, store_factory, metadata_version):
     df_list = [
         {
             "label": "cluster_1",
-            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
-            "indices": {"core": {val: ["cluster_2"] for val in df.TARGET.unique()}},
+            "data": [(SINGLE_TABLE, df.copy(deep=True)), ("helper", df_helper)],
+            "indices": {
+                SINGLE_TABLE: {val: ["cluster_2"] for val in df.TARGET.unique()}
+            },
         },
         {
             "label": "cluster_2",
-            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
-            "indices": {"core": {val: ["cluster_2"] for val in df.TARGET.unique()}},
+            "data": [(SINGLE_TABLE, df.copy(deep=True)), ("helper", df_helper)],
+            "indices": {
+                SINGLE_TABLE: {val: ["cluster_2"] for val in df.TARGET.unique()}
+            },
         },
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from kartothek.core.testing import (
 )
 from kartothek.io.testing.utils import no_pickle_store_from_url
 from kartothek.io_components.metapartition import (
+    SINGLE_TABLE,
     MetaPartition,
     gen_uuid,
     parse_input_to_metapartition,
@@ -202,7 +203,7 @@ def _get_meta_partitions_with_dataframe(metadata_version):
     df_2 = pd.DataFrame(OrderedDict([("P", [1]), ("info", ["a"])]))
     mp = MetaPartition(
         label="cluster_1",
-        data={"core": df, "helper": df_2},
+        data={SINGLE_TABLE: df, "helper": df_2},
         metadata_version=metadata_version,
     )
     df_3 = pd.DataFrame(
@@ -218,7 +219,7 @@ def _get_meta_partitions_with_dataframe(metadata_version):
     df_4 = pd.DataFrame(OrderedDict([("P", [2]), ("info", ["b"])]))
     mp2 = MetaPartition(
         label="cluster_2",
-        data={"core": df_3, "helper": df_4},
+        data={SINGLE_TABLE: df_3, "helper": df_4},
         metadata_version=metadata_version,
     )
     return [mp, mp2]

--- a/tests/io/dask/dataframe/test_read.py
+++ b/tests/io/dask/dataframe/test_read.py
@@ -6,6 +6,7 @@ import pytest
 
 from kartothek.io.dask.dataframe import read_dataset_as_ddf
 from kartothek.io.testing.read import *  # noqa
+from kartothek.io_components.metapartition import SINGLE_TABLE
 
 
 @pytest.fixture()
@@ -22,7 +23,7 @@ def _read_as_ddf(
     dataset_has_index=False,
     **kwargs,
 ):
-    table = tables or "core"
+    table = tables or SINGLE_TABLE
     if categoricals:
         categoricals = categoricals[table]
     ddf = read_dataset_as_ddf(

--- a/tests/io/dask/delayed/test_read.py
+++ b/tests/io/dask/delayed/test_read.py
@@ -24,7 +24,7 @@ def _load_dataframes(output_type, *args, **kwargs):
     elif output_type == "table":
         if "tables" in kwargs:
             kwargs.pop("tables")
-        func = partial(read_table_as_delayed, table="core")
+        func = partial(read_table_as_delayed)
     tasks = func(*args, **kwargs)
 
     s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)

--- a/tests/io/eager/test_commit.py
+++ b/tests/io/eager/test_commit.py
@@ -18,13 +18,14 @@ from kartothek.io.eager import (
     store_dataframes_as_dataset,
     write_single_partition,
 )
+from kartothek.io_components.metapartition import SINGLE_TABLE
 
 
 def test_commit_dataset_from_metapartition(dataset_function, store):
 
     new_data = {
         "data": {
-            "core": pd.DataFrame(
+            SINGLE_TABLE: pd.DataFrame(
                 OrderedDict(
                     [
                         ("P", [5]),
@@ -67,7 +68,9 @@ def test_commit_dataset_from_metapartition(dataset_function, store):
     # Read the data and check whether the rows above are included.
     # This checks whether all necessary informations were updated in the header
     # (e.g. files attributes of the partitions)
-    actual = read_table(store=store, table="core", dataset_uuid=dataset_function.uuid)
+    actual = read_table(
+        store=store, table=SINGLE_TABLE, dataset_uuid=dataset_function.uuid
+    )
     df_expected = pd.DataFrame(
         OrderedDict(
             [
@@ -96,7 +99,7 @@ def test_commit_dataset_from_dict(dataset_function, store):
 
     new_data = {
         "data": {
-            "core": pd.DataFrame(
+            SINGLE_TABLE: pd.DataFrame(
                 OrderedDict(
                     [
                         ("P", [5]),
@@ -113,7 +116,10 @@ def test_commit_dataset_from_dict(dataset_function, store):
         store=store, dataset_uuid=dataset_function.uuid, data=new_data
     )
     new_partition = [
-        {"label": new_metapartition.label, "data": [("core", None), ("helper", None)]}
+        {
+            "label": new_metapartition.label,
+            "data": [(SINGLE_TABLE, None), ("helper", None)],
+        }
     ]
     pre_commit_dataset = DatasetMetadata.load_from_store(
         uuid=dataset_function.uuid, store=store
@@ -143,7 +149,9 @@ def test_commit_dataset_from_dict(dataset_function, store):
     # Read the data and check whether the rows above are included.
     # This checks whether all necessary informations were updated in the header
     # (e.g. files attributes of the partitions)
-    actual = read_table(store=store, table="core", dataset_uuid=dataset_function.uuid)
+    actual = read_table(
+        store=store, table=SINGLE_TABLE, dataset_uuid=dataset_function.uuid
+    )
     df_expected = pd.DataFrame(
         OrderedDict(
             [

--- a/tests/io/eager/test_read.py
+++ b/tests/io/eager/test_read.py
@@ -152,7 +152,7 @@ def test_write_and_read_default_table_name(store_session):
     from kartothek.io.eager import store_dataframes_as_dataset
 
     df_write = pd.DataFrame({"P": [3.14, 2.71]})
-    store_dataframes_as_dataset(store_session, "test_default_table_name", df_write)
+    store_dataframes_as_dataset(store_session, "test_default_table_name", [df_write])
 
     # assert default table name "table" is used
     df_read_as_dfs = read_dataset_as_dataframes(

--- a/tests/io/eager/test_read.py
+++ b/tests/io/eager/test_read.py
@@ -11,12 +11,13 @@ from kartothek.io.eager import (
     read_table,
 )
 from kartothek.io.testing.read import *  # noqa
+from kartothek.io_components.metapartition import SINGLE_TABLE
 
 
 def _read_table(*args, **kwargs):
     if "tables" in kwargs:
         kwargs.pop("tables")
-    res = read_table(*args, table="core", **kwargs)
+    res = read_table(*args, **kwargs)
 
     if len(res):
         # Array split conserves dtypes
@@ -48,14 +49,14 @@ def backend_identifier():
 
 def test_read_table_eager(dataset, store_session, use_categoricals):
     if use_categoricals:
-        categories = {"core": ["P"]}
+        categories = {SINGLE_TABLE: ["P"]}
     else:
         categories = None
 
     df = read_table(
         store=store_session,
         dataset_uuid="dataset_uuid",
-        table="core",
+        table=SINGLE_TABLE,
         categoricals=categories,
     )
     expected_df = pd.DataFrame(
@@ -114,7 +115,7 @@ def test_read_table_with_columns(dataset, store_session):
     df = read_table(
         store=store_session,
         dataset_uuid="dataset_uuid",
-        table="core",
+        table=SINGLE_TABLE,
         columns=["P", "L"],
     )
 
@@ -131,7 +132,7 @@ def test_read_table_simple_list_for_cols_cats(dataset, store_session):
     df = read_table(
         store=store_session,
         dataset_uuid="dataset_uuid",
-        table="core",
+        table=SINGLE_TABLE,
         columns=["P", "L"],
         categoricals=["P", "L"],
     )
@@ -145,3 +146,16 @@ def test_read_table_simple_list_for_cols_cats(dataset, store_session):
     expected_df = expected_df.astype("category")
 
     pdt.assert_frame_equal(df, expected_df, check_dtype=False, check_like=True)
+
+
+def test_write_and_read_default_table_name(store_session):
+    from kartothek.io.eager import store_dataframes_as_dataset
+
+    df_write = pd.DataFrame({"P": [3.14, 2.71]})
+    store_dataframes_as_dataset(store_session, "test_default_table_name", df_write)
+
+    # assert default table name "table" is used
+    df_read_as_dfs = read_dataset_as_dataframes(
+        "test_default_table_name", store_session
+    )
+    pd.testing.assert_frame_equal(df_write, df_read_as_dfs[0]["table"])

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -14,6 +14,7 @@ from kartothek.core.common_metadata import make_meta, store_schema_metadata
 from kartothek.core.index import ExplicitSecondaryIndex
 from kartothek.core.naming import DEFAULT_METADATA_VERSION
 from kartothek.io_components.metapartition import (
+    SINGLE_TABLE,
     MetaPartition,
     _unique_label,
     parse_input_to_metapartition,
@@ -200,7 +201,7 @@ def test_load_dataframes(
     assert len(mp.data) == 2
     data = mp.data
 
-    pdt.assert_frame_equal(data["core"], expected_df, check_dtype=False)
+    pdt.assert_frame_equal(data[SINGLE_TABLE], expected_df, check_dtype=False)
     pdt.assert_frame_equal(data["helper"], expected_df_2, check_dtype=False)
 
     empty_mp = MetaPartition("empty_mp", metadata_version=mp.metadata_version)
@@ -232,12 +233,12 @@ def test_load_dataframes_selective(meta_partitions_files_only, store_session):
     assert len(mp.files) > 0
     assert len(mp.data) == 0
     mp = meta_partitions_files_only[0].load_dataframes(
-        store=store_session, tables=["core"]
+        store=store_session, tables=[SINGLE_TABLE]
     )
     assert len(mp.data) == 1
     data = mp.data
 
-    pdt.assert_frame_equal(data["core"], expected_df, check_dtype=False)
+    pdt.assert_frame_equal(data[SINGLE_TABLE], expected_df, check_dtype=False)
 
 
 def test_load_dataframes_columns_projection(

--- a/tests/io_components/test_read.py
+++ b/tests/io_components/test_read.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 
 from kartothek.io.eager import store_dataframes_as_dataset
-from kartothek.io_components.metapartition import MetaPartition
+from kartothek.io_components.metapartition import SINGLE_TABLE, MetaPartition
 from kartothek.io_components.read import dispatch_metapartitions
 
 
@@ -24,7 +24,7 @@ def test_dispatch_metapartitions(dataset, store_session):
     assert isinstance(mp, MetaPartition)
     assert dict(mp.dataset_metadata) == dict(dataset.metadata)
 
-    assert set(mp.table_meta.keys()) == {"core", "helper"}
+    assert set(mp.table_meta.keys()) == {SINGLE_TABLE, "helper"}
 
 
 def test_dispatch_metapartitions_label_filter(dataset, store_session):


### PR DESCRIPTION
# Description:

This PR makes ``read_table`` methods in the ``kartothek.io`` module use the default table name as it is already specified for store/update methods in ``kartothek.io_components.metapartition`` if none is given.

- [x] Closes #121 
- [x] Changelog entry
