### PR TITLE
Fix pandas DeprecationWarning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Version 3.X.X (2019-09-XX)
 - ``MetaPartition.parse_input_to_metapartition`` accepts dicts and list of tuples equivalents as ``obj`` input
 - Improve performance for some cases where predicates are used with the `in` operator.
 - Correctly preserve :class:`~kartothek.core.index.ExplicitSecondaryIndex` dtype when index is empty
+- Fixed DeprecationWarning in pandas ``CategoricalDtype``
 
 
 Version 3.4.0 (2019-09-17)

--- a/kartothek/io/dask/_utils.py
+++ b/kartothek/io/dask/_utils.py
@@ -49,7 +49,7 @@ def _construct_categorical(column, dataset_metadata_factory):
             column,
             len(values),
         )
-    return pd.api.types.CategoricalDtype(values)
+    return pd.api.types.CategoricalDtype(values, ordered=False)
 
 
 def _maybe_get_categoricals_from_index(dataset_metadata_factory, categoricals):

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -273,7 +273,7 @@ def align_categories(dfs, categoricals):
         categories = list(largest_df_categories) + sorted(
             set(categories) - set(largest_df_categories)
         )
-        cat_dtype = pd.api.types.CategoricalDtype(categories)
+        cat_dtype = pd.api.types.CategoricalDtype(categories, ordered=False)
         col_dtype[column] = cat_dtype
 
     return_dfs = []

--- a/tests/serialization/test_filter.py
+++ b/tests/serialization/test_filter.py
@@ -61,8 +61,8 @@ def test_filter_array_like_lower_eq(array_like):
     "cat_type",
     [
         "category",
-        pd.CategoricalDtype(["A", "B", "C"]),
-        pd.CategoricalDtype(["B", "C", "A"]),
+        pd.CategoricalDtype(["A", "B", "C"], ordered=False),
+        pd.CategoricalDtype(["B", "C", "A"], ordered=False),
         pd.CategoricalDtype(["A", "B", "C"], ordered=True),
     ],
 )


### PR DESCRIPTION
# Description:

Running the test ```tests/io/dask/dataframe/test_read.py::test_load_dataframe_categoricals_with_index``` was giving warning ```FutureWarning: Constructing a CategoricalDtype without specifying `ordered` will default to `ordered=False` in a future version; `ordered=None` must be explicitly passed.```

This has been fixed