### PR TITLE
fix broken build due to pip-compile errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 
   matrix:
     # required builds
-    - PIP_COMPILE_ARGS="-P pyarrow==0.12.1 -P dask<2.2.0"
+    - PIP_COMPILE_ARGS="-P pyarrow==0.12.1 -P dask<2.2.0 -P distributed<2.2.0"
     - PIP_COMPILE_ARGS="-P pyarrow==0.13.0"
     - PIP_COMPILE_ARGS="-P pyarrow==0.14.1"
 


### PR DESCRIPTION
`pip-compile` wasn't able to figure out that when `dask<2.2.0` is specified it shouldn't get a distributed version which requires a greater version of dask, so we make that clear

- [ ] Closes #150 

