### PR TITLE
update docstring of `io.eager.store_dataframes...` and df arg parsing

### DIFF
--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -473,14 +473,22 @@ def store_dataframes_as_dataset(
 
     Parameters
     ----------
-    dfs : dict of pd.DataFrame or pd.DataFrame
-        The dataframe(s) to be stored. If only a single dataframe is passed, it will be stored as the `core` table.
+    dfs: List[Union[pd.DataFrame, Dict[str, pd.DataFrame]]]
+        The dataframe(s) to be stored.
 
     Returns
     -------
     The stored dataset
 
     """
+    if isinstance(dfs, (pd.DataFrame, dict)):
+        dfs = [dfs]
+        warnings.warn(
+            "Passing a single dataframe instead of an iterable is deprecated and may "
+            "be removed in the next major release.",
+            DeprecationWarning,
+        )
+
     return store_dataframes_as_dataset__iter(
         dfs,
         store=store,


### PR DESCRIPTION
Up until a few commits ago, passing a single dataframe was supported.
This now re-enables that support but raises a deprecation warning.
This commit also updates the docstring of the function to make the input
clear to a user.


