### PR TITLE
Add codecov configuration to decrease false negative rate

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1
+
+ignore:
+  - kartothek/core/_deprecation.py


### PR DESCRIPTION
The default settings currently highlight all of our builds as failed. I had a look at the past PRs and this threshold is still rather strict but should be forgiving for most trivial coverage decreases.

I don't want to get rid of it immediately since I actually look at the coverage reports every now and then but I want it to be less noisy. If the threshold is too low, we can increase it