### PR TITLE
No schema validation in internal ops

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ Version 3.X.X (2019-09-XX)
 - Fixed DeprecationWarning in pandas ``CategoricalDtype``
 - Fixed broken docstring for `store_dataframes_as_dataset`
 - Make ``kartothek.io.*read_table*`` methods use default table name if unspecified
+- Internal operations no longer perform schema validations. This will improve
+  performance for batched partition operations (e.g. `partition_on`) but will
+  defer the validation in case of inconsistencies to the final commit. Exception
+  messages will be less verbose in these cases as before.
 
 
 Version 3.4.0 (2019-09-17)

--- a/kartothek/io/testing/write.py
+++ b/kartothek/io/testing/write.py
@@ -730,8 +730,8 @@ def test_schema_check_write_nice_error(store_factory, bound_store_dataframes):
 
 Schema violation
 
-Origin schema: {core/P=2/Q=1/uuid2, core/P=2/Q=2/uuid2}
-Origin reference: {core/P=1/Q=1/uuid1, core/P=1/Q=2/uuid1}
+Origin schema: {core/P=2/Q=2/uuid2}
+Origin reference: {core/P=1/Q=2/uuid1}
 
 Diff:
 """
@@ -770,8 +770,8 @@ def test_schema_check_write_cut_error(store_factory, bound_store_dataframes):
 
 Schema violation
 
-Origin schema: {core/P=2/Q=0/uuid2, core/P=2/Q=1/uuid2, core/P=2/Q=10/uuid2, core/P=2/Q=11/uuid2, core/P=2/Q=12/uuid2, core/P=2/Q=13/uuid2, core/P=2/Q=14/uuid2, core/P=2/Q=15/uuid2, core/P=2/Q=16/uuid2, core/P=2/Q=17...}
-Origin reference: {core/P=1/Q=0/uuid1, core/P=1/Q=1/uuid1, core/P=1/Q=10/uuid1, core/P=1/Q=11/uuid1, core/P=1/Q=12/uuid1, core/P=1/Q=13/uuid1, core/P=1/Q=14/uuid1, core/P=1/Q=15/uuid1, core/P=1/Q=16/uuid1, core/P=1/Q=17...}
+Origin schema: {core/P=2/Q=99/uuid2}
+Origin reference: {core/P=1/Q=99/uuid1}
 
 Diff:
 """

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -130,7 +130,7 @@ def _apply_to_list(method):
                     result = method_return
                 else:
                     for mp in method_return:
-                        result = result.add_metapartition(mp)
+                        result = result.add_metapartition(mp, schema_validation=False)
         if not isinstance(result, MetaPartition):
             raise ValueError(
                 "Result for method {} is not a `MetaPartition` but".format(
@@ -1187,7 +1187,8 @@ class MetaPartition(Iterable):
                         logical_conjunction=kwargs.get(
                             "logical_conjunction", self.logical_conjunction
                         ),
-                    )
+                    ),
+                    schema_validation=False,
                 )
             return mp_parent
         else:
@@ -1316,7 +1317,7 @@ class MetaPartition(Iterable):
                 },
                 partition_keys=partition_on,
             )
-            new_mp = new_mp.add_metapartition(tmp_mp)
+            new_mp = new_mp.add_metapartition(tmp_mp, schema_validation=False)
         if self.indices:
             new_mp = new_mp.build_indices(columns=self.indices.keys())
         return new_mp


### PR DESCRIPTION
# Description:

This should improve overall performance for very large datasets by introducing slots for objects which are created frequently.

The schema validation within the MP seemed quite unnecessary so I removed them. The change in exception messages stems from hashing the schemas at the very final reduction which isn't performed by default.