### PR TITLE
enable fast_finish in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ after_success:
   - codecov
 
 matrix:
+  # When marking the build as finished, do not wait for allowed failures to complete
+  fast_finish: true
   allow_failures:
     - env: ARROW_NIGHTLY=1
     - env: PIP_COMPILE_ARGS="-P pyarrow==0.13.0" NUMFOCUS_NIGHTLY=1


### PR DESCRIPTION
# Description:

We often wait for builds to pass the tests. This commit makes this wait a little bit shorter by marking the build as "passing" (if all required jobs have passed) before the allowed_failures jobs of the build matrix have finished (by default, it waits until the allowed_failures have finished).

Travis docs: https://docs.travis-ci.com/user/customizing-the-build/#fast-finishing