### PR TITLE
Hash buckets in update_ddf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 Version 3.5.2 (unreleased)
 ==========================
 - Fix addition of bogus index columns to Parquet files when using `sort_partitions_by`.
+- The partition on shuffle algorithm in :func:`~kartothek.io.dask.dataframe.update_dataset_from_ddf` will now produce
+  deterministic buckets based on hashed input data
 
 Version 3.5.1 (2019-10-25)
 ==========================

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -2,9 +2,10 @@
 
 
 from functools import partial
+from typing import List
 
-import dask.array as da
 import numpy as np
+import pandas as pd
 
 from kartothek.io_components.metapartition import (
     MetaPartition,
@@ -13,6 +14,26 @@ from kartothek.io_components.metapartition import (
 from kartothek.io_components.utils import sort_values_categorical
 
 from ._utils import map_delayed
+
+_KTK_HASH_BUCKET = "__KTK_HASH_BUCKET"
+
+
+def _hash_bucket(df: pd.DataFrame, subset: List[str], num_buckets: int):
+    """
+    Categorize each row of `df` based on the data in the columns `subset`
+    into `num_buckets` values. This is based on `pandas.util.hash_pandas_object`
+    """
+
+    if subset is None:
+        subset = df.columns
+    hash_arr = pd.util.hash_pandas_object(df[subset], index=False)
+    buckets = hash_arr % num_buckets
+
+    available_bit_widths = np.array([8, 16, 32, 64])
+    mask = available_bit_widths > np.log2(num_buckets)
+    bit_width = min(available_bit_widths[mask])
+    df[_KTK_HASH_BUCKET] = buckets.astype(f"uint{bit_width}")
+    return df
 
 
 def _update_dask_partitions_shuffle(
@@ -30,32 +51,35 @@ def _update_dask_partitions_shuffle(
     if ddf.npartitions == 0:
         return ddf
 
-    splits = np.array_split(
-        np.arange(ddf.npartitions), min(ddf.npartitions, num_buckets)
-    )
-    lower_bounds = map(min, splits)
-    upper_bounds = map(max, splits)
+    if num_buckets is not None:
+        if sort_partitions_by:
+            bucket_by = [sort_partitions_by]
+        else:
+            bucket_by = None
 
-    final = []
-    for lower, upper in zip(lower_bounds, upper_bounds):
-        chunk_ddf = ddf.partitions[lower : upper + 1]
-        chunk_ddf = chunk_ddf.groupby(by=partition_on[0])
-        chunk_ddf = chunk_ddf.apply(
-            partial(
-                _store_partition,
-                secondary_indices=secondary_indices,
-                sort_partitions_by=sort_partitions_by,
-                table=table,
-                dataset_uuid=dataset_uuid,
-                partition_on=partition_on,
-                store_factory=store_factory,
-                df_serializer=df_serializer,
-                metadata_version=metadata_version,
-            ),
-            meta=("MetaPartition", "object"),
-        )
-        final.append(chunk_ddf)
-    return da.concatenate([val.values for val in final])
+        meta = ddf._meta
+        meta[_KTK_HASH_BUCKET] = np.uint64(0)
+        ddf = ddf.map_partitions(_hash_bucket, bucket_by, num_buckets, meta=meta)
+        group_cols = [partition_on[0], _KTK_HASH_BUCKET]
+    else:
+        group_cols = [partition_on[0]]
+
+    ddf = ddf.groupby(by=group_cols)
+    ddf = ddf.apply(
+        partial(
+            _store_partition,
+            secondary_indices=secondary_indices,
+            sort_partitions_by=sort_partitions_by,
+            table=table,
+            dataset_uuid=dataset_uuid,
+            partition_on=partition_on,
+            store_factory=store_factory,
+            df_serializer=df_serializer,
+            metadata_version=metadata_version,
+        ),
+        meta=("MetaPartition", "object"),
+    )
+    return ddf
 
 
 def _update_dask_partitions_one_to_one(
@@ -106,6 +130,8 @@ def _store_partition(
     df_serializer,
     metadata_version,
 ):
+    if _KTK_HASH_BUCKET in df:
+        df = df.drop(_KTK_HASH_BUCKET, axis=1)
     store = store_factory()
     # I don't have access to the group values
     mps = parse_input_to_metapartition(

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -47,16 +47,12 @@ def _update_dask_partitions_shuffle(
     dataset_uuid,
     num_buckets,
     sort_partitions_by,
+    bucket_by,
 ):
     if ddf.npartitions == 0:
         return ddf
 
     if num_buckets is not None:
-        if sort_partitions_by:
-            bucket_by = [sort_partitions_by]
-        else:
-            bucket_by = None
-
         meta = ddf._meta
         meta[_KTK_HASH_BUCKET] = np.uint64(0)
         ddf = ddf.map_partitions(_hash_bucket, bucket_by, num_buckets, meta=meta)
@@ -130,8 +126,6 @@ def _store_partition(
     df_serializer,
     metadata_version,
 ):
-    if _KTK_HASH_BUCKET in df:
-        df = df.drop(_KTK_HASH_BUCKET, axis=1)
     store = store_factory()
     # I don't have access to the group values
     mps = parse_input_to_metapartition(

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -166,6 +166,19 @@ def update_dataset_from_ddf(
         This effectively splits up the execution ``num_buckets`` times. Setting this parameter may be helpful when
         scaling.
         This only has an effect if ``shuffle==True``
+    bucket_by:
+        The subset of columns which should be considered for bucketing.
+
+        This parameter ensures that groups of the given subset are never split
+        across buckets within a given partition.
+        This only has an effect if ``shuffle==True``
+
+        .. admonition:: Secondary indices
+
+            This parameter has a strong effect on the performance of secondary
+            indices. Since it guarantees that a given tuple of the subset will
+            be entirely put into the same file you can build efficient indices
+            with this approach.
     """
     partition_on = normalize_arg("partition_on", partition_on)
     secondary_indices = normalize_arg("secondary_indices", secondary_indices)

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -119,6 +119,7 @@ def update_dataset_from_ddf(
     default_metadata_version=DEFAULT_METADATA_VERSION,
     partition_on=None,
     factory=None,
+    bucket_by=None,
 ):
     """
     Update a dataset from a dask.dataframe.
@@ -171,6 +172,9 @@ def update_dataset_from_ddf(
 
         This parameter ensures that groups of the given subset are never split
         across buckets within a given partition.
+
+        Without specifying this the buckets will be created randomly.
+
         This only has an effect if ``shuffle==True``
 
         .. admonition:: Secondary indices
@@ -179,6 +183,10 @@ def update_dataset_from_ddf(
             indices. Since it guarantees that a given tuple of the subset will
             be entirely put into the same file you can build efficient indices
             with this approach.
+
+        .. note::
+
+            Only columns with data types which can be hashed are allowed to be used in this.
     """
     partition_on = normalize_arg("partition_on", partition_on)
     secondary_indices = normalize_arg("secondary_indices", secondary_indices)
@@ -227,6 +235,7 @@ def update_dataset_from_ddf(
                 dataset_uuid=dataset_uuid,
                 num_buckets=num_buckets,
                 sort_partitions_by=sort_partitions_by,
+                bucket_by=bucket_by,
             )
         else:
             delayed_tasks = ddf.to_delayed()


### PR DESCRIPTION
# Description:

This allows for a deterministic bucketing based on hashing. For large scale data processing this requires a bit more ram (10-20%) but scales very well otherwise.
I would suggest to expose a kwarg `bucket_by` which exposes this parameter publicly and otherwise acts similar to partition_on