### PR TITLE
allow failures for numfocus nightly again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: ARROW_NIGHTLY=1
-    - env: PIP_COMPILE_ARGS="-P pyarrow==0.13.0" NUMFOCUS_NIGHTLY=1
+    - env: PIP_COMPILE_ARGS="-P pyarrow==0.15.0" NUMFOCUS_NIGHTLY=1
   include:
     - name: "osx + builtin python3"
       os: osx


### PR DESCRIPTION
The arrow bump enabled the numfocus nighlties to be as required builds. unfortunately, the envs need to match exactly. I.e. we need to be more careful next time