### PR TITLE
Drop index after sorting so it does not end up in the Arrow table.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Version 3.5.2 (unreleased)
+==========================
+- Fix addition of bogus index columns to Parquet files when using `sort_partitions_by`.
+
 Version 3.5.1 (2019-10-25)
 ==========================
 - Fix potential ``pyarrow.lib.ArrowNotImplementedError`` when trying to store or pickle empty

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -338,7 +338,7 @@ def sort_values_categorical(df, column):
         df[column] = cat_accesor.reorder_categories(
             sorted(cat_accesor.categories), ordered=True
         )
-    return df.sort_values(by=[column])
+    return df.sort_values(by=[column]).reset_index(drop=True)
 
 
 def check_single_table_dataset(dataset, expected_table=None):

--- a/tests/io_components/test_utils.py
+++ b/tests/io_components/test_utils.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pandas.testing as pdt
+import pyarrow as pa
 import pytest
 
 from kartothek.io_components.utils import (
@@ -188,3 +189,14 @@ def test_sort_cateogrical():
     assert sorted_df["cat"].is_monotonic
     assert sorted_df["cat"].cat.ordered
     assert all(sorted_df["cat"].cat.categories == sorted(categories))
+
+
+def test_sort_categorical_pyarrow_conversion():
+    """
+    Make sure sorting does not introduce indices that end up in the Arrow table.
+    """
+    df = pd.DataFrame(dict(a=[3, 2, 1]))
+    sorted_df = sort_values_categorical(df, "a")
+    table = pa.Table.from_pandas(df)
+    sorted_table = pa.Table.from_pandas(sorted_df)
+    assert table.schema.names == sorted_table.schema.names


### PR DESCRIPTION
# Description:

I've observed a blowup of parquet file size when using `sort_partitions_by`. The reason is that sorting introduces an int64 index that gets serialized into the Parquet files.

## Example:
not using `sort_partitions_by`:
```<pyarrow._parquet.ParquetSchema object at 0x7f0eac7f6470>
l_id: INT64
c_date: INT32 DATE
e_type: BYTE_ARRAY UTF8
e_name: BYTE_ARRAY UTF8
```

using `sort_partitions_by`:
```<pyarrow._parquet.ParquetSchema object at 0x7f0ebc625c18>
l_id: INT64
c_date: INT32 DATE
e_type: BYTE_ARRAY UTF8
e_name: BYTE_ARRAY UTF8
__index_level_0__: INT64
```

- [x ] Changelog entry
