### PR TITLE
Register classes with dask sizeof

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,22 @@
 Changelog
 =========
 
+Next release
+============
+
+Improvements
+^^^^^^^^^^^^
+
+- Dask is now able to calculate better size estimates for the following classes:
+    * :class:`~kartothek.core.dataset.DatasetMetadata`
+    * :class:`~kartothek.core.factory.DatasetFactory`
+    * :class:`~kartothek.io_components.metapartition.MetaPartition`
+    * :class:`~kartothek.core.index.ExplicitSecondaryIndex`
+    * :class:`~kartothek.core.index.PartitionIndex`
+    * :class:`~kartothek.core.partition.Partition`
+    * :class:`~kartothek.core.common_metadata.SchemaWrapper`
+
+
 Version 3.6.2 (2019-12-17)
 ==========================
 

--- a/kartothek/io/dask/__init__.py
+++ b/kartothek/io/dask/__init__.py
@@ -1,0 +1,3 @@
+from ._sizeof import register_sizeof_ktk_classes
+
+register_sizeof_ktk_classes()

--- a/kartothek/io/dask/_sizeof.py
+++ b/kartothek/io/dask/_sizeof.py
@@ -1,0 +1,22 @@
+from dask.sizeof import sizeof as dask_sizeof
+
+
+def _dct_sizeof(obj):
+    return dask_sizeof(obj.__dict__)
+
+
+def register_sizeof_ktk_classes():
+    from kartothek.core.dataset import DatasetMetadata
+    from kartothek.core.factory import DatasetFactory
+    from kartothek.io_components.metapartition import MetaPartition
+    from kartothek.core.index import ExplicitSecondaryIndex, PartitionIndex
+    from kartothek.core.partition import Partition
+    from kartothek.core.common_metadata import SchemaWrapper
+
+    dask_sizeof.register(DatasetMetadata, _dct_sizeof)
+    dask_sizeof.register(DatasetFactory, _dct_sizeof)
+    dask_sizeof.register(MetaPartition, _dct_sizeof)
+    dask_sizeof.register(ExplicitSecondaryIndex, _dct_sizeof)
+    dask_sizeof.register(PartitionIndex, _dct_sizeof)
+    dask_sizeof.register(Partition, _dct_sizeof)
+    dask_sizeof.register(SchemaWrapper, _dct_sizeof)


### PR DESCRIPTION
# Description:

While this doesn't introduce a __sizeof__ implementation for the classes, this registers the classes for the Dask sizeof implementations which enables fast (approximate), recursive size estimations for our objects when used in a dask context.

- [x] Closes #167
- [x] Changelog entry
