### PR TITLE
add license header as requested by legal

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (c) 2019 JDA Software, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
They want that to clarify that this is a MIT license and people don't just need to guess from the text or the GitHub auto-detection.
