### PR TITLE
Improve predicate TypeError messages

### DIFF
--- a/kartothek/core/index.py
+++ b/kartothek/core/index.py
@@ -231,7 +231,9 @@ class IndexBase(CopyMixin):
         if index_arr is None:
             index_arr = np.array(list(index_dct.keys()))
 
-        index = filter_array_like(index_arr, op, value, strict_date_types=True)
+        index = filter_array_like(
+            index_arr, op, value, strict_date_types=True, column_name=self.column
+        )
         allowed_values = index_arr[index]
         # Need to determine allowed values to include predicates like `in`
         for value in allowed_values:

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -608,11 +608,15 @@ def test_eval_operators_type_safety():
     # gh66
     ind = IndexBase(column="col", index_dct={1234: ["part"]}, dtype=pa.int64())
     with pytest.raises(
-        TypeError, match="Unexpected type encountered. Expected i but got O."
+        TypeError,
+        match=r"Unexpected type for predicate: Column 'col' has pandas type 'int64', "
+        r"but predicate value '1234' has pandas type 'object' \(Python type '<class 'str'>'\).",
     ):
         ind.eval_operator("==", "1234")
     with pytest.raises(
-        TypeError, match="Unexpected type encountered. Expected i but got f."
+        TypeError,
+        match=r"Unexpected type for predicate: Column 'col' has pandas type 'int64', "
+        r"but predicate value 1234.0 has pandas type 'float64' \(Python type '<class 'float'>'\).",
     ):
         ind.eval_operator("==", 1234.0)
 

--- a/tests/serialization/test_filter.py
+++ b/tests/serialization/test_filter.py
@@ -93,7 +93,7 @@ def test_filter_array_like_categoricals(op, expected, cat_type):
 @pytest.mark.parametrize("op", ["==", "!=", "<", "<=", ">", ">=", "in"])
 def test_raise_on_type(value, filter_value, op):
     array_like = pd.Series([value])
-    with pytest.raises(TypeError, match="Unexpected type encountered."):
+    with pytest.raises(TypeError, match="Unexpected type for predicate:"):
         filter_array_like(array_like, op, filter_value, strict_date_types=True)
 
 


### PR DESCRIPTION
Improve error messages when passing predicate values of wrong type.

Example old:

```
TypeError: Unexpected type encountered. Expected O but got M.
```

Example new:

```
TypeError: Unexpected type for predicate: Column 'col1' has pandas type 'object',
but predicate value Timestamp('2020-01-01 00:00:00') has pandas type 'datetime64[ns]'
(Python type '<class 'pandas._libs.tslibs.timestamps.Timestamp'>').
```