### PR TITLE
Do not produce duplicate jobs when using predicates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 3.6.1 (2019-12-10)
+==========================
+
+Bug fixes
+^^^^^^^^^
+* Fix a regression introduced in 3.5.0 where predicates which allow multiple
+  values for a field would generate duplicates
+
 Version 3.6.0 (2019-12-03)
 ==========================
 

--- a/kartothek/io_components/read.py
+++ b/kartothek/io_components/read.py
@@ -84,7 +84,7 @@ def dispatch_metapartitions_from_factory(
             logical_conjunction = list(
                 zip(dispatch_by, ["=="] * len(dispatch_by), group_name)
             )
-            for label in group.index:
+            for label in group.index.unique():
                 mps.append(
                     MetaPartition.from_partition(
                         partition=dataset_factory.partitions[label],
@@ -98,7 +98,7 @@ def dispatch_metapartitions_from_factory(
                 )
             yield mps
     else:
-        for part_label in base_df.index:
+        for part_label in base_df.index.unique():
             part = dataset_factory.partitions[part_label]
 
             yield MetaPartition.from_partition(

--- a/tests/io_components/test_read.py
+++ b/tests/io_components/test_read.py
@@ -136,3 +136,37 @@ def test_dispatch_metapartitions_concat_regression(store):
 
     mps = list(dispatch_metapartitions(dataset.uuid, store, dispatch_by=["p"]))
     assert len(mps) == 1
+
+
+def test_dispatch_metapartitions_dups_with_predicates(store):
+    dataset = store_dataframes_as_dataset(
+        dfs=[pd.DataFrame({"p": [0, 1], "x": 0})],
+        dataset_uuid="test",
+        store=store,
+        secondary_indices=["p"],
+    )
+
+    wout_preds = list(dispatch_metapartitions(dataset.uuid, store))
+    w_preds = list(
+        dispatch_metapartitions(dataset.uuid, store, predicates=[[("p", "in", [0, 1])]])
+    )
+
+    assert wout_preds == w_preds
+
+
+def test_dispatch_metapartitions_dups_with_predicates_dispatch_by(store):
+    dataset = store_dataframes_as_dataset(
+        dfs=[pd.DataFrame({"p": [0, 1], "x": 0})],
+        dataset_uuid="test",
+        store=store,
+        secondary_indices=["p", "x"],
+    )
+
+    wout_preds = list(dispatch_metapartitions(dataset.uuid, store, dispatch_by="x"))
+    w_preds = list(
+        dispatch_metapartitions(
+            dataset.uuid, store, predicates=[[("p", "in", [0, 1])]], dispatch_by="x"
+        )
+    )
+
+    assert wout_preds == w_preds


### PR DESCRIPTION
# Description:

This is quite severe and I will immediately release a bug fix version after merge.
For all predicates with multiple values per field this would create duplicate jobs because the `base_df` would look like

```
                                 p
partition
b5c6dc26872c47f2b485b924779537b7  0
b5c6dc26872c47f2b485b924779537b7  1
```