### PR TITLE
Nice error message if partition_on and secondary_indices overlap

### DIFF
--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -21,7 +21,7 @@ from kartothek.io_components.metapartition import (
     parse_input_to_metapartition,
 )
 from kartothek.io_components.read import dispatch_metapartitions_from_factory
-from kartothek.io_components.utils import normalize_args
+from kartothek.io_components.utils import normalize_args, raise_if_indices_overlap
 from kartothek.io_components.write import (
     raise_if_dataset_exists,
     store_dataset_from_partitions,
@@ -206,6 +206,8 @@ def store_bag_as_dataset(
 
     if not overwrite:
         raise_if_dataset_exists(dataset_uuid=dataset_uuid, store=store)
+
+    raise_if_indices_overlap(partition_on, secondary_indices)
 
     input_to_mps = partial(
         parse_input_to_metapartition, metadata_version=metadata_version

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -31,6 +31,7 @@ from kartothek.io_components.utils import (
     _ensure_compatible_indices,
     normalize_arg,
     normalize_args,
+    raise_if_indices_overlap,
     validate_partition_keys,
 )
 from kartothek.io_components.write import (
@@ -518,6 +519,8 @@ def store_delayed_as_dataset(
 
     if not overwrite:
         raise_if_dataset_exists(dataset_uuid=dataset_uuid, store=store)
+
+    raise_if_indices_overlap(partition_on, secondary_indices)
 
     input_to_mps = partial(
         parse_input_to_metapartition, metadata_version=metadata_version

--- a/kartothek/io/iter.py
+++ b/kartothek/io/iter.py
@@ -20,6 +20,7 @@ from kartothek.io_components.update import update_dataset_from_partitions
 from kartothek.io_components.utils import (
     _ensure_compatible_indices,
     normalize_args,
+    raise_if_indices_overlap,
     sort_values_categorical,
     validate_partition_keys,
 )
@@ -300,6 +301,8 @@ def store_dataframes_as_dataset__iter(
 
     if not overwrite:
         raise_if_dataset_exists(dataset_uuid=dataset_uuid, store=store)
+
+    raise_if_indices_overlap(partition_on, secondary_indices)
 
     new_partitions = []
     for df in df_generator:

--- a/kartothek/io/testing/write.py
+++ b/kartothek/io/testing/write.py
@@ -889,3 +889,13 @@ def test_store_overwrite_none(store_factory, bound_store_dataframes):
         overwrite=True,
     )
     assert md2.tables == []
+
+
+def test_secondary_index_on_partition_column(store_factory, bound_store_dataframes):
+    df1 = pd.DataFrame({"x": [1], "y": [1]})
+    with pytest.raises(
+        RuntimeError, match="Cannot create secondary index on partition columns: {'x'}"
+    ):
+        bound_store_dataframes(
+            [df1], store=store_factory, partition_on=["x"], secondary_indices=["x"]
+        )

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -367,6 +367,14 @@ def check_single_table_dataset(dataset, expected_table=None):
         )
 
 
+def raise_if_indices_overlap(partition_on, secondary_indices):
+    partition_secondary_overlap = set(partition_on) & set(secondary_indices)
+    if partition_secondary_overlap:
+        raise RuntimeError(
+            f"Cannot create secondary index on partition columns: {partition_secondary_overlap}"
+        )
+
+
 class NoPickleFactory:
     def __init__(self, obj):
         self.obj = obj


### PR DESCRIPTION
Before this change, user would get error like "Column X missing from dataframe" (because X has been made a partition key already and removed).