### PR TITLE
Raise an error in `dataset.query` when column queried is not an index column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ Improvements
 Bug fixes
 ^^^^^^^^^
 * Fix an issue where :func:`~kartothek.io.dask.dataframe.update_dataset_from_ddf` would create a column named "_KTK_HASH_BUCKET" in the dataset
-
+* Fix https://github.com/JDASoftwareGroup/kartothek/issues/198
 
 Version 3.6.1 (2019-12-11)
 ==========================

--- a/kartothek/core/dataset.py
+++ b/kartothek/core/dataset.py
@@ -311,6 +311,20 @@ class DatasetMetadataBase(CopyMixin):
         for column, value in kwargs.items():
             if column in combined_indices:
                 candidate_set &= set(combined_indices[column].query(value))
+            else:
+                if (
+                    # FIXME: `self.tables[0]`. What if column exists in another table?
+                    not self.table_meta[self.tables[0]]
+                    .internal()
+                    .field_by_name(column)
+                ):
+                    raise ValueError(
+                        f"Column provided (`{column}`) does not appear in dataset"
+                    )
+                # Rather than returning all partitions, we abort the execution at this stage to be safe
+                raise ValueError(
+                    f"Column provided (`{column}`) does not appear in dataset indices"
+                )
 
         return list(candidate_set)
 


### PR DESCRIPTION
This fixes https://github.com/JDASoftwareGroup/kartothek/issues/198

- [ ] Changelog entry
