### PR TITLE
Decrease parquet version to 1.0

### DIFF
--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -68,7 +68,7 @@ def _reset_dictionary_columns(table):
 
 
 class ParquetSerializer(DataFrameSerializer):
-    _PARQUET_VERSION = "2.0"
+    _PARQUET_VERSION = "1.0"
     type_stable = True
 
     def __init__(self, compression="SNAPPY", chunk_size=None):


### PR DESCRIPTION
@xhochy I was just browsing a few arrow tickets I opened ages ago and stumbled upon a comment claiming that one shouldn't use parquet 2.0 in production. Is this still the case?

https://issues.apache.org/jira/browse/PARQUET-458?focusedCommentId=16931914&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16931914
https://issues.apache.org/jira/browse/ARROW-5089