### PR TITLE
Do not cast dict encoded tables before storage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Next release
 Improvements
 ^^^^^^^^^^^^
 
-- Dask is now able to calculate better size estimates for the following classes:
+* Performance improvements for categorical data when using pyarrow>=0.15.0
+* Dask is now able to calculate better size estimates for the following classes:
     * :class:`~kartothek.core.dataset.DatasetMetadata`
     * :class:`~kartothek.core.factory.DatasetFactory`
     * :class:`~kartothek.io_components.metapartition.MetaPartition`

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -58,6 +58,8 @@ def _reset_dictionary_columns(table):
     1. Categorical columns of null won't cast https://issues.apache.org/jira/browse/ARROW-5085
     2. Massive performance issue due to non-fast path implementation https://issues.apache.org/jira/browse/ARROW-5089
     """
+    if ARROW_LARGER_EQ_0150:
+        return table
     for i in range(table.num_columns):
         col = table[i]
         if pa.types.is_dictionary(col.type):


### PR DESCRIPTION
# Description:

This section is quite costly when using categorical data. With arrow 0.15.0 both issues where fixed