### PR TITLE
Run tests for arrow 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,11 @@ env:
     - CONDA_CREATE_ARGS="pyarrow==0.13.0"
     - CONDA_CREATE_ARGS="pyarrow==0.14.1"
     - CONDA_CREATE_ARGS="pyarrow==0.15.0"
+    - CONDA_CREATE_ARGS="pyarrow==0.16.0"
 
 
     # optional builds
-    - CONDA_CREATE_ARGS="pyarrow==0.15.0" NUMFOCUS_NIGHTLY=1
+    - CONDA_CREATE_ARGS="pyarrow==0.16.0" NUMFOCUS_NIGHTLY=1
     - ARROW_NIGHTLY=1
 
 before_install:
@@ -66,7 +67,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: ARROW_NIGHTLY=1
-    - env: CONDA_CREATE_ARGS="pyarrow==0.15.0" NUMFOCUS_NIGHTLY=1
+    - env: CONDA_CREATE_ARGS="pyarrow==0.16.0" NUMFOCUS_NIGHTLY=1
   include:
     - name: "osx + builtin python3"
       os: osx
@@ -91,7 +92,6 @@ matrix:
         - conda config --set channel_priority strict
     - name: "Docs"
       env:
-        - CONDA_CREATE_ARGS="pyarrow==0.15.0"
         - KTK_TESTS=0
         - KTK_DOCS=1
 

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -5,7 +5,7 @@ msgpack-python>=0.5.2
 numpy!=1.15.0,!=1.16.0
 pandas>=0.23.0, !=1.0.0 # https://github.com/pandas-dev/pandas/issues/31441
 # pyarrow==0.14.0 breaks kartothek
-pyarrow>=0.13.0, !=0.14.0, <0.16.0 # Keep upper bound pinned until we see non-breaking releases in the future
+pyarrow>=0.13.0, !=0.14.0, <0.17.0 # Keep upper bound pinned until we see non-breaking releases in the future
 simplejson
 simplekv
 storefact

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ msgpack>=0.5.2
 numpy!=1.15.0,!=1.16.0
 pandas>=0.23.0, !=1.0.0 # https://github.com/pandas-dev/pandas/issues/31441
 # pyarrow==0.14.0 breaks kartothek
-pyarrow>=0.13.0, !=0.14.0, <0.16.0 # Keep upper bound pinned until we see non-breaking releases in the future
+pyarrow>=0.13.0, !=0.14.0, <0.17.0 # Keep upper bound pinned until we see non-breaking releases in the future
 simplejson
 simplekv
 storefact


### PR DESCRIPTION
# Description:

I suggest to soon-ish drop support for 0.13.0 and 0.14.1 to not blow up the test matrix. In the same step we can also add py3.8.
For now, I'd like to keep as is and do at least one more release before we cut
