### PR TITLE
Use proper generator for map_delayed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Next release
 Improvements
 ^^^^^^^^^^^^
 
+* Decrease scheduling overhead for dask based pipelines
 * Performance improvements for categorical data when using pyarrow>=0.15.0
 * Dask is now able to calculate better size estimates for the following classes:
     * :class:`~kartothek.core.dataset.DatasetMetadata`

--- a/kartothek/io/dask/_utils.py
+++ b/kartothek/io/dask/_utils.py
@@ -2,9 +2,15 @@
 
 
 import warnings
+from functools import partial
 
 import pandas as pd
 from dask import delayed
+
+try:
+    from cytoolz import map
+except ImportError:
+    pass
 
 CATEGORICAL_EFFICIENCY_WARN_LIMIT = 100000
 
@@ -70,5 +76,7 @@ def _maybe_get_categoricals_from_index(dataset_metadata_factory, categoricals):
     return categoricals_from_index
 
 
-def map_delayed(mps, func, *args, **kwargs):
-    return [delayed(func)(mp, *args, **kwargs) for mp in mps]
+def map_delayed(func, mps, **kwargs):
+    func = partial(func, **kwargs)
+    delayed_func = delayed(func)
+    return map(delayed_func, mps)


### PR DESCRIPTION
# Description:

This explicit loop and list creation is pretty slow. See below measurements for a dataset with about 150k partitions, especially when calling this many times this becomes quite an overhead.

The changes in delete are due to partial not properly working if one of the kwargs is a delayed object. Since this is only private the change should be fine

![image](https://user-images.githubusercontent.com/8629629/74164653-5e215d80-4c24-11ea-8e98-32e1b0d16ac8.png)

