### PR TITLE
Reconstruct dask index during loading

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,19 @@
 Changelog
 =========
 
+Version 3.8.0 (Unreleased)
+==========================
+
+* Add keyword argument `dask_index_on` which reconstructs a dask index from an kartothek index when loading the dataset
+* Add method :func:`~kartothek.core.index.IndexBase.observed_values` which returns an array of all observed values of the index column
+
+
 Version 3.7.1 (2020-02-XX)
 ==========================
 
 * GH227 Fix a Type error when loading categorical data in dask without
   specifying it explicitly
+
 
 Version 3.7.0 (2020-02-12)
 ==========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,13 +5,14 @@ Changelog
 Version 3.8.0 (Unreleased)
 ==========================
 
+Improvements
+^^^^^^^^^^^^
+
 * Add keyword argument `dask_index_on` which reconstructs a dask index from an kartothek index when loading the dataset
 * Add method :func:`~kartothek.core.index.IndexBase.observed_values` which returns an array of all observed values of the index column
 
-
-Version 3.7.1 (2020-02-XX)
-==========================
-
+Bug fixes
+^^^^^^^^^
 * GH227 Fix a Type error when loading categorical data in dask without
   specifying it explicitly
 

--- a/kartothek/core/docs.py
+++ b/kartothek/core/docs.py
@@ -41,7 +41,13 @@ _PARAMETER_MAPPING = {
         not present in the dataset, a ValueError is raised.""",
     "dispatch_by": """
     dispatch_by: list of strings, optional
-        List of index columns to group and partition the dataframe by.""",
+        List of index columns to group and partition the jobs by.
+        There will be one job created for every observed index value combination. This may result in either many very small partitions or in few very large partitions, depending on the index you are using this on.
+
+        .. admonition:: Secondary indices
+
+            This is also useable in combination with secondary indices where the physical file layout may not be aligned with the logically requested layout. For optimal performance it is recommended to use this for columns which can benefit from predicate pushdown since the jobs will fetch their data individually and will *not* shuffle data in memory / over network.
+        """,
     "df_serializer": """
     df_serializer : DataFrameSerializer, optional
         A pandas DataFrame serialiser from `kartothek.serialization`""",

--- a/kartothek/core/docs.py
+++ b/kartothek/core/docs.py
@@ -42,12 +42,18 @@ _PARAMETER_MAPPING = {
     "dispatch_by": """
     dispatch_by: list of strings, optional
         List of index columns to group and partition the jobs by.
-        There will be one job created for every observed index value combination. This may result in either many very small partitions or in few very large partitions, depending on the index you are using this on.
+        There will be one job created for every observed index value
+        combination. This may result in either many very small partitions or in
+        few very large partitions, depending on the index you are using this on.
 
         .. admonition:: Secondary indices
 
-            This is also useable in combination with secondary indices where the physical file layout may not be aligned with the logically requested layout. For optimal performance it is recommended to use this for columns which can benefit from predicate pushdown since the jobs will fetch their data individually and will *not* shuffle data in memory / over network.
-        """,
+            This is also useable in combination with secondary indices where
+            the physical file layout may not be aligned with the logically
+            requested layout. For optimal performance it is recommended to use
+            this for columns which can benefit from predicate pushdown since
+            the jobs will fetch their data individually and will *not* shuffle
+            data in memory / over network.""",
     "df_serializer": """
     df_serializer : DataFrameSerializer, optional
         A pandas DataFrame serialiser from `kartothek.serialization`""",

--- a/kartothek/core/index.py
+++ b/kartothek/core/index.py
@@ -132,6 +132,16 @@ class IndexBase(CopyMixin):
             class_=type(self).__name__, attrs=", ".join(repr_str)
         )
 
+    def observed_values(self) -> np.array:
+        """
+        Return an array of all observed values
+        """
+        return np.fromiter(
+            (self.normalize_value(self.dtype, x) for x in self.index_dct.keys()),
+            count=len(self.index_dct),
+            dtype=self.dtype.to_pandas_dtype(),
+        )
+
     @staticmethod
     def normalize_value(dtype: pa.DataType, value: Any) -> Any:
         """

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import dask
 import dask.dataframe as dd
 import numpy as np
@@ -15,6 +12,7 @@ from kartothek.io_components.utils import (
     _ensure_compatible_indices,
     check_single_table_dataset,
     normalize_arg,
+    normalize_args,
     validate_partition_keys,
 )
 
@@ -24,6 +22,7 @@ from .delayed import read_table_as_delayed
 
 
 @default_docs
+@normalize_args
 def read_dataset_as_ddf(
     dataset_uuid=None,
     store=None,
@@ -52,6 +51,10 @@ def read_dataset_as_ddf(
 
         For details on performance, see also `dispatch_by`
     """
+    if dask_index_on is not None and not isinstance(dask_index_on, str):
+        raise TypeError(
+            f"The paramter `dask_index_on` must be a string but got {type(dask_index_on)}"
+        )
     ds_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
         store=store,
@@ -87,7 +90,7 @@ def read_dataset_as_ddf(
         divisions.append(divisions[-1])
         return dd.from_delayed(
             delayed_partitions, meta=meta, divisions=divisions
-        ).set_index(dask_index_on, divisions=divisions)
+        ).set_index(dask_index_on, divisions=divisions, sorted=True)
     else:
         return dd.from_delayed(delayed_partitions, meta=meta)
 

--- a/kartothek/io_components/read.py
+++ b/kartothek/io_components/read.py
@@ -6,10 +6,11 @@ import pandas as pd
 from kartothek.core.factory import DatasetFactory
 from kartothek.core.index import ExplicitSecondaryIndex
 from kartothek.io_components.metapartition import MetaPartition
-from kartothek.io_components.utils import _make_callable
+from kartothek.io_components.utils import _make_callable, normalize_args
 from kartothek.serialization import check_predicates, columns_in_predicates
 
 
+@normalize_args
 def dispatch_metapartitions_from_factory(
     dataset_factory,
     label_filter=None,

--- a/kartothek/io_components/read.py
+++ b/kartothek/io_components/read.py
@@ -75,7 +75,7 @@ def dispatch_metapartitions_from_factory(
 
         # Group the resulting MetaParitions by partition keys or a subset of those keys
         merged_partitions = base_df.groupby(
-            by=list(dispatch_by), sort=False, as_index=False
+            by=list(dispatch_by), sort=True, as_index=False
         )
         for group_name, group in merged_partitions:
             if not isinstance(group_name, tuple):

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -185,7 +185,12 @@ def validate_partition_keys(
     return ds_factory, ds_metadata_version, partition_on
 
 
-_ARGS_TO_TYPE = {"partition_on": list, "delete_scope": list, "secondary_indices": list}
+_ARGS_TO_TYPE = {
+    "partition_on": list,
+    "delete_scope": list,
+    "secondary_indices": list,
+    "dispatch_by": list,
+}
 
 
 def normalize_arg(arg_name, old_value):
@@ -228,6 +233,7 @@ def normalize_args(function, *args, **kwargs):
     def _wrapper(*args, **kwargs):
         for arg_name in _ARGS_TO_TYPE.keys():
             if arg_name in sig.parameters.keys():
+
                 ix = inspect.getfullargspec(function).args.index(arg_name)
                 if arg_name in kwargs:
                     kwargs[arg_name] = normalize_arg(arg_name, kwargs[arg_name])

--- a/tests/core/test_docs.py
+++ b/tests/core/test_docs.py
@@ -1,4 +1,5 @@
 import inspect
+from collections import defaultdict
 
 import pytest
 
@@ -76,13 +77,16 @@ from kartothek.io.iter import (
 def test_docs(function):
     docstrings = function.__doc__
     arguments = inspect.signature(function).parameters
+    valid_docs = defaultdict(set)
+    for arg in arguments:
+        valid = _PARAMETER_MAPPING.get(arg, "Parameters") in docstrings
+        valid_docs[valid].add(arg)
 
-    assert all(
-        [
-            _PARAMETER_MAPPING.get(argument, "Parameters") in docstrings
-            for argument in arguments
-        ]
-    )
+    assert valid_docs[True]
+    if valid_docs[False]:
+        raise AssertionError(
+            f"Wrong or missing docstrings for parameters {valid_docs[False]}.\n\n{docstrings}"
+        )
 
     assert all([argument in docstrings for argument in arguments])
 


### PR DESCRIPTION
# Description:

This is a feature I wanted to build for quite some time now and with the `dispatch_by` logic it is, in fact, rather simple

With the `dask_index_on` kwarg it is possible to set the Dask index on a given index column directly which allows for very efficient joins on this column.