### PR TITLE
Dump conda list such that we can recreate environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ install:
 # If docs break or formatting, linting is off, I'd like to know immediately
 before_script:
   - conda list
+  - conda list --export
   - travis_retry pre-commit run -a
   - if [[ $KTK_DOCS == 1 ]]; then python setup.py docs ; fi
 


### PR DESCRIPTION
Master is currently failing. This adds an additional machine readable (i.e. `conda install --file` compatible) output for local reproduction

I kept the original list because it has nicer human readable output. no strong opinion here