### PR TITLE
Fix a type error when reading parquet files with categorical data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 3.7.1 (2020-02-XX)
+==========================
+
+* GH227 Fix a Type error when loading categorical data in dask without
+  specifying it explicitly
+
 Version 3.7.0 (2020-02-12)
 ==========================
 

--- a/tests/serialization/test_parquet.py
+++ b/tests/serialization/test_parquet.py
@@ -431,3 +431,16 @@ def test_predicate_accept_in(store, predicate_value, expected):
         )
         == expected
     )
+
+
+def test_read_categorical(store):
+    df = pd.DataFrame({"col": ["a"]}).astype({"col": "category"})
+
+    serialiser = ParquetSerializer()
+    key = serialiser.store(store, "prefix", df)
+
+    df = serialiser.restore_dataframe(store, key)
+    assert df.dtypes["col"] == "O"
+
+    df = serialiser.restore_dataframe(store, key, categories=["col"])
+    assert df.dtypes["col"] == pd.CategoricalDtype(["a"], ordered=False)


### PR DESCRIPTION
# Description:

We should ensure that the schema is always as expected.

cc @xhochy is this intended from arrow side that the categorical is returned even though not explicitly requested? Feels awkward with the explicit categories kwarg


- [x] Closes #227
- [x] Changelog entry
