### PR TITLE
Remove pytest-flake8 and add toolz to runtime dependencies

### DIFF
--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -9,5 +9,6 @@ pyarrow>=0.13.0, !=0.14.0, <0.17.0 # Keep upper bound pinned until we see non-br
 simplejson
 simplekv
 storefact
+toolz
 urlquote>=1.1.3
 zstandard

--- a/conda-test-requirements.txt
+++ b/conda-test-requirements.txt
@@ -1,13 +1,11 @@
 # Test Code Dependencies
 distributed
 pytz
-toolz
 
 # Test Framework
 hypothesis
 pytest>=4.5.0
 pytest-cov
-pytest-flake8
 pytest-mock
 setuptools_scm
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ pyarrow>=0.13.0, !=0.14.0, <0.17.0 # Keep upper bound pinned until we see non-br
 simplejson
 simplekv
 storefact
+toolz
 urlquote>=1.1.3
 zstandard

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,13 +1,11 @@
 # Test Code Dependencies
 distributed
 pytz
-toolz
 
 # Test Framework
 hypothesis
 pytest>=4.5.0
 pytest-cov
-pytest-flake8
 pytest-mock
 setuptools-scm
 


### PR DESCRIPTION
# Description:

Run use toolz in our own code so we should move it (so far it was implicitly installed via dask)

pytest-flake8 is not used in our configs and if developers prefer this to be installed and used this is an individual choice (similar to pytest-xdist, -profiling, -sugar, etc.)