### PR TITLE
Remove deprecated usage of pandas.utils.testing

### DIFF
--- a/kartothek/io/testing/merge.py
+++ b/kartothek/io/testing/merge.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from datetime import date
 
 import pandas as pd
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 
 from kartothek.io_components.metapartition import SINGLE_TABLE
 

--- a/kartothek/io/testing/write.py
+++ b/kartothek/io/testing/write.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 import pytest
 
 from kartothek.core.dataset import DatasetMetadata

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -7,7 +7,7 @@ import dask
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 import pytest
 
 from kartothek.core.factory import DatasetFactory

--- a/tests/io/eager/test_read.py
+++ b/tests/io/eager/test_read.py
@@ -2,7 +2,7 @@ import datetime
 
 import numpy as np
 import pandas as pd
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 import pytest
 
 from kartothek.io.eager import (

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -7,7 +7,7 @@ from datetime import date, datetime
 
 import numpy as np
 import pandas as pd
-import pandas.util.testing as pdt
+import pandas.testing as pdt
 import pytest
 
 from kartothek.core.common_metadata import make_meta, store_schema_metadata

--- a/tests/serialization/test_dataframe.py
+++ b/tests/serialization/test_dataframe.py
@@ -7,7 +7,6 @@ import datetime
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
-import pandas.util.testing as pdtest
 import pyarrow as pa
 import pytest
 
@@ -50,7 +49,7 @@ def test_store_df_to_store(store):
     dataframe_format = default_serializer()
     assert isinstance(dataframe_format, ParquetSerializer)
     key = dataframe_format.store(store, "prefix", df)
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
 
 @pytest.mark.parametrize("serialiser", SERLIALISERS)
@@ -58,7 +57,7 @@ def test_store_table_to_store(serialiser, store):
     df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["∆", "€"]})
     table = pa.Table.from_pandas(df)
     key = serialiser.store(store, "prefix", table)
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
 
 @pytest.mark.parametrize("serialiser", SERLIALISERS)
@@ -75,16 +74,16 @@ def test_dataframe_roundtrip(serialiser, store):
         )
         key = serialiser.store(store, "prefix", df)
 
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
     # Test partial restore
-    pdtest.assert_frame_equal(
+    pdt.assert_frame_equal(
         DataFrameSerializer.restore_dataframe(store, key, columns=["a", "c"]),
         df[["a", "c"]],
     )
 
     # Test that all serialisers can ingest predicate_pushdown_to_io
-    pdtest.assert_frame_equal(
+    pdt.assert_frame_equal(
         DataFrameSerializer.restore_dataframe(
             store, key, columns=["a", "c"], predicate_pushdown_to_io=False
         ),
@@ -95,7 +94,7 @@ def test_dataframe_roundtrip(serialiser, store):
     expected = df[["c", "d"]].copy()
     expected["c"] = expected["c"].astype("category")
     # Check that the dtypes match but don't care about the order of the categoricals.
-    pdtest.assert_frame_equal(
+    pdt.assert_frame_equal(
         DataFrameSerializer.restore_dataframe(
             store, key, columns=["c", "d"], categories=["c"]
         ),
@@ -104,7 +103,7 @@ def test_dataframe_roundtrip(serialiser, store):
     )
 
     # Test restore w/ empty col list
-    pdtest.assert_frame_equal(
+    pdt.assert_frame_equal(
         DataFrameSerializer.restore_dataframe(store, key, columns=[]), df[[]]
     )
 
@@ -122,20 +121,20 @@ def test_missing_column(serialiser, store):
 def test_dataframe_roundtrip_empty(serialiser, store):
     df = pd.DataFrame({})
     key = serialiser.store(store, "prefix", df)
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
     # Test partial restore
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
 
 @pytest.mark.parametrize("serialiser", SERLIALISERS)
 def test_dataframe_roundtrip_no_rows(serialiser, store):
     df = pd.DataFrame({"a": [], "b": [], "c": []}).astype(object)
     key = serialiser.store(store, "prefix", df)
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
     # Test partial restore
-    pdtest.assert_frame_equal(
+    pdt.assert_frame_equal(
         DataFrameSerializer.restore_dataframe(store, key, columns=["a", "c"]),
         df[["a", "c"]],
     )
@@ -446,7 +445,7 @@ def test_predicate_eval_string_types(serialiser, store, predicate_pushdown_to_io
     df = pd.DataFrame({b"a": [1, 2], "b": [3.0, 4.0]})
     key = serialiser.store(store, "prefix", df)
     df.columns = [ensure_unicode_string_type(col) for col in df.columns]
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
     for col in ["a", b"a", "a"]:
         predicates = [[(col, "==", 1)]]

--- a/tests/serialization/test_parquet.py
+++ b/tests/serialization/test_parquet.py
@@ -4,7 +4,6 @@ from datetime import date, datetime
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
-import pandas.util.testing as pdtest
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
@@ -33,7 +32,7 @@ def test_timestamp_us(store):
     df = pd.DataFrame({"ts": [ts]})
     serialiser = ParquetSerializer()
     key = serialiser.store(store, "prefix", df)
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
 
 def test_pyarrow_07992(store):
@@ -55,7 +54,7 @@ def test_pyarrow_07992(store):
     buf = pa.BufferOutputStream()
     pq.write_table(table, buf)
     store.put(key, buf.getvalue().to_pybytes())
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
 
 def test_index_metadata(store):
@@ -73,7 +72,7 @@ def test_index_metadata(store):
     buf = pa.BufferOutputStream()
     pq.write_table(table, buf)
     store.put(key, buf.getvalue().to_pybytes())
-    pdtest.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
+    pdt.assert_frame_equal(DataFrameSerializer.restore_dataframe(store, key), df)
 
 
 @pytest.fixture(params=[1, 5, None])


### PR DESCRIPTION
# Description:

This is deprecated. Minimal supported version of pandas doesn't change since this has been around for a long time