### PR TITLE
Let merge_datasets_as_delayed merge >2 datasets, filter by predicates and subset column

### DIFF
--- a/kartothek/io_components/merge.py
+++ b/kartothek/io_components/merge.py
@@ -1,20 +1,20 @@
 import logging
+import pathlib
 
-from kartothek.core.dataset import DatasetMetadata
-from kartothek.io_components.metapartition import MetaPartition
 from kartothek.io_components.utils import _instantiate_store
+
+from .read import dispatch_metapartitions
 
 LOGGER = logging.getLogger(__name__)
 
 
-def align_datasets(left_dataset_uuid, right_dataset_uuid, store, match_how="exact"):
+def align_datasets(dataset_uuids, store, predicates=None, match_how="exact"):
     """
     Determine dataset partition alignment
 
     Parameters
     ----------
-    left_dataset_uuid : basestring
-    right_dataset_uuid : basestring
+    dataset_uuids : List[basestring]
     store : KeyValuestore or callable
     match_how : basestring or callable, {exact, prefix, all, callable}
 
@@ -23,37 +23,6 @@ def align_datasets(left_dataset_uuid, right_dataset_uuid, store, match_how="exac
     list
     """
     store = _instantiate_store(store)
-    left_dataset = DatasetMetadata.load_from_store(uuid=left_dataset_uuid, store=store)
-    right_dataset = DatasetMetadata.load_from_store(
-        uuid=right_dataset_uuid, store=store
-    )
-
-    metadata_version = left_dataset.metadata_version
-
-    # Loop over the dataset with fewer partitions, treating its keys as
-    # partition label prefixes
-    if (
-        callable(match_how)
-        or match_how == "left"
-        or (
-            match_how == "prefix"
-            and len(list(left_dataset.partitions.keys())[0])
-            < len(list(right_dataset.partitions.keys())[0])
-        )
-    ):
-        first_dataset = left_dataset
-        second_dataset = right_dataset
-    else:
-        first_dataset = right_dataset
-        second_dataset = left_dataset
-    # The del statements are here to reduce confusion below
-    del left_dataset
-    del right_dataset
-
-    # For every partition in the 'small' dataset, at least one partition match
-    # needs to be found in the larger dataset.
-    available_partitions = list(second_dataset.partitions.items())
-    partition_stack = available_partitions[:]
 
     # TODO: write a test which protects against the following scenario!!
     # Sort the partition labels by length of the labels, starting with the
@@ -61,46 +30,32 @@ def align_datasets(left_dataset_uuid, right_dataset_uuid, store, match_how="exac
     # similar partitions, e.g. cluster_100 and cluster_1. This, of course,
     # works only as long as the internal loop removes elements which were
     # matched already (here improperly called stack)
-    for l_1 in sorted(first_dataset.partitions, key=len, reverse=True):
-        p_1 = first_dataset.partitions[l_1]
-        res = [
-            MetaPartition.from_partition(
-                partition=p_1, metadata_version=metadata_version
-            )
-        ]
-        for parts in available_partitions:
-            l_2, p_2 = parts
-            if callable(match_how) and not match_how(l_1, l_2):
-                continue
-            if match_how == "exact" and l_1 != l_2:
-                continue
-            elif match_how == "prefix" and not l_2.startswith(l_1):
-                LOGGER.debug("rejecting (%s, %s)", l_1, l_2)
-                continue
+    mp_0 = dispatch_metapartitions(dataset_uuids[0], store, predicates=predicates)
 
-            LOGGER.debug(
-                "Found alignment between partitions " "(%s, %s) and" "(%s, %s)",
-                first_dataset.uuid,
-                p_1.label,
-                second_dataset.uuid,
-                p_2.label,
+    for mp_0_i in mp_0:
+        l_1 = mp_0_i.label
+        res = [mp_0_i]
+        for j in range(1, len(dataset_uuids)):
+            mp_j = dispatch_metapartitions(
+                dataset_uuids[j], store, predicates=predicates
             )
-            res.append(
-                MetaPartition.from_partition(
-                    partition=p_2, metadata_version=metadata_version
+            for mp_j_i in mp_j:
+                l_j = mp_j_i.label
+                if callable(match_how) and not match_how(l_1, l_j):
+                    continue
+                if match_how == "prefix":
+                    raise NotImplementedError
+                elif match_how == "exact" and not (
+                    pathlib.Path(l_1).parent == pathlib.Path(l_j).parent
+                ):
+                    continue
+
+                LOGGER.debug(
+                    "Found alignment between partitions " "(%s, %s) and" "(%s, %s)",
+                    dataset_uuids[0],
+                    l_1,
+                    dataset_uuids[j],
+                    l_j,
                 )
-            )
-
-            # In exact or prefix matching schemes, it is expected to only
-            # find one partition alignment. in this case reduce the size of
-            # the inner loop
-            if match_how in ["exact", "prefix"]:
-                partition_stack.remove((l_2, p_2))
-        # Need to copy, otherwise remove will alter the loop iterator
-        available_partitions = partition_stack[:]
-        if len(res) == 1:
-            raise RuntimeError(
-                "No matching partition for {} in dataset {} "
-                "found".format(p_1, first_dataset)
-            )
+                res.append(mp_j_i)
         yield res

--- a/kartothek/io_components/merge.py
+++ b/kartothek/io_components/merge.py
@@ -1,9 +1,8 @@
 import logging
 import pathlib
 
+from kartothek.io_components.read import dispatch_metapartitions
 from kartothek.io_components.utils import _instantiate_store
-
-from .read import dispatch_metapartitions
 
 LOGGER = logging.getLogger(__name__)
 

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Optional, cast
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+
 from kartothek.core import naming
 from kartothek.core._compat import ARROW_LARGER_EQ_0150
 from kartothek.core.common_metadata import (
@@ -32,13 +33,16 @@ from kartothek.core.partition import Partition
 from kartothek.core.urlencode import decode_key, quote_indices
 from kartothek.core.utils import ensure_string_type, verify_metadata_version
 from kartothek.core.uuid import gen_uuid
+from kartothek.io_components.utils import (
+    _ensure_valid_indices,
+    _instantiate_store,
+    combine_metadata,
+)
 from kartothek.serialization import (
     DataFrameSerializer,
     default_serializer,
     filter_df_from_predicates,
 )
-
-from kartothek.io_components.utils import _ensure_valid_indices, _instantiate_store, combine_metadata
 
 LOGGER = logging.getLogger(__name__)
 
@@ -900,12 +904,6 @@ class MetaPartition(Iterable):
             labels = list(new_data.keys())
 
         dfs = [new_data.pop(label) for label in labels]
-        # partition_values = dfs[0][self.partition_keys].drop_duplicates()
-        # # assert len(partition_values) == 1
-        # dfs = [
-        #     df  #.drop(columns=self.partition_keys)
-        #     for df in dfs
-        # ]
 
         LOGGER.debug("Merging internal dataframes of %s", self.label)
 
@@ -919,9 +917,6 @@ class MetaPartition(Iterable):
                 merge_kwargs,
             )
             raise
-
-        # Reassign partition values
-        # df_merged = df_merged.assign(**partition_values.T.to_dict()[0], copy=False)
 
         df_merged = filter_df_from_predicates(df_merged, predicates)
 

--- a/kartothek/io_components/read.py
+++ b/kartothek/io_components/read.py
@@ -88,7 +88,7 @@ def dispatch_metapartitions_from_factory(
                 mps.append(
                     MetaPartition.from_partition(
                         partition=dataset_factory.partitions[label],
-                        dataset_metadata=dataset_factory.metadata,
+                        dataset_metadata=dataset_factory.dataset_metadata,
                         indices=indices_to_dispatch,
                         metadata_version=dataset_factory.metadata_version,
                         table_meta=dataset_factory.table_meta,
@@ -103,7 +103,7 @@ def dispatch_metapartitions_from_factory(
 
             yield MetaPartition.from_partition(
                 partition=part,
-                dataset_metadata=dataset_factory.metadata,
+                dataset_metadata=dataset_factory.dataset_metadata,
                 indices=indices_to_dispatch,
                 metadata_version=dataset_factory.metadata_version,
                 table_meta=dataset_factory.table_meta,

--- a/kartothek/io_components/read.py
+++ b/kartothek/io_components/read.py
@@ -88,7 +88,7 @@ def dispatch_metapartitions_from_factory(
                 mps.append(
                     MetaPartition.from_partition(
                         partition=dataset_factory.partitions[label],
-                        dataset_metadata=dataset_factory.dataset_metadata,
+                        dataset_metadata=dataset_factory.metadata,  # Should this not be dataset_factory.dataset_metadata?
                         indices=indices_to_dispatch,
                         metadata_version=dataset_factory.metadata_version,
                         table_meta=dataset_factory.table_meta,
@@ -103,7 +103,7 @@ def dispatch_metapartitions_from_factory(
 
             yield MetaPartition.from_partition(
                 partition=part,
-                dataset_metadata=dataset_factory.dataset_metadata,
+                dataset_metadata=dataset_factory.metadata,
                 indices=indices_to_dispatch,
                 metadata_version=dataset_factory.metadata_version,
                 table_meta=dataset_factory.table_meta,

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -9,6 +9,7 @@ from typing import Callable, Optional
 
 import decorator
 import pandas as pd
+
 from kartothek.core.dataset import DatasetMetadata
 from kartothek.core.factory import _ensure_factory
 
@@ -78,8 +79,6 @@ def _combine_metadata(dataset_metadata, append_to_list):
     else:
         first = dataset_metadata.pop()
         second = dataset_metadata.pop()
-        if isinstance(first, InvalidObject) or isinstance(second, InvalidObject):
-            return first
         if first == second:
             return first
         # None is harmless and may occur if a key appears in one but not the other dict

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -9,7 +9,6 @@ from typing import Callable, Optional
 
 import decorator
 import pandas as pd
-
 from kartothek.core.dataset import DatasetMetadata
 from kartothek.core.factory import _ensure_factory
 
@@ -79,6 +78,8 @@ def _combine_metadata(dataset_metadata, append_to_list):
     else:
         first = dataset_metadata.pop()
         second = dataset_metadata.pop()
+        if isinstance(first, InvalidObject) or isinstance(second, InvalidObject):
+            return first
         if first == second:
             return first
         # None is harmless and may occur if a key appears in one but not the other dict


### PR DESCRIPTION
# Description:

This Draft PR tries to implement changes as suggested in #235. The current philosophy is to
 * Implement an additional function (e.g. `merge_many_datasets_as_delayed`) not to break the existing API
 * rewrite `align_datasets` to efficiently cope with multiple datasets
 * Implement an additional `merge_many_dataframes` or similar to the `MetaPartition` class to allow for merging of dataframes.

The new `merge_many_datasets_as_delayed` can be supplied with `predicates` to subset rows and `columns` to subset columns. To account for the case where a column is defined in multiple datasets, `columns` needs to be a dictionary of type `{uuid: table: [columns]}`.