### PR TITLE
fix arrow nightly builds

### DIFF
--- a/kartothek/core/common_metadata.py
+++ b/kartothek/core/common_metadata.py
@@ -58,7 +58,7 @@ class SchemaWrapper:
     def _schema_compat(self):
         # https://issues.apache.org/jira/browse/ARROW-5104
         schema = self.__schema
-        if self.__schema is not None and self.__schema.metadata is not None:
+        if self.__schema is not None and self.__schema.pandas_metadata is not None:
             pandas_metadata = schema.pandas_metadata
             index_cols = pandas_metadata["index_columns"]
             if len(index_cols) > 1:
@@ -547,8 +547,10 @@ def _remove_diff_header(diff):
 
 def _diff_schemas(first, second):
     # see https://issues.apache.org/jira/browse/ARROW-4176
-    first_pyarrow_info, _ = str(first).split("metadata\n--------")
-    second_pyarrow_info, _ = str(second).split("metadata\n--------")
+
+    # Pyarrow >0.16.0 do not include the metadata anymore
+    first_pyarrow_info = str(first).split("metadata\n--------")[0]
+    second_pyarrow_info = str(second).split("metadata\n--------")[0]
     pyarrow_diff = _remove_diff_header(
         difflib.unified_diff(
             str(first_pyarrow_info).splitlines(), str(second_pyarrow_info).splitlines()


### PR DESCRIPTION
# Description:

This closes the nightly build failures. The issue is that a parquet schema roundtrip adds additional metadata to the fields. This can currently cause problems, especially for nested data types.

We can wait with merging until see https://github.com/apache/arrow/pull/6569 is fixed/resolved. Maybe the nested data types are already resolved there. Then the fixes here would boil down to the fix in `_diff_schemas`

- [x] Closes #237
- [x] Changelog entry
- [x] Wait until https://github.com/apache/arrow/pull/6569 is resolved
