### PR TITLE
Do not trigger SettingWithCopyWarning in bucketing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Version 3.7.1 (2020-02-XX)
 
 * GH227 Fix a Type error when loading categorical data in dask without
   specifying it explicitly
+* No longer trigger the SettingWithCopyWarning when using bucketing
 
 Version 3.7.0 (2020-02-12)
 ==========================

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -32,8 +32,7 @@ def _hash_bucket(df: pd.DataFrame, subset: List[str], num_buckets: int):
     available_bit_widths = np.array([8, 16, 32, 64])
     mask = available_bit_widths > np.log2(num_buckets)
     bit_width = min(available_bit_widths[mask])
-    df[_KTK_HASH_BUCKET] = buckets.astype(f"uint{bit_width}")
-    return df
+    return df.assign(**{_KTK_HASH_BUCKET: buckets.astype(f"uint{bit_width}")})
 
 
 def _update_dask_partitions_shuffle(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,8 @@ from kartothek.io_components.metapartition import (
 from kartothek.io_components.write import store_dataset_from_partitions
 from kartothek.serialization import ParquetSerializer
 
+pd.options.mode.chained_assignment = "raise"
+
 
 @pytest.fixture
 def frozen_time():


### PR DESCRIPTION
I thought this was already part of our test suite... Anyhow we should make sure to avoid the setting with copy warning and raise in our tests if it happens.