### PR TITLE
Allow the creation of empty header from pa.Schema

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Bug fixes
 * GH227 Fix a Type error when loading categorical data in dask without
   specifying it explicitly
 * No longer trigger the SettingWithCopyWarning when using bucketing
+* GH228 Fix an issue where empty header creation from a pyarrow schema would not
+  normalize the schema which causes schema violations during update.
+* Fix an issue where :func:`~kartothek.io.eager.create_empty_dataset_header`
+  would not accept a store factory.
 
 
 Version 3.7.0 (2020-02-12)

--- a/kartothek/core/common_metadata.py
+++ b/kartothek/core/common_metadata.py
@@ -249,7 +249,9 @@ def make_meta(obj, origin, partition_keys=None):
     if isinstance(obj, SchemaWrapper):
         return obj
     if isinstance(obj, pa.Schema):
-        return SchemaWrapper(obj, origin)
+        return normalize_column_order(
+            SchemaWrapper(obj, origin), partition_keys=partition_keys
+        )
 
     if not isinstance(obj, pd.DataFrame):
         raise ValueError("Input must be a pyarrow schema, or a pandas dataframe")

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -536,6 +536,7 @@ def create_empty_dataset_header(
     Parameters
     ----------
     """
+    store = _make_callable(store)()
     if not overwrite:
         raise_if_dataset_exists(dataset_uuid=dataset_uuid, store=store)
 

--- a/tests/io/eager/test_update.py
+++ b/tests/io/eager/test_update.py
@@ -1,11 +1,51 @@
-# -*- coding: utf-8 -*-
-
+import numpy as np
+import pandas as pd
+import pyarrow as pa
 import pytest
 
-from kartothek.io.eager import update_dataset_from_dataframes
+from kartothek.io.eager import (
+    commit_dataset,
+    create_empty_dataset_header,
+    update_dataset_from_dataframes,
+    write_single_partition,
+)
 from kartothek.io.testing.update import *  # noqa: F40
 
 
 @pytest.fixture()
 def bound_update_dataset():
     return update_dataset_from_dataframes
+
+
+def test_create_empty_header_from_pyarrow_schema(store_factory):
+    # GH228
+    df = pd.DataFrame(
+        [{"part": 1, "id": 1, "col1": "abc"}, {"part": 2, "id": 2, "col1": np.nan}]
+    )
+    dataset_uuid = "sample_ds"
+    schema = pa.Schema.from_pandas(df)
+
+    dm = create_empty_dataset_header(
+        store=store_factory,
+        dataset_uuid=dataset_uuid,
+        table_meta={"table": schema},
+        partition_on=["part"],
+    )
+
+    new_partitions = [
+        write_single_partition(
+            store=store_factory,
+            dataset_uuid=dataset_uuid,
+            data=[{"table": df.loc[df["part"] == 1]}],
+            partition_on=["part"],
+        )
+    ]
+    assert len(dm.partitions) == 0
+    dm = commit_dataset(
+        store=store_factory,
+        dataset_uuid=dataset_uuid,
+        new_partitions=new_partitions,
+        partition_on=["part"],
+    )
+
+    assert len(dm.partitions) == 1


### PR DESCRIPTION
# Description:

Passing a pyarrow Schema to the create_empty_header function created a corrupt header since the schema was not properly normalised (column/field order).

- [x] Closes #228
- [x] Changelog entry
