### PR TITLE
Only fix column ordering if needed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 3.8.1 (2020-03-XX)
+==========================
+
+Improvements
+^^^^^^^^^^^^
+
+* Only fix column odering when restoring ``DataFrame`` if the ordering is incorrect.
+
 Version 3.8.0 (2020-03-12)
 ==========================
 

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -315,7 +315,7 @@ def read_table(
     df = pd.concat(dfs, ignore_index=True, sort=False)
 
     # ensure column order
-    if len(empty_df.columns) > 0:
+    if len(empty_df.columns) > 0 and list(empty_df.columns) != list(df.columns):
         df = df.reindex(empty_df.columns, copy=False, axis=1)
 
     return df


### PR DESCRIPTION
Calling `pandas.DataFrame.reindex` isn't for free even in the case it is a no-op.

- [x] Changelog entry

cc @mlondschien @jtilly