### PR TITLE
Reset index with range index

### DIFF
--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -839,7 +839,9 @@ class MetaPartition(Iterable):
                     ind_col = ind_col.dt.date
             index_cols.append(ind_col)
 
-        df = df.reset_index(drop=True)
+        # We are the owner of the DataFrame and thus can afford in-place operations.
+        # The following is the much faster version of `df = df.reset_index(drop=True)`
+        df.index = pd_index
 
         index_names = [col.name for col in index_cols]
         # The index might already be part of the dataframe which is recovered from the parquet file.

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -839,9 +839,8 @@ class MetaPartition(Iterable):
                     ind_col = ind_col.dt.date
             index_cols.append(ind_col)
 
-        # We are the owner of the DataFrame and thus can afford in-place operations.
-        # The following is the much faster version of `df = df.reset_index(drop=True)`
-        df.index = pd_index
+        # One of the few places `inplace=True` makes a signifcant difference
+        df.reset_index(drop=True, inplace=True)
 
         index_names = [col.name for col in index_cols]
         # The index might already be part of the dataframe which is recovered from the parquet file.


### PR DESCRIPTION
We are the sole owner of the `DataFrame` in this case and can thus make in-place operations. For larger DataFrames, this was `7s` vs `5us` for me.

cc @mlondschien @jtilly