### PR TITLE
Allow dask_index_on for all col types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ Improvements
 
 * Only fix column odering when restoring ``DataFrame`` if the ordering is incorrect.
 
+Bug fixes
+^^^^^^^^^
+* GH248 Fix an issue causing a ValueError to be raised when using `dask_index_on` on non-integer columns
+
 Version 3.8.0 (2020-03-12)
 ==========================
 

--- a/asv_bench/benchmarks/index.py
+++ b/asv_bench/benchmarks/index.py
@@ -80,6 +80,9 @@ class Index(IndexBase):
     ):
         self.ktk_index.as_flat_series(partitions_as_index=True)
 
+    def time_observed_values(self, number_values, number_partitions, arrow_type):
+        self.ktk_index.observed_values()
+
 
 class SerializeIndex(IndexBase):
     timeout = 180

--- a/kartothek/core/index.py
+++ b/kartothek/core/index.py
@@ -132,15 +132,13 @@ class IndexBase(CopyMixin):
             class_=type(self).__name__, attrs=", ".join(repr_str)
         )
 
-    def observed_values(self) -> np.array:
+    def observed_values(self, date_as_object=True) -> np.array:
         """
         Return an array of all observed values
         """
-        return np.fromiter(
-            (self.normalize_value(self.dtype, x) for x in self.index_dct.keys()),
-            count=len(self.index_dct),
-            dtype=self.dtype.to_pandas_dtype(),
-        )
+        keys = np.array(list(self.index_dct.keys()))
+        labeled_array = pa.array(keys, type=self.dtype)
+        return np.array(labeled_array.to_pandas(date_as_object=date_as_object))
 
     @staticmethod
     def normalize_value(dtype: pa.DataType, value: Any) -> Any:


### PR DESCRIPTION
# Description:

For most data types the observed values method did not properly work. We should, at some point, refactor the index internals since upon every usage lately we need to convert to an array. I borrowed the logic from the dict-to-array code path. Might be slower but it should be stable

- [x] Closes #248 
- [x] Changelog entry
