### PR TITLE
Add workaround for ARROW-8142

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ Improvements
 
 * Only fix column odering when restoring ``DataFrame`` if the ordering is incorrect.
 
+Bug fixes
+^^^^^^^^^
+* GH255 Fix an issue causing the python interpreter to shut down when reading an
+  empty file (see also https://issues.apache.org/jira/browse/ARROW-8142)
+
 Version 3.8.0 (2020-03-12)
 ==========================
 

--- a/tests/serialization/test_parquet.py
+++ b/tests/serialization/test_parquet.py
@@ -443,3 +443,17 @@ def test_read_categorical(store):
 
     df = serialiser.restore_dataframe(store, key, categories=["col"])
     assert df.dtypes["col"] == pd.CategoricalDtype(["a"], ordered=False)
+
+
+def test_read_categorical_empty(store):
+
+    df = pd.DataFrame({"col": ["a"]}).astype({"col": "category"}).iloc[:0]
+    serialiser = ParquetSerializer()
+    key = serialiser.store(store, "prefix", df)
+
+    df = serialiser.restore_dataframe(store, key)
+    assert df.dtypes["col"] == "O"
+
+    df = serialiser.restore_dataframe(store, key, categories=["col"])
+
+    assert df.dtypes["col"] == pd.CategoricalDtype([], ordered=False)


### PR DESCRIPTION
# Description:

We hit these arrow issues is there are empty dict encoded chunked arrays

https://issues.apache.org/jira/browse/ARROW-8142
https://issues.apache.org/jira/browse/ARROW-7907

- [x] Changelog entry

xref #248 
