### PR TITLE
Add Docstrings to Delete Dataset API

### DIFF
--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -49,6 +49,8 @@ from kartothek.io_components.write import raise_if_dataset_exists
 @default_docs
 def delete_dataset(dataset_uuid=None, store=None, factory=None):
     """
+    Delete the entire dataset from the store.
+
     Parameters
     ----------
     """


### PR DESCRIPTION
# Description:

It seems the current sphinx parser in API really wants some description to be present!
I've added docstrings which will not lead to broken API definition of `delete_dataset`
Link: https://kartothek.readthedocs.io/en/latest/api.html

Given this is an internal change, I felt no need to add a changelog.