### PR TITLE
Fix some deprecations and other warnings

### DIFF
--- a/kartothek/core/testing.py
+++ b/kartothek/core/testing.py
@@ -5,11 +5,13 @@ import contextlib
 import datetime
 from datetime import date
 from unittest import mock
+from warnings import catch_warnings, simplefilter
 
 import hypothesis.extra.numpy as hyp_np
 import hypothesis.strategies as hyp_st
 import numpy as np
 import pandas as pd
+from hypothesis.errors import NonInteractiveExampleWarning
 
 from kartothek.core.uuid import gen_uuid_object
 
@@ -102,7 +104,9 @@ def get_numpy_array_strategy(
     # the text example generation has quite some overhead when called the first time.
     # we don't want this in our test sample generation since the HealthCheck of hypothesis
     # might be triggered.
-    hyp_st.text().example()
+    with catch_warnings():
+        simplefilter("ignore", NonInteractiveExampleWarning)
+        hyp_st.text().example()
 
     dtype_strategy = get_scalar_dtype_strategy(exclude_dtypes)
     array_strategy = hyp_np.arrays(dtype=dtype_strategy, shape=shape, unique=unique)

--- a/kartothek/io/testing/update.py
+++ b/kartothek/io/testing/update.py
@@ -199,11 +199,7 @@ def test_update_dataset_with_partitions__reducer_partitions(
     assert set(store_factory().keys()) == set()
 
     df1 = pd.DataFrame(
-        {
-            "P": [1, 2, 3, 1, 2, 3],
-            "L": [1, 1, 1, 1, 1, 1],
-            "TARGET": pd.np.arange(10, 16),
-        }
+        {"P": [1, 2, 3, 1, 2, 3], "L": [1, 1, 1, 1, 1, 1], "TARGET": np.arange(10, 16)}
     )
     df2 = df1.copy(deep=True)
     df2.L = 2
@@ -482,7 +478,7 @@ def test_sort_partitions_by(
         {
             "P": [1, 2, 3, 1, 2, 3],
             "L": [1, 1, 1, 1, 1, 1],
-            "TARGET": list(reversed(pd.np.arange(10, 16))),
+            "TARGET": list(reversed(np.arange(10, 16))),
         }
     )
 

--- a/kartothek/serialization/_generic.py
+++ b/kartothek/serialization/_generic.py
@@ -378,7 +378,7 @@ def _ensure_type_stability(
         error messages.
     """
 
-    value_dtype = pd.Series(value).dtype
+    value_dtype = pd.Series(value if is_list_like(value) else [value]).dtype
     array_like, array_value_type = _handle_categorical_data(array_like, require_ordered)
     array_like, array_value_type = _handle_null_arrays(array_like, value_dtype)
 

--- a/tests/serialization/test_filter.py
+++ b/tests/serialization/test_filter.py
@@ -187,3 +187,25 @@ def test_filter_df_from_predicates_bool(op, col):
         df[col] = df[col].astype(df[col].cat.as_ordered().dtype)
     expected = eval(f"df[df[col] {op} value]")
     pdt.assert_frame_equal(actual, expected, check_categorical=False)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        1,
+        np.uint8(1),
+        1.1,
+        "A",
+        datetime.date(2020, 1, 1),
+        pd.Timestamp("2020-01-01"),
+        np.datetime64("2020-01-01"),
+    ],
+)
+def test_filter_df_from_predicates_empty_in(value):
+    df = pd.DataFrame({"A": [value]})
+    df["B"] = range(len(df))
+
+    predicates = [[("A", "in", [])]]
+    actual = filter_df_from_predicates(df, predicates)
+    expected = df.iloc[[]]
+    pdt.assert_frame_equal(actual, expected, check_categorical=False)


### PR DESCRIPTION
See commit msgs for details.

There is one notable case left where we test the roundtrip of byte-string columns through pyarrow, likely a leftover from python 2. Since I would like to raise in the serializer in that case and also adjust the tests, this will be done in another PR.
