### PR TITLE
fix deprecated flake8 pre-commit hook (fixes red master)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,8 +15,8 @@ repos:
         args:
           - --target-version=py36
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.1
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
     hooks:
     -   id: flake8
 


### PR DESCRIPTION
master has been red for more than one week due to flake8 pre-commit hook:
```
Flake8...................................................................Failed

- hook id: flake8

- exit code: 1

kartothek/io_components/metapartition.py:140:17: F523 '...'.format(...) has unused arguments at position(s): 1

kartothek/serialization/_parquet.py:304:25: E741 ambiguous variable name 'l'

tests/core/test_dataset_dyn_part.py:357:9: E741 ambiguous variable name 'l'

tests/core/test_dataset_dyn_part.py:407:22: F523 '...'.format(...) has unused arguments at position(s): 0

tests/core/test_dataset_dyn_part.py:428:28: F523 '...'.format(...) has unused arguments at position(s): 0


```
See: https://travis-ci.com/github/JDASoftwareGroup/kartothek/jobs/332586544
This fixes it.