### PR TITLE
Compress payload columns during shuffle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 3.9.0 (UNRELEASED)
+==========================
+
+* Significant performance improvements for shuffle operations in :func:`~kartothek.io.dask.dataframe.update_dataset_from_ddf`
+
 Version 3.8.2 (2020-04-09)
 ==========================
 

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -1,18 +1,24 @@
 import logging
 from functools import partial
-from typing import List
+from typing import Callable, List, Optional, Union
 
+import dask.array as da
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
+from dask.delayed import Delayed
+from simplekv import KeyValueStore
 
 from kartothek.io_components.metapartition import (
     MetaPartition,
     parse_input_to_metapartition,
 )
 from kartothek.io_components.utils import sort_values_categorical
+from kartothek.serialization import DataFrameSerializer
 
 from ._utils import map_delayed
 
+StoreFactoryType = Callable[[], KeyValueStore]
 _logger = logging.getLogger()
 
 _KTK_HASH_BUCKET = "__KTK_HASH_BUCKET"
@@ -37,8 +43,7 @@ def _hash_bucket(df: pd.DataFrame, subset: List[str], num_buckets: int):
     return df.assign(**{_KTK_HASH_BUCKET: buckets.astype(f"uint{bit_width}")})
 
 
-def _pack_payload(partition: pd.DataFrame, group_key: List[str]) -> pd.DataFrame:
-    # TODO: benchmark how good plain parquet would do
+def pack_payload_pandas(partition: pd.DataFrame, group_key: List[str]) -> pd.DataFrame:
     try:
         # Technically distributed is an optional dependency
         from distributed.protocol import serialize_bytes
@@ -48,14 +53,91 @@ def _pack_payload(partition: pd.DataFrame, group_key: List[str]) -> pd.DataFrame
         )
         return partition
 
-    # This is not _optimal_ since dask internally will perform another groupby in shuffle-group
-    # Once / if this is merged upstream, we can get rid of this
-    res = partition.groupby(group_key, sort=False, observed=True).apply(serialize_bytes)
-    res.name = _PAYLOAD_COL
-    return res.reset_index()
+    if partition.empty:
+        res = partition[group_key]
+        res[_PAYLOAD_COL] = b""
+    else:
+        res = partition.groupby(
+            group_key,
+            sort=False,
+            observed=True,
+            # Keep the as_index s.t. the group values are not dropped. With this
+            # the behaviour seems to be consistent along pandas versions
+            as_index=True,
+        ).apply(lambda x: pd.Series({_PAYLOAD_COL: serialize_bytes(x)}))
+
+        res = res.reset_index()
+    return res
 
 
-def _unpack_payload(partition: pd.DataFrame) -> pd.DataFrame:
+def pack_payload(df: dd.DataFrame, group_key: Union[List[str], str]) -> dd.DataFrame:
+    """
+    Pack all payload columns (everything except of group_key) into a single
+    columns. This column will contain a single byte string containing the
+    serialized and compressed payload data. The payload data is just dead weight
+    when reshuffling. By compressing it once before the shuffle starts, this
+    saves a lot of memory and network/disk IO.
+
+    Example::
+
+        >>> import pandas as pd
+        ... import dask.dataframe as dd
+        ... from dask.dataframe.shuffle import pack_payload
+        ...
+        ... df = pd.DataFrame({"A": [1, 1] * 2 + [2, 2] * 2 + [3, 3] * 2, "B": range(12)})
+        ... ddf = dd.from_pandas(df, npartitions=2)
+
+        >>> ddf.partitions[0].compute()
+
+        A  B
+        0  1  0
+        1  1  1
+        2  1  2
+        3  1  3
+        4  2  4
+        5  2  5
+
+        >>> pack_payload(ddf, "A").partitions[0].compute()
+
+        A                               __dask_payload_bytes
+        0  1  b'\x03\x00\x00\x00\x00\x00\x00\x00)\x00\x00\x03...
+        1  2  b'\x03\x00\x00\x00\x00\x00\x00\x00)\x00\x00\x03...
+
+
+    See also https://github.com/dask/dask/pull/6259
+
+    """
+
+    if (
+        # https://github.com/pandas-dev/pandas/issues/34455
+        isinstance(df._meta.index, pd.Float64Index)
+        # TODO: Try to find out what's going on an file a bug report
+        # For datetime indices the apply seems to be corrupt
+        # s.t. apply(lambda x:x) returns different values
+        or isinstance(df._meta.index, pd.DatetimeIndex)
+    ):
+        return df
+
+    if not isinstance(group_key, list):
+        group_key = [group_key]
+
+    packed_meta = df._meta[group_key]
+    packed_meta[_PAYLOAD_COL] = b""
+
+    _pack_payload = partial(pack_payload_pandas, group_key=group_key)
+
+    return df.map_partitions(_pack_payload, meta=_pack_payload(df._meta))
+
+
+def unpack_payload_pandas(
+    partition: pd.DataFrame, unpack_meta: pd.DataFrame
+) -> pd.DataFrame:
+    """
+    Revert ``pack_payload_pandas`` and restore packed payload
+
+    unpack_meta:
+        A dataframe indicating the sc
+    """
     try:
         # Technically distributed is an optional dependency
         from distributed.protocol import deserialize_bytes
@@ -65,29 +147,95 @@ def _unpack_payload(partition: pd.DataFrame) -> pd.DataFrame:
         )
         return partition
 
-    return pd.concat(
-        partition[_PAYLOAD_COL].map(lambda part: deserialize_bytes(part)).values,
-        copy=False,
-    )
+    if partition.empty:
+        return unpack_meta.iloc[:0]
+
+    mapped = partition[_PAYLOAD_COL].map(deserialize_bytes)
+
+    return pd.concat(mapped.values, copy=False, ignore_index=True)
 
 
-def _update_dask_partitions_shuffle(
-    ddf,
-    table,
-    secondary_indices,
-    metadata_version,
-    partition_on,
-    store_factory,
-    df_serializer,
-    dataset_uuid,
-    num_buckets,
-    sort_partitions_by,
-    bucket_by,
-):
+def unpack_payload(df: dd.DataFrame, meta: pd.DataFrame) -> dd.DataFrame:
+    """Revert payload packing of ``pack_payload`` and restores full dataframe."""
+
+    if (
+        # https://github.com/pandas-dev/pandas/issues/34455
+        isinstance(df._meta.index, pd.Float64Index)
+        # TODO: Try to find out what's going on an file a bug report
+        # For datetime indices the apply seems to be corrupt
+        # s.t. apply(lambda x:x) returns different values
+        or isinstance(df._meta.index, pd.DatetimeIndex)
+    ):
+        return df
+
+    return df.map_partitions(unpack_payload_pandas, meta=meta)
+
+
+def update_dask_partitions_shuffle(
+    ddf: dd.DataFrame,
+    table: str,
+    secondary_indices: List[str],
+    metadata_version: int,
+    partition_on: List[str],
+    store_factory: StoreFactoryType,
+    df_serializer: DataFrameSerializer,
+    dataset_uuid: str,
+    num_buckets: Optional[int],
+    sort_partitions_by: Optional[str],
+    bucket_by: List[str],
+) -> da.Array:
+    """
+    Perform a dataset update with dask reshuffling to control partitioning.
+
+    The shuffle operation will perform the following steps
+
+    1. Pack payload data
+
+       Payload data is serialized and compressed into a single byte value using
+       ``distributed.protocol.serialize_bytes``, see also ``pack_payload``.
+
+    2. Apply bucketing
+
+       Hash the column subset ``bucket_by`` and distribute the hashes in
+       ``num_buckets`` bins/buckets. Internally every bucket is identified by an
+       integer and we will create one physical file for every bucket ID. The
+       bucket ID is not exposed to the user and is dropped after the shuffle,
+       before the store. This is done since we do not want to guarantee at the
+       moment, that the hash function remains stable.
+
+    3. Perform shuffle (dask.DataFrame.groupby.apply)
+
+        The groupby key will be the combination of ``partition_on`` fields and the
+        hash bucket ID. This will create a physical file for every unique tuple
+        in ``partition_on + bucket_ID``. The function which is applied to the
+        dataframe will perform all necessary subtask for storage of the dataset
+        (partition_on, index calc, etc.).
+
+    4. Unpack data (within the apply-function)
+
+        After the shuffle, the first step is to unpack the payload data since
+        the follow up tasks will require the full dataframe.
+
+    5. Pre storage processing and parquet serialization
+
+        We apply important pre storage processing like sorting data, applying
+        final partitioning (at this time there should be only one group in the
+        payload data but using the ``MetaPartition.partition_on`` guarantees the
+        appropriate data structures kartothek expects are created.).
+        After the preprocessing is done, the data is serialized and stored as
+        parquet. The applied function will return an (empty) MetaPartition with
+        indices and metadata which will then be used to commit the dataset.
+
+    Returns
+    -------
+
+    A dask.Array holding relevant MetaPartition objects as values
+
+    """
     if ddf.npartitions == 0:
         return ddf
 
-    group_cols = partition_on[:]
+    group_cols = partition_on.copy()
     if num_buckets is not None:
         meta = ddf._meta
         meta[_KTK_HASH_BUCKET] = np.uint64(0)
@@ -96,7 +244,9 @@ def _update_dask_partitions_shuffle(
 
     packed_meta = ddf._meta[group_cols]
     packed_meta[_PAYLOAD_COL] = b""
-    ddf = ddf.map_partitions(_pack_payload, group_key=group_cols, meta=packed_meta)
+    unpacked_meta = ddf._meta
+
+    ddf = pack_payload(ddf, group_key=group_cols)
     ddf = ddf.groupby(by=group_cols)
     ddf = ddf.apply(
         partial(
@@ -109,22 +259,27 @@ def _update_dask_partitions_shuffle(
             store_factory=store_factory,
             df_serializer=df_serializer,
             metadata_version=metadata_version,
+            unpacked_meta=unpacked_meta,
         ),
         meta=("MetaPartition", "object"),
     )
     return ddf
 
 
-def _update_dask_partitions_one_to_one(
-    delayed_tasks,
-    secondary_indices,
-    metadata_version,
-    partition_on,
-    store_factory,
-    df_serializer,
-    dataset_uuid,
-    sort_partitions_by,
-):
+def update_dask_partitions_one_to_one(
+    delayed_tasks: List[Delayed],
+    secondary_indices: List[str],
+    metadata_version: int,
+    partition_on: List[str],
+    store_factory: StoreFactoryType,
+    df_serializer: DataFrameSerializer,
+    dataset_uuid: str,
+    sort_partitions_by: Optional[str],
+) -> List[Delayed]:
+    """
+    Perform an ordinary, partition wise update where the usual partition
+    pre-store processing is applied to every dask internal partition.
+    """
     input_to_mps = partial(
         parse_input_to_metapartition,
         metadata_version=metadata_version,
@@ -136,7 +291,9 @@ def _update_dask_partitions_one_to_one(
         mps = map_delayed(
             partial(
                 MetaPartition.apply,
-                func=partial(sort_values_categorical, column=sort_partitions_by),
+                # FIXME: Type checks collide with partial. We should rename
+                # apply func kwarg
+                **{"func": partial(sort_values_categorical, column=sort_partitions_by)},
             ),
             mps,
         )
@@ -155,17 +312,18 @@ def _update_dask_partitions_one_to_one(
 
 
 def _store_partition(
-    df,
-    secondary_indices,
-    sort_partitions_by,
-    table,
-    dataset_uuid,
-    partition_on,
-    store_factory,
-    df_serializer,
-    metadata_version,
-):
-    df = _unpack_payload(df)
+    df: pd.DataFrame,
+    secondary_indices: List[str],
+    sort_partitions_by: Optional[str],
+    table: str,
+    dataset_uuid: str,
+    partition_on: Optional[List[str]],
+    store_factory: StoreFactoryType,
+    df_serializer: DataFrameSerializer,
+    metadata_version: int,
+    unpacked_meta: pd.DataFrame,
+) -> MetaPartition:
+    df = unpack_payload_pandas(df, unpacked_meta)
     if _KTK_HASH_BUCKET in df:
         df = df.drop(_KTK_HASH_BUCKET, axis=1)
     store = store_factory()

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -1,6 +1,4 @@
-# -*- coding: utf-8 -*-
-
-
+import logging
 from functools import partial
 from typing import List
 
@@ -15,7 +13,11 @@ from kartothek.io_components.utils import sort_values_categorical
 
 from ._utils import map_delayed
 
+_logger = logging.getLogger()
+
 _KTK_HASH_BUCKET = "__KTK_HASH_BUCKET"
+
+_PAYLOAD_COL = "__ktk_shuffle_payload"
 
 
 def _hash_bucket(df: pd.DataFrame, subset: List[str], num_buckets: int):
@@ -35,6 +37,40 @@ def _hash_bucket(df: pd.DataFrame, subset: List[str], num_buckets: int):
     return df.assign(**{_KTK_HASH_BUCKET: buckets.astype(f"uint{bit_width}")})
 
 
+def _pack_payload(partition: pd.DataFrame, group_key: List[str]) -> pd.DataFrame:
+    # TODO: benchmark how good plain parquet would do
+    try:
+        # Technically distributed is an optional dependency
+        from distributed.protocol import serialize_bytes
+    except ImportError:
+        _logger.warning(
+            "Shuffle payload columns cannot be compressed since distributed is not installed."
+        )
+        return partition
+
+    # This is not _optimal_ since dask internally will perform another groupby in shuffle-group
+    # Once / if this is merged upstream, we can get rid of this
+    res = partition.groupby(group_key, sort=False, observed=True).apply(serialize_bytes)
+    res.name = _PAYLOAD_COL
+    return res.reset_index()
+
+
+def _unpack_payload(partition: pd.DataFrame) -> pd.DataFrame:
+    try:
+        # Technically distributed is an optional dependency
+        from distributed.protocol import deserialize_bytes
+    except ImportError:
+        _logger.warning(
+            "Shuffle payload columns cannot be compressed since distributed is not installed."
+        )
+        return partition
+
+    return pd.concat(
+        partition[_PAYLOAD_COL].map(lambda part: deserialize_bytes(part)).values,
+        copy=False,
+    )
+
+
 def _update_dask_partitions_shuffle(
     ddf,
     table,
@@ -51,14 +87,16 @@ def _update_dask_partitions_shuffle(
     if ddf.npartitions == 0:
         return ddf
 
+    group_cols = partition_on[:]
     if num_buckets is not None:
         meta = ddf._meta
         meta[_KTK_HASH_BUCKET] = np.uint64(0)
         ddf = ddf.map_partitions(_hash_bucket, bucket_by, num_buckets, meta=meta)
-        group_cols = [partition_on[0], _KTK_HASH_BUCKET]
-    else:
-        group_cols = [partition_on[0]]
+        group_cols.append(_KTK_HASH_BUCKET)
 
+    packed_meta = ddf._meta[group_cols]
+    packed_meta[_PAYLOAD_COL] = b""
+    ddf = ddf.map_partitions(_pack_payload, group_key=group_cols, meta=packed_meta)
     ddf = ddf.groupby(by=group_cols)
     ddf = ddf.apply(
         partial(
@@ -127,6 +165,7 @@ def _store_partition(
     df_serializer,
     metadata_version,
 ):
+    df = _unpack_payload(df)
     if _KTK_HASH_BUCKET in df:
         df = df.drop(_KTK_HASH_BUCKET, axis=1)
     store = store_factory()

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -16,7 +16,7 @@ from kartothek.io_components.utils import (
     validate_partition_keys,
 )
 
-from ._update import _update_dask_partitions_one_to_one, _update_dask_partitions_shuffle
+from ._update import update_dask_partitions_one_to_one, update_dask_partitions_shuffle
 from ._utils import _maybe_get_categoricals_from_index
 from .delayed import read_table_as_delayed
 
@@ -258,7 +258,7 @@ def update_dataset_from_ddf(
         secondary_indices = _ensure_compatible_indices(ds_factory, secondary_indices)
 
         if shuffle and partition_on:
-            mps = _update_dask_partitions_shuffle(
+            mps = update_dask_partitions_shuffle(
                 ddf=ddf,
                 table=table,
                 secondary_indices=secondary_indices,
@@ -274,7 +274,7 @@ def update_dataset_from_ddf(
         else:
             delayed_tasks = ddf.to_delayed()
             delayed_tasks = [{"data": {table: task}} for task in delayed_tasks]
-            mps = _update_dask_partitions_one_to_one(
+            mps = update_dask_partitions_one_to_one(
                 delayed_tasks=delayed_tasks,
                 secondary_indices=secondary_indices,
                 metadata_version=metadata_version,

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -39,7 +39,7 @@ from kartothek.io_components.write import (
     store_dataset_from_partitions,
 )
 
-from ._update import _update_dask_partitions_one_to_one
+from ._update import update_dask_partitions_one_to_one
 from ._utils import (
     _cast_categorical_to_index_cat,
     _get_data,
@@ -461,7 +461,7 @@ def update_dataset_from_delayed(
     )
 
     secondary_indices = _ensure_compatible_indices(ds_factory, secondary_indices)
-    mps = _update_dask_partitions_one_to_one(
+    mps = update_dask_partitions_one_to_one(
         delayed_tasks=delayed_tasks,
         secondary_indices=secondary_indices,
         metadata_version=metadata_version,

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -14,8 +14,8 @@ from kartothek.core.factory import DatasetFactory
 from kartothek.io.dask._update import (
     _KTK_HASH_BUCKET,
     _hash_bucket,
-    _pack_payload,
-    _unpack_payload,
+    pack_payload_pandas,
+    unpack_payload_pandas,
 )
 from kartothek.io.dask.dataframe import update_dataset_from_ddf
 from kartothek.io.iter import read_dataset_as_dataframes__iterator
@@ -112,6 +112,7 @@ def test_update_shuffle_buckets(
       most ``num_buckets`` per primary partition value.
     * If we demand a column to be sorted it is per partition monotonic
     """
+
     primaries = np.arange(unique_primaries)
     secondary = np.arange(unique_secondaries)
     num_rows = 100
@@ -292,16 +293,33 @@ def test_pack_payload(df_all_types):
     df = pd.concat([df_all_types] * 10, ignore_index=True)
     size_before = df.memory_usage(deep=True).sum()
 
-    packed_df = _pack_payload(df, group_key=list(df.columns[-2:]))
+    packed_df = pack_payload_pandas(df, group_key=list(df.columns[-2:]))
 
     size_after = packed_df.memory_usage(deep=True).sum()
 
     assert size_after < size_before
 
 
+def test_pack_payload_empty(df_all_types):
+    # For a single row dataframe the packing actually has a few more bytes
+    df_empty = df_all_types.iloc[:0]
+
+    group_key = [df_all_types.columns[-1]]
+    pdt.assert_frame_equal(
+        df_empty,
+        unpack_payload_pandas(
+            pack_payload_pandas(df_empty, group_key=group_key), unpack_meta=df_empty
+        ),
+    )
+
+
 @pytest.mark.parametrize("num_group_cols", [1, 4])
 def test_pack_payload_roundtrip(df_all_types, num_group_cols):
     group_key = list(df_all_types.columns[-num_group_cols:])
     pdt.assert_frame_equal(
-        df_all_types, _unpack_payload(_pack_payload(df_all_types, group_key=group_key))
+        df_all_types,
+        unpack_payload_pandas(
+            pack_payload_pandas(df_all_types, group_key=group_key),
+            unpack_meta=df_all_types,
+        ),
     )


### PR DESCRIPTION
This compresses the payload columns into a single bytestream before shuffle. This has several benefits

* network/disk IO significantly reduced
* intermediate (de)serialization is cheaper

I'm very confident that there is still a lot of room for improvement here but this simple implementation showed already about an order of magnitude better performance on small scale tests. I'll also see if we can get something similar into dask right away.

Credits go to @marco-neumann-jdas for the idea