### PR TITLE
Allow shuffling without partition_on

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Version 3.9.0 (UNRELEASED)
 ==========================
 
 * Significant performance improvements for shuffle operations in :func:`~kartothek.io.dask.dataframe.update_dataset_from_ddf`
+* Allow calling :func:`~kartothek.io.dask.dataframe.update_dataset_from_ddf`
+  without `partition_on` when `shuffle=True`
+
 
 Version 3.8.2 (2020-04-09)
 ==========================

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -6,7 +6,10 @@ from kartothek.core.common_metadata import empty_dataframe_from_schema
 from kartothek.core.docs import default_docs
 from kartothek.core.factory import _ensure_factory
 from kartothek.core.naming import DEFAULT_METADATA_VERSION
-from kartothek.io_components.metapartition import parse_input_to_metapartition, SINGLE_TABLE
+from kartothek.io_components.metapartition import (
+    SINGLE_TABLE,
+    parse_input_to_metapartition,
+)
 from kartothek.io_components.update import update_dataset_from_partitions
 from kartothek.io_components.utils import (
     _ensure_compatible_indices,
@@ -236,10 +239,6 @@ def update_dataset_from_ddf(
         ds_factory=factory,
     )
 
-    if shuffle and not partition_on:
-        raise ValueError(
-            "If ``shuffle`` is requested, at least one ``partition_on`` column needs to be provided."
-        )
     if ds_factory is not None:
         check_single_table_dataset(ds_factory, table)
 
@@ -257,7 +256,7 @@ def update_dataset_from_ddf(
     else:
         secondary_indices = _ensure_compatible_indices(ds_factory, secondary_indices)
 
-        if shuffle and partition_on:
+        if shuffle:
             mps = update_dask_partitions_shuffle(
                 ddf=ddf,
                 table=table,


### PR DESCRIPTION
# Description:

I caught myself a few times now where I wanted to shuffle without particular `partition_on` In combination with indices and `bucket_by` this allows for some quite powerful dataset layouts. For instance if there are too many unique values of a field to really use `partition_on` but few enough that it makes sense to use indices. There is no technical limitation not to allow this.

This would be a good example for a how to / advanced recipes section now that I think of it...