### PR TITLE
Allow pyarrow==0.17.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,11 @@ env:
     - CONDA_CREATE_ARGS="pyarrow==0.14.1"
     - CONDA_CREATE_ARGS="pyarrow==0.15.0"
     - CONDA_CREATE_ARGS="pyarrow==0.16.0"
+    - CONDA_CREATE_ARGS="pyarrow==0.17.1"
 
 
     # optional builds
-    - CONDA_CREATE_ARGS="pyarrow==0.16.0" NUMFOCUS_NIGHTLY=1
+    - CONDA_CREATE_ARGS="pyarrow==0.17.1" NUMFOCUS_NIGHTLY=1
     - ARROW_NIGHTLY=1
 
 before_install:

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -5,7 +5,7 @@ msgpack-python>=0.5.2
 numpy!=1.15.0,!=1.16.0
 pandas>=0.23.0, !=1.0.0 # https://github.com/pandas-dev/pandas/issues/31441
 # pyarrow==0.14.0 breaks kartothek
-pyarrow>=0.13.0, !=0.14.0, <0.17.0 # Keep upper bound pinned until we see non-breaking releases in the future
+pyarrow>=0.13.0, !=0.14.0, <0.18.0 # Keep upper bound pinned until we see non-breaking releases in the future
 simplejson
 simplekv
 storefact

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ msgpack>=0.5.2
 numpy!=1.15.0,!=1.16.0
 pandas>=0.23.0, !=1.0.0 # https://github.com/pandas-dev/pandas/issues/31441
 # pyarrow==0.14.0 breaks kartothek
-pyarrow>=0.13.0, !=0.14.0, <0.17.0 # Keep upper bound pinned until we see non-breaking releases in the future
+pyarrow>=0.13.0, !=0.14.0, <0.18.0 # Keep upper bound pinned until we see non-breaking releases in the future
 simplejson
 simplekv
 storefact


### PR DESCRIPTION
We're currently still stuck on 0.13.X in some places which is why I don't want to drop the support for the old versions, yet. We're moving on towards 17 and I hope the release following this will be the last one with support for <=15