### PR TITLE
Fix empty predicates bug

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 3.9.1 (2020-xx-xx)
+==========================
+
+Bug fixes
+^^^^^^^^^
+* Fix empty predicates error in predicate pushdown as a result of partition-level filtering
+
+
 Version 3.9.0 (2020-06-03)
 ==========================
 

--- a/kartothek/io/testing/read.py
+++ b/kartothek/io/testing/read.py
@@ -762,7 +762,9 @@ def test_extensiondtype_rountrip(store_factory, bound_load_dataframes):
     pdt.assert_frame_equal(df["data"][0][1], result_df)
 
 
-def test_gh_294(store_factory, bound_load_dataframes, output_type):
+def test_predicate_parsing_OR_query(
+    store_factory, bound_load_dataframes, output_type
+):  # gh-294
     """
     Ensure that we can read dataframe with predicates without issue even when partition-level parsing
     of predicates returns an empty list.
@@ -793,6 +795,7 @@ def test_gh_294(store_factory, bound_load_dataframes, output_type):
         result_dfs = result
     result_df = pd.concat(result_dfs).reset_index(drop=True)
 
+    # TODO: remove this when gh-295 is fixed
     # We only set the test as xfail here to ensure that the code above has actually ran without errors
     pytest.xfail("Results returned are incorrect because of gh-295.")
     pdt.assert_frame_equal(expected_df, result_df)

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -606,7 +606,7 @@ class MetaPartition(Iterable):
                     # A condititon applies to the whole DataFrame, so we need to
                     # load all data.
                     return None
-        return filtered_predicates
+        return filtered_predicates if filtered_predicates else None
 
     @default_docs
     @_apply_to_list


### PR DESCRIPTION
# Description:
I'm hitting a ValueError at https://github.com/JDASoftwareGroup/kartothek/blob/e62b9434e8951efdcd64e828d006a86daa2de128/kartothek/serialization/_generic.py#L174 with `predicates=[]`, when using complex predicates which are then parsed to `[]` after kartothek checks the partition indices here https://github.com/JDASoftwareGroup/kartothek/blob/e62b9434e8951efdcd64e828d006a86daa2de128/kartothek/io_components/metapartition.py#L707

ipdb sample:
```
ipdb> split_predicates,                                                                                                                       
([_SplitPredicate(key_part=[_Literal(column='abc', op='==', value='def')], content_part=[]), _SplitPredicate(key_part=[_Literal(column='order_date', op='<', value=datetime.date(2018, 1, 3))], content_part=[]), _SplitPredicate(key_part=[_Literal(column='order_date', op='>', value=datetime.date(2018, 1, 6))], content_part=[])],)
ipdb> has_index_condition                                                                                                                     
True
ipdb> n                                                                                                                                       
> /Users/xrzq/public_workspace/kartothek/kartothek/io_components/metapartition.py(712)load_dataframes()
    711                 filtered_predicates = []
--> 712                 if has_index_condition:
    713                     filtered_predicates = self._apply_partition_key_predicates(

ipdb> n                                                                                                                                       
> /Users/xrzq/public_workspace/kartothek/kartothek/io_components/metapartition.py(713)load_dataframes()
    712                 if has_index_condition:
--> 713                     filtered_predicates = self._apply_partition_key_predicates(
    714                         table, indices, split_predicates

ipdb> filtered_predicates                                                                                                                     
[]
```

Error stacktrace
```
predicates = []

    def check_predicates(predicates: PredicatesType) -> None:
        """
        Check if predicates are well-formed.
        """
        if predicates is None:
            return
    
        if len(predicates) == 0:
>           raise ValueError("Empty predicates")
E           ValueError: Empty predicates

../../public_workspace/kartothek/kartothek/serialization/_generic.py:174: ValueError

```

I haven't had the time to reproduce this yet. I will add a unit test when I do.
Feedback is appreciated
