### PR TITLE
Cast categoricals in empty_df in read_table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+Version 3.9.1 (2020-06-XX)
+==========================
+
+Bug fixes
+^^^^^^^^^
+
+* Ensure that the empty (sentinel) DataFrame used in :func:`~kartothek.io.eager.read_table`
+  also has the correct behaviour when using the ``categoricals`` argument.
+
 Version 3.9.0 (2020-06-03)
 ==========================
 

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -310,6 +310,8 @@ def read_table(
         schema=ds_factory.table_meta[table],
         columns=columns[table] if columns is not None else None,
     )
+    if categoricals:
+        empty_df = empty_df.astype({col: "category" for col in categoricals[table]})
     dfs = [partition_data[table] for partition_data in partitions] + [empty_df]
     # require meta 4 otherwise, can't construct types/columns
     if categoricals:


### PR DESCRIPTION
# Description:

Ensure that the `empty_df` also has the right datatype set for categoricals. Otherwise `align_categories` will emit a large number of log messages.

- [ ] Closes #xxxx
- [x] Changelog entry
