### PR TITLE
wip: use distributed.Queue as storage for metadata poc

### DIFF
--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -539,6 +539,13 @@ class MetaPartition(Iterable):
             "logical_conjunction": self.logical_conjunction,
         }
 
+    # TODO: serialization? example follows
+    # def __getstate__(self):
+    #     return self.metapartitions
+    #
+    # def __setstate__(self, state):
+    #     return MetaPartition(MetaPartition.from_dict(mp_dict) for mp_dict in state)
+
     @_apply_to_list
     def remove_dataframes(self):
         """


### PR DESCRIPTION
With the intention of improving resilience,
> instead of storing the intermediate results (partition metadata) on dask workers we could submit those to a more central instance (an event bus or even simpler the dask scheduler)
this way the jobs would be safe from worker failures

cc @fjetter 
