### PR TITLE
Feat/collect parqet statistics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog
 Version 3.9.1 (2020-06-XX)
 ==========================
 
+New functionality
+^^^^^^^^^^^^^^^^^
+
+* Add :meth:`~kartothek.io_components.metapartition.MetaPartition.get_parquet_metadata` and :func:`~kartothek.io.dask.dataframe.collect_dataset_metadata`, enabling users to collect information about the Parquet metadata of a dataset
+
 Bug fixes
 ^^^^^^^^^
 

--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from functools import partial
 
 import dask.bag as db
+from toolz.itertoolz import random_sample
 
 from kartothek.core import naming
 from kartothek.core.docs import default_docs
@@ -20,14 +21,15 @@ from kartothek.io_components.metapartition import (
     MetaPartition,
     parse_input_to_metapartition,
 )
-from kartothek.io_components.read import dispatch_metapartitions_from_factory
+from kartothek.io_components.read import (
+    dispatch_metapartitions,
+    dispatch_metapartitions_from_factory,
+)
 from kartothek.io_components.utils import normalize_args, raise_if_indices_overlap
 from kartothek.io_components.write import (
     raise_if_dataset_exists,
     store_dataset_from_partitions,
 )
-from kartothek.io_components.read import dispatch_metapartitions
-from toolz.itertoolz import random_sample
 
 
 def _store_dataset_from_partitions_flat(mpss, *args, **kwargs):

--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -292,25 +292,3 @@ def build_dataset_indices__bag(
             update_indices_from_partitions, dataset_metadata_factory=ds_factory
         )
     )
-
-
-def collect_dataset_statistics(store, dataset_uuid, table_name, predicates=None, sample_size=0.3):
-    """
-    WIP: Retrieve some statistics, maybe even plot them, generate a report...?
-    """
-    # TODO not sure if this is the right place for this function
-
-    mp_iterator = dispatch_metapartitions(dataset_uuid=dataset_uuid, store=store, predicates=predicates)
-    bag = db.from_sequence(random_sample(sample_size, mp_iterator))
-
-    def _get_parquet_stats(mp, store=store, table_name=table_name):
-        """
-        WIP: Retrieve plain parquet metadata, derive some interesting numbers from them
-        """
-        # TODO include more calculations here?
-        pq_metadata = mp.get_parquet_metadata(store=store, table_name=table_name)
-        pq_metadata["rows_per_row_group"] = pq_metadata.["num_rows"] / pq_metadata["num_row_groups"]
-        return pq_metadata
-
-    df_stats = bag.map(_get_parquet_stats, store=store, table_name=table_name).to_dataframe().compute()
-    return df_stats

--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from functools import partial
 
 import dask.bag as db
-from toolz.itertoolz import random_sample
 
 from kartothek.core import naming
 from kartothek.core.docs import default_docs
@@ -21,10 +20,7 @@ from kartothek.io_components.metapartition import (
     MetaPartition,
     parse_input_to_metapartition,
 )
-from kartothek.io_components.read import (
-    dispatch_metapartitions,
-    dispatch_metapartitions_from_factory,
-)
+from kartothek.io_components.read import dispatch_metapartitions_from_factory
 from kartothek.io_components.utils import normalize_args, raise_if_indices_overlap
 from kartothek.io_components.write import (
     raise_if_dataset_exists,

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from simplekv import KeyValueStore
 
+from kartothek.core._compat import ARROW_LARGER_EQ_0141
 from kartothek.core.common_metadata import empty_dataframe_from_schema
 from kartothek.core.docs import default_docs
 from kartothek.core.factory import DatasetFactory, _ensure_factory
@@ -368,6 +369,8 @@ def collect_dataset_metadata(
       If no metadata could be retrieved, raise an error.
 
     """
+    if not ARROW_LARGER_EQ_0141:
+        raise RuntimeError("This function requires `pyarrow>=0.14.1`.")
     if not 0.0 < frac <= 1.0:
         raise ValueError(
             f"Invalid value for parameter `frac`: {frac}."

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -1,13 +1,15 @@
 import random
+from typing import Callable, Optional
 
 import dask
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
+from simplekv import KeyValueStore
 
 from kartothek.core.common_metadata import empty_dataframe_from_schema
 from kartothek.core.docs import default_docs
-from kartothek.core.factory import _ensure_factory
+from kartothek.core.factory import DatasetFactory, _ensure_factory
 from kartothek.core.naming import DEFAULT_METADATA_VERSION
 from kartothek.io_components.metapartition import (
     _METADATA_SCHEMA,
@@ -24,6 +26,7 @@ from kartothek.io_components.utils import (
     normalize_args,
     validate_partition_keys,
 )
+from kartothek.serialization import PredicatesType
 
 from ._update import update_dask_partitions_one_to_one, update_dask_partitions_shuffle
 from ._utils import _maybe_get_categoricals_from_index
@@ -310,13 +313,13 @@ def update_dataset_from_ddf(
 
 
 def collect_dataset_metadata(
-    store,
-    dataset_uuid,
-    table_name=SINGLE_TABLE,
-    predicates=None,
-    frac=1.0,
-    factory=None,
-):
+    store: Optional[Callable[[], KeyValueStore]] = None,
+    dataset_uuid: Optional[str] = None,
+    table_name: str = SINGLE_TABLE,
+    predicates: Optional[PredicatesType] = None,
+    frac: float = 1.0,
+    factory: Optional[DatasetFactory] = None,
+) -> dd.DataFrame:
     """
     Collect parquet metadata of the dataset. The `frac` parameter can be used to select a subset of the data.
 

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -313,7 +313,7 @@ def update_dataset_from_ddf(
 
 
 def collect_dataset_metadata(
-    store_factory,
+    store,
     dataset_uuid,
     table_name=SINGLE_TABLE,
     predicates=None,
@@ -332,7 +332,7 @@ def collect_dataset_metadata(
 
     Parameters
     ----------
-    store_factory
+    store
       A factory function providing a KeyValueStore
     dataset_uuid
       The dataset's unique identifier
@@ -374,7 +374,7 @@ def collect_dataset_metadata(
         )
     dataset_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
-        store=store_factory,
+        store=store,
         factory=factory,
         load_dataset_metadata=False,
     )

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -1,4 +1,3 @@
-import logging
 import random
 
 import dask
@@ -29,8 +28,6 @@ from kartothek.io_components.utils import (
 from ._update import update_dask_partitions_one_to_one, update_dask_partitions_shuffle
 from ._utils import _maybe_get_categoricals_from_index
 from .delayed import read_table_as_delayed
-
-_logger = logging.getLogger()
 
 
 @default_docs

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -355,7 +355,8 @@ def collect_dataset_metadata(
     A dask.DataFrame containing the following information about dataset statistics:
        * `partition_label`: File name of the parquet file, unique to each physical partition.
        * `row_group_id`: Index of the row groups within one parquet file.
-       * `row_group_byte_size`: Byte size of the data within one row group.
+       * `row_group_compressed_size`: Byte size of the data within one row group.
+       * `row_group_uncompressed_size`: Byte size (uncompressed) of the data within one row group.
        * `number_rows_total`: Total number of rows in one parquet file.
        * `number_row_groups`: Number of row groups in one parquet file.
        * `serialized_size`: Serialized size of the parquet file.

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -349,7 +349,7 @@ def collect_dataset_metadata(
 
     Returns
     -------
-    A delayed pandas.DataFrame containing the following information about dataset statistics:
+    A dask.DataFrame containing the following information about dataset statistics:
        * `partition_label`: File name of the parquet file, unique to each physical partition.
        * `row_group_id`: Index of the row groups within one parquet file.
        * `row_group_byte_size`: Byte size of the data within one row group.
@@ -384,7 +384,7 @@ def collect_dataset_metadata(
         # ensure that even with sampling at least one metapartition is returned
         cutoff_index = max(1, int(len(mps) * frac))
         mps = mps[:cutoff_index]
-        df = dd.from_delayed(
+        ddf = dd.from_delayed(
             [
                 dask.delayed(MetaPartition.get_parquet_metadata)(
                     mp, store=dataset_factory.store_factory, table_name=table_name,
@@ -395,6 +395,6 @@ def collect_dataset_metadata(
     else:
         df = pd.DataFrame(columns=_METADATA_SCHEMA.keys())
         df = df.astype(_METADATA_SCHEMA)
-        df = dask.delayed(df)
+        ddf = dd.from_pandas(df, npartitions=1)
 
-    return df
+    return ddf

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -313,7 +313,12 @@ def update_dataset_from_ddf(
 
 
 def collect_dataset_metadata(
-    store_factory, dataset_uuid, table_name, predicates=None, frac=1.0, factory=None,
+    store_factory,
+    dataset_uuid,
+    table_name=SINGLE_TABLE,
+    predicates=None,
+    frac=1.0,
+    factory=None,
 ):
     """
     Collect parquet metadata of the dataset. The `frac` parameter can be used to select a subset of the data.

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1583,10 +1583,15 @@ class MetaPartition(Iterable):
             }
             data["row_group_id"] = range(data["number_row_groups"])
 
-            data["row_group_byte_size"], data["number_rows_per_row_group"] = zip(*[
-                (pq_metadata.row_group(rg_id).total_byte_size, pq_metadata.row_group(rg_id).num_rows)
-                for rg_id in data["row_group_id"]
-            ])
+            data["row_group_byte_size"], data["number_rows_per_row_group"] = zip(
+                *[
+                    (
+                        pq_metadata.row_group(rg_id).total_byte_size,
+                        pq_metadata.row_group(rg_id).num_rows,
+                    )
+                    for rg_id in data["row_group_id"]
+                ]
+            )
             return pd.DataFrame(
                 data=data,
                 columns=[

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1549,6 +1549,26 @@ class MetaPartition(Iterable):
             store.delete(file_key)
         return self.copy(files={}, data={}, metadata={})
 
+    def get_parquet_metadata(self, store, table_name):
+        """
+        Retrieve the parquet metadata, especially relevant for dataset statistics.
+
+        # TODO docstrings
+        """
+        if not isinstance(table_name, str):
+            raise TypeError("Expecting a string for parameter `table_name`.")
+
+        if self.files:
+            fd = store.open(self.files[table_name])
+            pq_metadata = pa.parquet.ParquetFile(fd).metadata
+            # TODO include more stats
+            stats = {"number_rows": pq_metadata.num_rows}
+        else:
+            # TODO reword
+            LOGGER.warning("No files in MetaPartition, can't collect any stats")
+            stats = {"number_rows": None}
+        return stats
+
 
 def _unique_label(label_list):
     label = os.path.commonprefix(label_list)

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1569,6 +1569,9 @@ class MetaPartition(Iterable):
         if not isinstance(table_name, str):
             raise TypeError("Expecting a string for parameter `table_name`.")
 
+        if callable(store):
+            store = store()
+
         if self.files:
             fd = store.open(self.files[table_name])
             pq_metadata = pa.parquet.ParquetFile(fd).metadata
@@ -1580,18 +1583,26 @@ class MetaPartition(Iterable):
             }
             data["row_group_id"] = range(data["number_row_groups"])
             data["row_group_byte_size"] = [
-                pq_metadata.row_group(rg_id).total_byte_size for rg_id in data["row_group_id"]
+                pq_metadata.row_group(rg_id).total_byte_size
+                for rg_id in data["row_group_id"]
             ]
 
             return pd.DataFrame(
                 data=data,
                 columns=[
-                    "partition_label", "row_group_id", "row_group_byte_size", "number_rows", "number_row_groups", "serialized_size"
-                ]
+                    "partition_label",
+                    "row_group_id",
+                    "row_group_byte_size",
+                    "number_rows",
+                    "number_row_groups",
+                    "serialized_size",
+                ],
             )
 
         else:
-            raise RuntimeError("This should not happen: MetaPartition with no data associated.")
+            raise RuntimeError(
+                "This should not happen: MetaPartition with no data associated."
+            )
 
 
 def _unique_label(label_list):

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1577,25 +1577,26 @@ class MetaPartition(Iterable):
             pq_metadata = pa.parquet.ParquetFile(fd).metadata
             data = {
                 "partition_label": self.label,
-                "number_rows": pq_metadata.num_rows,
+                "number_rows_total": pq_metadata.num_rows,
                 "number_row_groups": pq_metadata.num_row_groups,
                 "serialized_size": pq_metadata.serialized_size,
             }
             data["row_group_id"] = range(data["number_row_groups"])
-            data["row_group_byte_size"] = [
-                pq_metadata.row_group(rg_id).total_byte_size
-                for rg_id in data["row_group_id"]
-            ]
 
+            data["row_group_byte_size"], data["number_rows_per_row_group"] = zip(*[
+                (pq_metadata.row_group(rg_id).total_byte_size, pq_metadata.row_group(rg_id).num_rows)
+                for rg_id in data["row_group_id"]
+            ])
             return pd.DataFrame(
                 data=data,
                 columns=[
                     "partition_label",
                     "row_group_id",
                     "row_group_byte_size",
-                    "number_rows",
+                    "number_rows_total",
                     "number_row_groups",
                     "serialized_size",
+                    "number_rows_per_row_group",
                 ],
             )
 

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1567,12 +1567,13 @@ class MetaPartition(Iterable):
                 "serialized_size": pq_metadata.serialized_size,
             }
             for rg_nb in range(stats["number_row_groups"]):
-                stats[f"row_group_{rg_nb}_byte_size"] = pq_metadata.row_group(rg_nb).total_byte_size
+                stats[f"row_group_{rg_nb}_byte_size"] = pq_metadata.row_group(
+                    rg_nb
+                ).total_byte_size
             return stats
         else:
             LOGGER.info("No files in MetaPartition, no metadata to track.")
-            return dict() # TODO really?
-
+            return dict()  # TODO really?
 
 
 def _unique_label(label_list):

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -1,0 +1,49 @@
+# import pytest
+import pandas as pd
+
+from kartothek.io.dask.dataframe import collect_dataset_statistics
+
+
+def test_collect_dataset_statistics(store_session_factory, dataset):
+    df_stats = collect_dataset_statistics(
+        store=store_session_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table",
+        predicates=None,
+        frac=1,
+    )
+    actual = df_stats.drop(columns=["row_group_byte_size", "serialized_size"], axis=1)
+
+    expected = pd.DataFrame(
+        data={
+            "partition_label": ["cluster_1", "cluster_2"],
+            "row_group_id": [0, 0],
+            "number_rows": [1, 1],
+            "number_row_groups": [1, 1],
+        }
+    )
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_collect_dataset_statistics_predicates(store_session_factory, dataset):
+    predicates = [[("P", "==", 1)]]
+
+    df_stats = collect_dataset_statistics(
+        store=store_session_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table",
+        predicates=predicates,
+        frac=1,
+    )
+    actual = df_stats.drop(columns=["row_group_byte_size", "serialized_size"], axis=1)
+
+    expected = pd.DataFrame(
+        data={
+            "partition_label": ["cluster_1"],
+            "row_group_id": [0],
+            "number_rows": [1],
+            "number_row_groups": [1],
+        }
+    )
+    # TODO this fails, might be an issue with the predicate passing to the metapartitions in `dispatch_metapartitions`?
+    pd.testing.assert_frame_equal(actual, expected)

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import pytest
 
+from kartothek.core._compat import ARROW_LARGER_EQ_0141
 from kartothek.io.dask.dataframe import collect_dataset_metadata
 from kartothek.io.eager import (
     store_dataframes_as_dataset,
@@ -9,6 +10,9 @@ from kartothek.io.eager import (
 from kartothek.io_components.metapartition import _METADATA_SCHEMA, MetaPartition
 from kartothek.io_components.write import store_dataset_from_partitions
 from kartothek.serialization import ParquetSerializer
+
+if not ARROW_LARGER_EQ_0141:
+    pytest.skip("requires arrow >= 0.14.1", allow_module_level=True)
 
 
 def test_collect_dataset_metadata(store_session_factory, dataset):

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -259,6 +259,22 @@ def test_collect_dataset_metadata_fraction_precision(store_factory):
     assert len(df_stats) == 20
 
 
+def test_collect_dataset_metadata_at_least_one_partition(store_factory):
+    """
+    Make sure we return at leat one partition, even if none would be returned by rounding frac * n_partitions
+    """
+    df = pd.DataFrame(data={"A": range(100), "B": range(100)})
+
+    store_dataframes_as_dataset(
+        store=store_factory, dataset_uuid="dataset_uuid", dfs=[df], partition_on=["A"],
+    )  # Creates 100 partitions
+
+    df_stats = collect_dataset_metadata(
+        store=store_factory, dataset_uuid="dataset_uuid", frac=0.005
+    )
+    assert len(df_stats) == 1
+
+
 def test_collect_dataset_metadata_table_without_partition(store_factory):
     """
     df2 doesn't have files for all partition (specifically `A==2`).

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -252,6 +252,19 @@ def test_collect_dataset_metadata_delete_dataset(store_factory):
     pd.testing.assert_frame_equal(expected, df_stats)
 
 
+def test_collect_dataset_metadata_fraction_precision(store_factory):
+    df = pd.DataFrame(data={"A": range(100), "B": range(100)})
+
+    store_dataframes_as_dataset(
+        store=store_factory, dataset_uuid="dataset_uuid", dfs=[df], partition_on=["A"],
+    )  # Creates 100 partitions
+
+    df_stats = collect_dataset_metadata(
+        store_factory=store_factory, dataset_uuid="dataset_uuid", frac=0.2
+    )
+    assert len(df_stats) == 20
+
+
 def test_collect_dataset_metadata_table_without_partition(store_factory):
     """
     df2 doesn't have files for all partition (specifically `A==2`).

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -34,7 +34,7 @@ METADATA_DTYPES = (
 
 def test_collect_dataset_metadata(store_session_factory, dataset):
     df_stats = collect_dataset_metadata(
-        store_factory=store_session_factory,
+        store=store_session_factory,
         dataset_uuid="dataset_uuid",
         table_name="table",
         predicates=None,
@@ -58,7 +58,7 @@ def test_collect_dataset_metadata_predicates(store_session_factory, dataset):
     predicates = [[("P", "==", 1)]]
 
     df_stats = collect_dataset_metadata(
-        store_factory=store_session_factory,
+        store=store_session_factory,
         dataset_uuid="dataset_uuid",
         table_name="table",
         predicates=predicates,
@@ -89,7 +89,7 @@ def test_collect_dataset_metadata_predicates_on_index(store_factory):
     predicates = [[("L", "==", "b")]]
 
     df_stats = collect_dataset_metadata(
-        store_factory=store_factory,
+        store=store_factory,
         dataset_uuid="dataset_uuid",
         table_name="table",
         predicates=predicates,
@@ -127,7 +127,7 @@ def test_collect_dataset_metadata_predicates_row_group_size(store_factory):
     predicates = [[("L", "==", "a")]]
 
     df_stats = collect_dataset_metadata(
-        store_factory=store_factory,
+        store=store_factory,
         dataset_uuid="dataset_uuid",
         table_name="table",
         predicates=predicates,
@@ -153,7 +153,7 @@ def test_collect_dataset_metadata_predicates_row_group_size(store_factory):
 
 def test_collect_dataset_metadata_frac_smoke(store_session_factory, dataset):
     df_stats = collect_dataset_metadata(
-        store_factory=store_session_factory,
+        store=store_session_factory,
         dataset_uuid="dataset_uuid",
         table_name="table",
         frac=0.8,
@@ -178,7 +178,7 @@ def test_collect_dataset_metadata_empty_dataset_mp(store_factory):
     )
 
     df_stats = collect_dataset_metadata(
-        store_factory=store_factory, dataset_uuid="dataset_uuid", table_name="table"
+        store=store_factory, dataset_uuid="dataset_uuid", table_name="table"
     )
     expected = pd.DataFrame(columns=METADATA_COLUMNS)
     expected = expected.astype(dict(zip(METADATA_COLUMNS, METADATA_DTYPES)))
@@ -194,9 +194,7 @@ def test_collect_dataset_metadata_empty_dataset(store_factory):
         UserWarning, match="^Can't retrieve metadata for empty dataset.*"
     ):
         df_stats = collect_dataset_metadata(
-            store_factory=store_factory,
-            dataset_uuid="dataset_uuid",
-            table_name="table",
+            store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
         )
     expected = pd.DataFrame(columns=METADATA_COLUMNS)
     expected = expected.astype(dict(zip(METADATA_COLUMNS, METADATA_DTYPES)))
@@ -210,7 +208,7 @@ def test_collect_dataset_metadata_concat(store_factory):
         store=store_factory, dataset_uuid="dataset_uuid", dfs=[df], partition_on=["A"]
     )
     df_stats1 = collect_dataset_metadata(
-        store_factory=store_factory, dataset_uuid="dataset_uuid", table_name="table",
+        store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
     )
 
     # Remove all partitions of the dataset
@@ -222,9 +220,7 @@ def test_collect_dataset_metadata_concat(store_factory):
         UserWarning, match="^Can't retrieve metadata for empty dataset.*"
     ):
         df_stats2 = collect_dataset_metadata(
-            store_factory=store_factory,
-            dataset_uuid="dataset_uuid",
-            table_name="table",
+            store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
         )
     pd.concat([df_stats1, df_stats2])
 
@@ -243,9 +239,7 @@ def test_collect_dataset_metadata_delete_dataset(store_factory):
         UserWarning, match="^Can't retrieve metadata for empty dataset.*"
     ):
         df_stats = collect_dataset_metadata(
-            store_factory=store_factory,
-            dataset_uuid="dataset_uuid",
-            table_name="table",
+            store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
         )
     expected = pd.DataFrame(columns=METADATA_COLUMNS)
     expected = expected.astype(dict(zip(METADATA_COLUMNS, METADATA_DTYPES)))
@@ -260,7 +254,7 @@ def test_collect_dataset_metadata_fraction_precision(store_factory):
     )  # Creates 100 partitions
 
     df_stats = collect_dataset_metadata(
-        store_factory=store_factory, dataset_uuid="dataset_uuid", frac=0.2
+        store=store_factory, dataset_uuid="dataset_uuid", frac=0.2
     )
     assert len(df_stats) == 20
 
@@ -300,7 +294,7 @@ def test_collect_dataset_metadata_table_without_partition(store_factory):
 def test_collect_dataset_metadata_invalid_frac(store_session_factory, dataset):
     with pytest.raises(ValueError, match="Invalid value for parameter `frac`"):
         collect_dataset_metadata(
-            store_factory=store_session_factory,
+            store=store_session_factory,
             dataset_uuid="dataset_uuid",
             table_name="table",
             frac=1.1,
@@ -308,7 +302,7 @@ def test_collect_dataset_metadata_invalid_frac(store_session_factory, dataset):
 
     with pytest.raises(ValueError, match="Invalid value for parameter `frac`"):
         collect_dataset_metadata(
-            store_factory=store_session_factory,
+            store=store_session_factory,
             dataset_uuid="dataset_uuid",
             table_name="table",
             frac=0.0,

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -254,7 +254,7 @@ def test_collect_dataset_metadata_delete_dataset(store_factory):
 
 def test_collect_dataset_metadata_table_without_partition(store_factory):
     """
-    df2 doesn't have files for all partition (specificaly `A==2`).
+    df2 doesn't have files for all partition (specifically `A==2`).
     Make sure that we still collect the right metadata
     """
     df1 = pd.DataFrame(data={"A": [1, 1, 2, 2], "b": [1, 1, 2, 2]})
@@ -267,10 +267,21 @@ def test_collect_dataset_metadata_table_without_partition(store_factory):
         partition_on=["A"],
     )
 
-    # df_stats = collect_dataset_metadata(
-    #     store_factory=store_factory, dataset_uuid="dataset_uuid", table_name="table2",
-    # )
-    # TODO assertions
+    df_stats = collect_dataset_metadata(
+        store_factory=store_factory, dataset_uuid="dataset_uuid", table_name="table2",
+    )
+    actual = df_stats.drop(
+        columns=["partition_label", "row_group_byte_size", "serialized_size"], axis=1
+    )
+    expected = pd.DataFrame(
+        data={
+            "row_group_id": [0],
+            "number_rows_total": [2],
+            "number_row_groups": [1],
+            "number_rows_per_row_group": [2],
+        }
+    )
+    pd.testing.assert_frame_equal(actual, expected)
 
 
 def test_collect_dataset_metadata_invalid_frac(store_session_factory, dataset):

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -147,7 +147,7 @@ def test_collect_dataset_statistics_frac_smoke(store_session_factory, dataset):
 
 def test_collect_dataset_statistics_frac_too_small(store_session_factory, dataset):
     with pytest.raises(ValueError):
-        df_stats = collect_dataset_statistics(
+        collect_dataset_statistics(
             store=store_session_factory,
             dataset_uuid="dataset_uuid",
             table_name="table",

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -275,7 +275,7 @@ def test_collect_dataset_metadata_table_without_partition(store_factory):
     )
 
     df_stats = collect_dataset_metadata(
-        store_factory=store_factory, dataset_uuid="dataset_uuid", table_name="table2",
+        store=store_factory, dataset_uuid="dataset_uuid", table_name="table2",
     )
     actual = df_stats.drop(
         columns=["partition_label", "row_group_byte_size", "serialized_size"], axis=1
@@ -289,6 +289,8 @@ def test_collect_dataset_metadata_table_without_partition(store_factory):
         }
     )
     pd.testing.assert_frame_equal(actual, expected)
+    assert len(df_stats) == 1
+    assert df_stats.iloc[0]["partition_label"].startswith("A=1/")
 
 
 def test_collect_dataset_metadata_invalid_frac(store_session_factory, dataset):

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -1,7 +1,9 @@
-# import pytest
 import pandas as pd
+import pytest
 
 from kartothek.io.dask.dataframe import collect_dataset_statistics
+from kartothek.io.eager import store_dataframes_as_dataset
+from kartothek.serialization import ParquetSerializer
 
 
 def test_collect_dataset_statistics(store_session_factory, dataset):
@@ -38,14 +40,116 @@ def test_collect_dataset_statistics_predicates(store_session_factory, dataset):
     )
     actual = df_stats.drop(columns=["row_group_byte_size", "serialized_size"], axis=1)
 
+    # Predicates are only evaluated on index level and have therefore no effect on this dataset
     expected = pd.DataFrame(
         data={
-            "partition_label": ["cluster_1"],
-            "row_group_id": [0],
-            "number_rows_total": [1],
-            "number_row_groups": [1],
-            "number_rows_per_row_group": [1],
+            "partition_label": ["cluster_1", "cluster_2"],
+            "row_group_id": [0, 0],
+            "number_rows_total": [1, 1],
+            "number_row_groups": [1, 1],
+            "number_rows_per_row_group": [1, 1],
         }
     )
-    # TODO this fails, might be an issue with the predicate passing to the metapartitions in `dispatch_metapartitions`?
     pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_collect_dataset_statistics_predicates_on_index(store_factory):
+    df = pd.DataFrame(
+        data={"P": range(10), "L": ["a", "a", "a", "a", "a", "b", "b", "b", "b", "b"]}
+    )
+    store_dataframes_as_dataset(
+        store=store_factory, dataset_uuid="dataset_uuid", partition_on=["L"], dfs=[df],
+    )
+    predicates = [[("L", "==", "b")]]
+
+    df_stats = collect_dataset_statistics(
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table",
+        predicates=predicates,
+        frac=1,
+    )
+    assert "L=b" in df_stats["partition_label"].values[0]
+    actual = df_stats.drop(
+        columns=["partition_label", "row_group_byte_size", "serialized_size"], axis=1
+    )
+
+    expected = pd.DataFrame(
+        data={
+            "row_group_id": [0],
+            "number_rows_total": [5],
+            "number_row_groups": [1],
+            "number_rows_per_row_group": [5],
+        }
+    )
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_collect_dataset_statistics_predicates_row_group_size(store_factory):
+    ps = ParquetSerializer(chunk_size=2)
+    df = pd.DataFrame(
+        data={"P": range(10), "L": ["a", "a", "a", "a", "a", "b", "b", "b", "b", "b"]}
+    )
+    store_dataframes_as_dataset(
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        partition_on=["L"],
+        dfs=[df],
+        df_serializer=ps,
+    )
+
+    predicates = [[("L", "==", "a")]]
+
+    df_stats = collect_dataset_statistics(
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table",
+        predicates=predicates,
+        frac=1,
+    )
+    for part_label in df_stats["partition_label"]:
+        assert "L=a" in part_label
+
+    actual = df_stats.drop(
+        columns=["partition_label", "row_group_byte_size", "serialized_size"], axis=1
+    )
+
+    expected = pd.DataFrame(
+        data={
+            "row_group_id": [0, 1, 2],
+            "number_rows_total": [5, 5, 5],
+            "number_row_groups": [3, 3, 3],
+            "number_rows_per_row_group": [2, 2, 1],
+        }
+    )
+    pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_collect_dataset_statistics_frac_smoke(store_session_factory, dataset):
+    df_stats = collect_dataset_statistics(
+        store=store_session_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table",
+        frac=0.8,
+    )
+    columns = {
+        "partition_label",
+        "row_group_id",
+        "row_group_byte_size",
+        "number_rows_total",
+        "number_row_groups",
+        "serialized_size",
+        "number_rows_per_row_group",
+    }
+
+    assert set(df_stats.columns) == columns
+
+
+def test_collect_dataset_statistics_frac_too_small(store_session_factory, dataset):
+    with pytest.raises(ValueError):
+        df_stats = collect_dataset_statistics(
+            store=store_session_factory,
+            dataset_uuid="dataset_uuid",
+            table_name="table",
+            frac=0.05,
+        )

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -20,7 +20,14 @@ def test_collect_dataset_metadata(store_session_factory, dataset):
         frac=1,
     ).compute()
 
-    actual = df_stats.drop(columns=["row_group_byte_size", "serialized_size"], axis=1)
+    actual = df_stats.drop(
+        columns=[
+            "row_group_compressed_size",
+            "row_group_uncompressed_size",
+            "serialized_size",
+        ],
+        axis=1,
+    )
     actual.sort_values(by=["partition_label", "row_group_id"], inplace=True)
 
     expected = pd.DataFrame(
@@ -47,7 +54,14 @@ def test_collect_dataset_metadata_predicates(store_session_factory, dataset):
         frac=1,
     ).compute()
 
-    actual = df_stats.drop(columns=["row_group_byte_size", "serialized_size"], axis=1)
+    actual = df_stats.drop(
+        columns=[
+            "row_group_compressed_size",
+            "row_group_uncompressed_size",
+            "serialized_size",
+        ],
+        axis=1,
+    )
     actual.sort_values(by=["partition_label", "row_group_id"], inplace=True)
 
     # Predicates are only evaluated on index level and have therefore no effect on this dataset
@@ -85,7 +99,13 @@ def test_collect_dataset_metadata_predicates_on_index(store_factory):
 
     df_stats.sort_values(by=["partition_label", "row_group_id"], inplace=True)
     actual = df_stats.drop(
-        columns=["partition_label", "row_group_byte_size", "serialized_size"], axis=1
+        columns=[
+            "partition_label",
+            "row_group_compressed_size",
+            "row_group_uncompressed_size",
+            "serialized_size",
+        ],
+        axis=1,
     )
 
     expected = pd.DataFrame(
@@ -128,7 +148,13 @@ def test_collect_dataset_metadata_predicates_row_group_size(store_factory):
     df_stats.sort_values(by=["partition_label", "row_group_id"], inplace=True)
 
     actual = df_stats.drop(
-        columns=["partition_label", "row_group_byte_size", "serialized_size"], axis=1
+        columns=[
+            "partition_label",
+            "row_group_compressed_size",
+            "row_group_uncompressed_size",
+            "serialized_size",
+        ],
+        axis=1,
     )
 
     expected = pd.DataFrame(
@@ -153,7 +179,8 @@ def test_collect_dataset_metadata_frac_smoke(store_session_factory, dataset):
     columns = {
         "partition_label",
         "row_group_id",
-        "row_group_byte_size",
+        "row_group_compressed_size",
+        "row_group_uncompressed_size",
         "number_rows_total",
         "number_row_groups",
         "serialized_size",
@@ -278,7 +305,13 @@ def test_collect_dataset_metadata_table_without_partition(store_factory):
         store=store_factory, dataset_uuid="dataset_uuid", table_name="table2",
     ).compute()
     actual = df_stats.drop(
-        columns=["partition_label", "row_group_byte_size", "serialized_size"], axis=1
+        columns=[
+            "partition_label",
+            "row_group_compressed_size",
+            "row_group_uncompressed_size",
+            "serialized_size",
+        ],
+        axis=1,
     )
     expected = pd.DataFrame(
         data={

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -18,8 +18,9 @@ def test_collect_dataset_statistics(store_session_factory, dataset):
         data={
             "partition_label": ["cluster_1", "cluster_2"],
             "row_group_id": [0, 0],
-            "number_rows": [1, 1],
+            "number_rows_total": [1, 1],
             "number_row_groups": [1, 1],
+            "number_rows_per_row_group": [1, 1],
         }
     )
     pd.testing.assert_frame_equal(actual, expected)
@@ -41,8 +42,9 @@ def test_collect_dataset_statistics_predicates(store_session_factory, dataset):
         data={
             "partition_label": ["cluster_1"],
             "row_group_id": [0],
-            "number_rows": [1],
+            "number_rows_total": [1],
             "number_row_groups": [1],
+            "number_rows_per_row_group": [1],
         }
     )
     # TODO this fails, might be an issue with the predicate passing to the metapartitions in `dispatch_metapartitions`?

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1656,12 +1656,14 @@ def test_get_parquet_metadata(store):
     actual.drop(labels="serialized_size", axis=1, inplace=True)
     actual.drop(labels="row_group_byte_size", axis=1, inplace=True)
 
-    expected = pd.DataFrame({
-        "partition_label": ["test_label"],
-        "row_group_id": 0,
-        "number_rows": 10,
-        "number_row_groups": 1,
-    })
+    expected = pd.DataFrame(
+        {
+            "partition_label": ["test_label"],
+            "row_group_id": 0,
+            "number_rows": 10,
+            "number_row_groups": 1,
+        }
+    )
     pd.testing.assert_frame_equal(actual, expected)
 
 
@@ -1671,14 +1673,18 @@ def test_get_parquet_metadata_empty_df(store):
     meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
 
     actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
-    actual.drop(columns=["serialized_size", "row_group_byte_size"], axis=1, inplace=True)
+    actual.drop(
+        columns=["serialized_size", "row_group_byte_size"], axis=1, inplace=True
+    )
 
-    expected = pd.DataFrame({
-        "partition_label": ["test_label"],
-        "row_group_id": 0,
-        "number_rows": 0,
-        "number_row_groups": 1,
-    })
+    expected = pd.DataFrame(
+        {
+            "partition_label": ["test_label"],
+            "row_group_id": 0,
+            "number_rows": 0,
+            "number_row_groups": 1,
+        }
+    )
 
     pd.testing.assert_frame_equal(actual, expected)
 
@@ -1688,15 +1694,31 @@ def test_get_parquet_metadata_row_group_size(store):
     mp = MetaPartition(label="test_label", data={"core": df},)
     ps = ParquetSerializer(chunk_size=5)
 
-    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid", df_serializer=ps)
+    meta_partition = mp.store_dataframes(
+        store=store, dataset_uuid="dataset_uuid", df_serializer=ps
+    )
     actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
-    actual.drop(columns=["serialized_size", "row_group_byte_size"], axis=1, inplace=True)
+    actual.drop(
+        columns=["serialized_size", "row_group_byte_size"], axis=1, inplace=True
+    )
 
-    expected = pd.DataFrame({
-        "partition_label": ["test_label", "test_label"],
-        "row_group_id": [0, 1],
-        "number_rows": [10, 10],
-        "number_row_groups": [2, 2],
-    })
+    expected = pd.DataFrame(
+        {
+            "partition_label": ["test_label", "test_label"],
+            "row_group_id": [0, 1],
+            "number_rows": [10, 10],
+            "number_row_groups": [2, 2],
+        }
+    )
     pd.testing.assert_frame_equal(actual, expected)
 
+
+def test_table_name_not_str(store):
+    df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
+    mp = MetaPartition(label="test_label", data={"core": df, "another_table": df},)
+    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
+
+    with pytest.raises(TypeError):
+        meta_partition.get_parquet_metadata(
+            store=store, table_name=["core", "another_table"]
+        )

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1653,6 +1653,7 @@ def test_get_parquet_metadata(store):
     meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
     pq_metadata = meta_partition.get_parquet_metadata(store=store, table_name="core")
     assert pq_metadata["number_rows"] == 10
+    assert pq_metadata["number_row_groups"] == 1
 
 
 def test_get_parquet_metadata_empty_df(store):
@@ -1661,6 +1662,7 @@ def test_get_parquet_metadata_empty_df(store):
     meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
     pq_metadata = meta_partition.get_parquet_metadata(store=store, table_name="core")
     assert pq_metadata["number_rows"] == 0
+    assert pq_metadata["number_row_groups"] == 1
 
 
 def test_get_parquet_metadata_empty_metapartition(store):
@@ -1668,4 +1670,7 @@ def test_get_parquet_metadata_empty_metapartition(store):
     mp = MetaPartition(label="test_label")
     meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
     pq_metadata = meta_partition.get_parquet_metadata(store=store, table_name="core")
-    assert pq_metadata["number_rows"] is None
+
+
+# TODO test for row group size > 1
+# TODO add test for one empty metapartition

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 
+from kartothek.core._compat import ARROW_LARGER_EQ_0141
 from kartothek.core.common_metadata import make_meta, store_schema_metadata
 from kartothek.core.index import ExplicitSecondaryIndex
 from kartothek.core.naming import DEFAULT_METADATA_VERSION
@@ -1647,6 +1648,7 @@ def test_parse_input_schema_formats():
         assert mp.data == {"table1": df}
 
 
+@pytest.mark.skipif(not ARROW_LARGER_EQ_0141, reason="requires arrow >= 0.14.1")
 def test_get_parquet_metadata(store):
     df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
     mp = MetaPartition(label="test_label", data={"core": df},)
@@ -1669,6 +1671,7 @@ def test_get_parquet_metadata(store):
     pd.testing.assert_frame_equal(actual, expected)
 
 
+@pytest.mark.skipif(not ARROW_LARGER_EQ_0141, reason="requires arrow >= 0.14.1")
 def test_get_parquet_metadata_empty_df(store):
     df = pd.DataFrame()
     mp = MetaPartition(label="test_label", data={"core": df},)
@@ -1698,6 +1701,7 @@ def test_get_parquet_metadata_empty_df(store):
     pd.testing.assert_frame_equal(actual, expected)
 
 
+@pytest.mark.skipif(not ARROW_LARGER_EQ_0141, reason="requires arrow >= 0.14.1")
 def test_get_parquet_metadata_row_group_size(store):
     df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
     mp = MetaPartition(label="test_label", data={"core": df},)
@@ -1729,6 +1733,7 @@ def test_get_parquet_metadata_row_group_size(store):
     pd.testing.assert_frame_equal(actual, expected)
 
 
+@pytest.mark.skipif(not ARROW_LARGER_EQ_0141, reason="requires arrow >= 0.14.1")
 def test_get_parquet_metadata_table_name_not_str(store):
     df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
     mp = MetaPartition(label="test_label", data={"core": df, "another_table": df},)

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1660,8 +1660,9 @@ def test_get_parquet_metadata(store):
         {
             "partition_label": ["test_label"],
             "row_group_id": 0,
-            "number_rows": 10,
+            "number_rows_total": 10,
             "number_row_groups": 1,
+            "number_rows_per_row_group": 10,
         }
     )
     pd.testing.assert_frame_equal(actual, expected)
@@ -1681,8 +1682,9 @@ def test_get_parquet_metadata_empty_df(store):
         {
             "partition_label": ["test_label"],
             "row_group_id": 0,
-            "number_rows": 0,
+            "number_rows_total": 0,
             "number_row_groups": 1,
+            "number_rows_per_row_group": 0,
         }
     )
 
@@ -1706,8 +1708,9 @@ def test_get_parquet_metadata_row_group_size(store):
         {
             "partition_label": ["test_label", "test_label"],
             "row_group_id": [0, 1],
-            "number_rows": [10, 10],
+            "number_rows_total": [10, 10],
             "number_row_groups": [2, 2],
+            "number_rows_per_row_group": [5, 5],
         }
     )
     pd.testing.assert_frame_equal(actual, expected)

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1645,3 +1645,27 @@ def test_parse_input_schema_formats():
     for obj in formats_obj:
         mp = parse_input_to_metapartition(obj=obj, metadata_version=4)
         assert mp.data == {"table1": df}
+
+
+def test_get_parquet_metadata(store):
+    df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
+    mp = MetaPartition(label="test_label", data={"core": df},)
+    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
+    pq_metadata = meta_partition.get_parquet_metadata(store=store, table_name="core")
+    assert pq_metadata["number_rows"] == 10
+
+
+def test_get_parquet_metadata_empty_df(store):
+    df = pd.DataFrame()
+    mp = MetaPartition(label="test_label", data={"core": df},)
+    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
+    pq_metadata = meta_partition.get_parquet_metadata(store=store, table_name="core")
+    assert pq_metadata["number_rows"] == 0
+
+
+def test_get_parquet_metadata_empty_metapartition(store):
+    # TODO not sure if this makes sense
+    mp = MetaPartition(label="test_label")
+    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
+    pq_metadata = meta_partition.get_parquet_metadata(store=store, table_name="core")
+    assert pq_metadata["number_rows"] is None

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1654,7 +1654,8 @@ def test_get_parquet_metadata(store):
 
     actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
     actual.drop(labels="serialized_size", axis=1, inplace=True)
-    actual.drop(labels="row_group_byte_size", axis=1, inplace=True)
+    actual.drop(labels="row_group_compressed_size", axis=1, inplace=True)
+    actual.drop(labels="row_group_uncompressed_size", axis=1, inplace=True)
 
     expected = pd.DataFrame(
         {
@@ -1675,7 +1676,13 @@ def test_get_parquet_metadata_empty_df(store):
 
     actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
     actual.drop(
-        columns=["serialized_size", "row_group_byte_size"], axis=1, inplace=True
+        columns=[
+            "serialized_size",
+            "row_group_compressed_size",
+            "row_group_uncompressed_size",
+        ],
+        axis=1,
+        inplace=True,
     )
 
     expected = pd.DataFrame(
@@ -1701,7 +1708,13 @@ def test_get_parquet_metadata_row_group_size(store):
     )
     actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
     actual.drop(
-        columns=["serialized_size", "row_group_byte_size"], axis=1, inplace=True
+        columns=[
+            "serialized_size",
+            "row_group_compressed_size",
+            "row_group_uncompressed_size",
+        ],
+        axis=1,
+        inplace=True,
     )
 
     expected = pd.DataFrame(


### PR DESCRIPTION
The idea is to collect the parquet metadata for each MetaPartition and derive interesting numbers from it. First shot is to have an interface function which only returns a dataframe with interesting numbers.
We could think about to extending this to something report-like including nice (and meaningful) plots, if we want to.