### PR TITLE
Improve performance for index remove partitions

### DIFF
--- a/asv_bench/benchmarks/index.py
+++ b/asv_bench/benchmarks/index.py
@@ -66,6 +66,12 @@ class Index(IndexBase):
     )
     param_names = ["number_values", "number_partitions", "dtype"]
 
+    def time_remove_partitions_inplace(
+        self, number_values, number_partitions, arrow_type
+    ):
+        partitions_to_remove = self.partition_values[len(self.partition_values) // 2 :]
+        self.ktk_index.remove_partitions(partitions_to_remove, inplace=True)
+
     def time_load_index(self, number_values, number_partitions, arrow_type):
         self.ktk_index_not_loaded.load(self.store)
 


### PR DESCRIPTION
The current implementation could take half an hour or so for somewhat larger datasets (20k partitions, 1M entries in index, removing half the partitions). The new implementation provides a speedup in this case of about 1000x.