### PR TITLE
make `store___iter` use `update__iter`, small re-factoring

### DIFF
--- a/kartothek/core/factory.py
+++ b/kartothek/core/factory.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, Optional, TypeVar, cast
 
 from kartothek.core.dataset import DatasetMetadata, DatasetMetadataBase
 from kartothek.core.utils import _check_callable
+from kartothek.core.uuid import gen_uuid
 
 if TYPE_CHECKING:
     from simplekv import KeyValueStore
@@ -16,10 +17,17 @@ def _ensure_factory(
     factory: Optional["DatasetFactory"],
     load_dataset_metadata: bool,
     load_schema: bool = True,
+    gen_uuid_if_none: bool = False,
 ) -> "DatasetFactory":
+
     if store is None and dataset_uuid is None and factory is not None:
         return factory
-    elif store is not None and dataset_uuid is not None and factory is None:
+    elif store is not None and factory is None:
+        if dataset_uuid is None:
+            if gen_uuid_if_none:
+                dataset_uuid = gen_uuid()
+            else:
+                raise ValueError("Missing `dataset_uuid`.")
         return DatasetFactory(
             dataset_uuid=dataset_uuid,
             store_factory=store,

--- a/kartothek/io_components/update.py
+++ b/kartothek/io_components/update.py
@@ -7,6 +7,7 @@ update of the content of existing partitions.
 
 
 from kartothek.core.index import PartitionIndex
+from kartothek.core.naming import DEFAULT_METADATA_STORAGE_FORMAT
 from kartothek.io_components.utils import _instantiate_store
 from kartothek.io_components.write import store_dataset_from_partitions
 
@@ -28,6 +29,7 @@ def update_dataset_from_partitions(
     delete_scope,
     metadata,
     metadata_merger,
+    metadata_storage_format=DEFAULT_METADATA_STORAGE_FORMAT,
 ):
     store = _instantiate_store(store_factory)
 
@@ -52,6 +54,7 @@ def update_dataset_from_partitions(
         metadata_merger=metadata_merger,
         update_dataset=ds_factory,
         remove_partitions=remove_partitions,
+        metadata_storage_format=metadata_storage_format,
     )
 
     return new_dataset

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,13 +137,15 @@ def mock_default_metadata_version(mocker, backend_identifier):
             # passed through this mock function
             raise AssertionError("Traversed through mock. Original error: {}".format(e))
 
-    mocker.patch(
-        "kartothek.io.{backend_identifier}.parse_input_to_metapartition".format(
-            backend_identifier=backend_identifier
-        ),
-        patched__parse_input_to_metapartition,
-    )
-
+    try:
+        mocker.patch(
+            "kartothek.io.{backend_identifier}.parse_input_to_metapartition".format(
+                backend_identifier=backend_identifier
+            ),
+            patched__parse_input_to_metapartition,
+        )
+    except AttributeError:  # function not imported for this backend
+        pass
     return mock_metadata_version
 
 


### PR DESCRIPTION
Small re-factoring to decrease the amount of copied code.

In particular, `store_dataframes_as_dataset__iter` now uses `update_dataset_from_dataframes__iter` under the hood.
Also added `factory` as an optional kwarg to `store_dataframes_as_dataset__iter`.

This should also make it easier to implement `store_dataset_from_ddf` in the future thanks to the function `check_dataset_creation_constraints`