### PR TITLE
Add hash_dataset and make dataframe payload compression functions public

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,10 @@ Changelog
 Version 3.14.0 (2020-XX-YY)
 ===========================
 
+New functionality
+^^^^^^^^^^^^^^^^^
+* Add ``hash_dataset`` functionality
+
 Improvements
 ^^^^^^^^^^^^
 
@@ -13,6 +17,7 @@ Improvements
 
 Version 3.13.1 (2020-08-04)
 ===========================
+
 * Fix evaluation of "OR"-connected predicates (#295)
 
 Version 3.13.0 (2020-07-30)
@@ -34,6 +39,7 @@ New functionality
 * Basic Features - Extend, Query, Remove(Partitions),
   Delete (can delete entire datasets/cube), API, CLI, Core and IO features.
 * Advanced Features - Multi-Dataset with Single Table, Explicit physical Partitions, Seed based join system.
+
 
 Version 3.11.0 (2020-07-15)
 ===========================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -101,6 +101,17 @@ This is the most user friendly interface of the dask containers and offers direc
 
     read_dataset_as_ddf
     update_dataset_from_ddf
+    collect_dataset_metadata
+    hash_dataset
+
+.. currentmodule:: kartothek.io.dask.compression
+
+.. autosummary::
+
+    pack_payload_pandas
+    pack_payload
+    unpack_payload_pandas
+    unpack_payload
 
 Bag
 ^^^

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -1,6 +1,5 @@
-import logging
 from functools import partial
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional
 
 import dask.array as da
 import dask.dataframe as dd
@@ -9,6 +8,7 @@ import pandas as pd
 from dask.delayed import Delayed
 from simplekv import KeyValueStore
 
+from kartothek.io.dask.compression import pack_payload, unpack_payload_pandas
 from kartothek.io_components.metapartition import (
     MetaPartition,
     parse_input_to_metapartition,
@@ -19,11 +19,9 @@ from kartothek.serialization import DataFrameSerializer
 from ._utils import map_delayed
 
 StoreFactoryType = Callable[[], KeyValueStore]
-_logger = logging.getLogger()
+
 
 _KTK_HASH_BUCKET = "__KTK_HASH_BUCKET"
-
-_PAYLOAD_COL = "__ktk_shuffle_payload"
 
 
 def _hash_bucket(df: pd.DataFrame, subset: List[str], num_buckets: int):
@@ -41,136 +39,6 @@ def _hash_bucket(df: pd.DataFrame, subset: List[str], num_buckets: int):
     mask = available_bit_widths > np.log2(num_buckets)
     bit_width = min(available_bit_widths[mask])
     return df.assign(**{_KTK_HASH_BUCKET: buckets.astype(f"uint{bit_width}")})
-
-
-def pack_payload_pandas(partition: pd.DataFrame, group_key: List[str]) -> pd.DataFrame:
-    try:
-        # Technically distributed is an optional dependency
-        from distributed.protocol import serialize_bytes
-    except ImportError:
-        _logger.warning(
-            "Shuffle payload columns cannot be compressed since distributed is not installed."
-        )
-        return partition
-
-    if partition.empty:
-        res = partition[group_key]
-        res[_PAYLOAD_COL] = b""
-    else:
-        res = partition.groupby(
-            group_key,
-            sort=False,
-            observed=True,
-            # Keep the as_index s.t. the group values are not dropped. With this
-            # the behaviour seems to be consistent along pandas versions
-            as_index=True,
-        ).apply(lambda x: pd.Series({_PAYLOAD_COL: serialize_bytes(x)}))
-
-        res = res.reset_index()
-    return res
-
-
-def pack_payload(df: dd.DataFrame, group_key: Union[List[str], str]) -> dd.DataFrame:
-    """
-    Pack all payload columns (everything except of group_key) into a single
-    columns. This column will contain a single byte string containing the
-    serialized and compressed payload data. The payload data is just dead weight
-    when reshuffling. By compressing it once before the shuffle starts, this
-    saves a lot of memory and network/disk IO.
-
-    Example::
-
-        >>> import pandas as pd
-        ... import dask.dataframe as dd
-        ... from dask.dataframe.shuffle import pack_payload
-        ...
-        ... df = pd.DataFrame({"A": [1, 1] * 2 + [2, 2] * 2 + [3, 3] * 2, "B": range(12)})
-        ... ddf = dd.from_pandas(df, npartitions=2)
-
-        >>> ddf.partitions[0].compute()
-
-        A  B
-        0  1  0
-        1  1  1
-        2  1  2
-        3  1  3
-        4  2  4
-        5  2  5
-
-        >>> pack_payload(ddf, "A").partitions[0].compute()
-
-        A                               __dask_payload_bytes
-        0  1  b'\x03\x00\x00\x00\x00\x00\x00\x00)\x00\x00\x03...
-        1  2  b'\x03\x00\x00\x00\x00\x00\x00\x00)\x00\x00\x03...
-
-
-    See also https://github.com/dask/dask/pull/6259
-
-    """
-
-    if (
-        # https://github.com/pandas-dev/pandas/issues/34455
-        isinstance(df._meta.index, pd.Float64Index)
-        # TODO: Try to find out what's going on an file a bug report
-        # For datetime indices the apply seems to be corrupt
-        # s.t. apply(lambda x:x) returns different values
-        or isinstance(df._meta.index, pd.DatetimeIndex)
-    ):
-        return df
-
-    if not isinstance(group_key, list):
-        group_key = [group_key]
-
-    packed_meta = df._meta[group_key]
-    packed_meta[_PAYLOAD_COL] = b""
-
-    _pack_payload = partial(pack_payload_pandas, group_key=group_key)
-
-    return df.map_partitions(_pack_payload, meta=_pack_payload(df._meta))
-
-
-def unpack_payload_pandas(
-    partition: pd.DataFrame, unpack_meta: pd.DataFrame
-) -> pd.DataFrame:
-    """
-    Revert ``pack_payload_pandas`` and restore packed payload
-
-    unpack_meta:
-        A dataframe indicating the sc
-    """
-    try:
-        # Technically distributed is an optional dependency
-        from distributed.protocol import deserialize_bytes
-    except ImportError:
-        _logger.warning(
-            "Shuffle payload columns cannot be compressed since distributed is not installed."
-        )
-        return partition
-
-    if partition.empty:
-        return unpack_meta.iloc[:0]
-
-    mapped = partition[_PAYLOAD_COL].map(deserialize_bytes)
-
-    return pd.concat(mapped.values, copy=False, ignore_index=True)
-
-
-def unpack_payload(df: dd.DataFrame, unpack_meta: pd.DataFrame) -> dd.DataFrame:
-    """Revert payload packing of ``pack_payload`` and restores full dataframe."""
-
-    if (
-        # https://github.com/pandas-dev/pandas/issues/34455
-        isinstance(df._meta.index, pd.Float64Index)
-        # TODO: Try to find out what's going on an file a bug report
-        # For datetime indices the apply seems to be corrupt
-        # s.t. apply(lambda x:x) returns different values
-        or isinstance(df._meta.index, pd.DatetimeIndex)
-    ):
-        return df
-
-    return df.map_partitions(
-        unpack_payload_pandas, unpack_meta=unpack_meta, meta=unpack_meta
-    )
 
 
 def update_dask_partitions_shuffle(
@@ -247,8 +115,6 @@ def update_dask_partitions_shuffle(
     ddf = ddf.map_partitions(_hash_bucket, bucket_by, num_buckets, meta=meta)
     group_cols.append(_KTK_HASH_BUCKET)
 
-    packed_meta = ddf._meta[group_cols]
-    packed_meta[_PAYLOAD_COL] = b""
     unpacked_meta = ddf._meta
 
     ddf = pack_payload(ddf, group_key=group_cols)

--- a/kartothek/io/dask/compression.py
+++ b/kartothek/io/dask/compression.py
@@ -1,0 +1,139 @@
+import logging
+from functools import partial
+from typing import List, Union
+
+import dask.dataframe as dd
+import pandas as pd
+
+_logger = logging.getLogger()
+_PAYLOAD_COL = "__ktk_shuffle_payload"
+
+
+def pack_payload_pandas(partition: pd.DataFrame, group_key: List[str]) -> pd.DataFrame:
+    try:
+        # Technically distributed is an optional dependency
+        from distributed.protocol import serialize_bytes
+    except ImportError:
+        _logger.warning(
+            "Shuffle payload columns cannot be compressed since distributed is not installed."
+        )
+        return partition
+
+    if partition.empty:
+        res = partition[group_key]
+        res[_PAYLOAD_COL] = b""
+    else:
+        res = partition.groupby(
+            group_key,
+            sort=False,
+            observed=True,
+            # Keep the as_index s.t. the group values are not dropped. With this
+            # the behaviour seems to be consistent along pandas versions
+            as_index=True,
+        ).apply(lambda x: pd.Series({_PAYLOAD_COL: serialize_bytes(x)}))
+
+        res = res.reset_index()
+    return res
+
+
+def pack_payload(df: dd.DataFrame, group_key: Union[List[str], str]) -> dd.DataFrame:
+    """
+    Pack all payload columns (everything except of group_key) into a single
+    columns. This column will contain a single byte string containing the
+    serialized and compressed payload data. The payload data is just dead weight
+    when reshuffling. By compressing it once before the shuffle starts, this
+    saves a lot of memory and network/disk IO.
+
+    Example::
+
+        >>> import pandas as pd
+        ... import dask.dataframe as dd
+        ... from dask.dataframe.shuffle import pack_payload
+        ...
+        ... df = pd.DataFrame({"A": [1, 1] * 2 + [2, 2] * 2 + [3, 3] * 2, "B": range(12)})
+        ... ddf = dd.from_pandas(df, npartitions=2)
+
+        >>> ddf.partitions[0].compute()
+
+        A  B
+        0  1  0
+        1  1  1
+        2  1  2
+        3  1  3
+        4  2  4
+        5  2  5
+
+        >>> pack_payload(ddf, "A").partitions[0].compute()
+
+        A                               __dask_payload_bytes
+        0  1  b'\x03\x00\x00\x00\x00\x00\x00\x00)\x00\x00\x03...
+        1  2  b'\x03\x00\x00\x00\x00\x00\x00\x00)\x00\x00\x03...
+
+
+    See also https://github.com/dask/dask/pull/6259
+
+    """
+
+    if (
+        # https://github.com/pandas-dev/pandas/issues/34455
+        isinstance(df._meta.index, pd.Float64Index)
+        # TODO: Try to find out what's going on an file a bug report
+        # For datetime indices the apply seems to be corrupt
+        # s.t. apply(lambda x:x) returns different values
+        or isinstance(df._meta.index, pd.DatetimeIndex)
+    ):
+        return df
+
+    if not isinstance(group_key, list):
+        group_key = [group_key]
+
+    packed_meta = df._meta[group_key]
+    packed_meta[_PAYLOAD_COL] = b""
+
+    _pack_payload = partial(pack_payload_pandas, group_key=group_key)
+
+    return df.map_partitions(_pack_payload, meta=packed_meta)
+
+
+def unpack_payload_pandas(
+    partition: pd.DataFrame, unpack_meta: pd.DataFrame
+) -> pd.DataFrame:
+    """
+    Revert ``pack_payload_pandas`` and restore packed payload
+
+    unpack_meta:
+        A dataframe indicating the schema of the unpacked data. This will be returned in case the input is empty
+    """
+    try:
+        # Technically distributed is an optional dependency
+        from distributed.protocol import deserialize_bytes
+    except ImportError:
+        _logger.warning(
+            "Shuffle payload columns cannot be compressed since distributed is not installed."
+        )
+        return partition
+
+    if partition.empty:
+        return unpack_meta.iloc[:0]
+
+    mapped = partition[_PAYLOAD_COL].map(deserialize_bytes)
+
+    return pd.concat(mapped.values, copy=False, ignore_index=True)
+
+
+def unpack_payload(df: dd.DataFrame, unpack_meta: pd.DataFrame) -> dd.DataFrame:
+    """Revert payload packing of ``pack_payload`` and restores full dataframe."""
+
+    if (
+        # https://github.com/pandas-dev/pandas/issues/34455
+        isinstance(df._meta.index, pd.Float64Index)
+        # TODO: Try to find out what's going on an file a bug report
+        # For datetime indices the apply seems to be corrupt
+        # s.t. apply(lambda x:x) returns different values
+        or isinstance(df._meta.index, pd.DatetimeIndex)
+    ):
+        return df
+
+    return df.map_partitions(
+        unpack_payload_pandas, unpack_meta=unpack_meta, meta=unpack_meta
+    )

--- a/tests/io/dask/dataframe/test_compression.py
+++ b/tests/io/dask/dataframe/test_compression.py
@@ -1,0 +1,88 @@
+import dask.dataframe as dd
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from kartothek.io.dask.compression import (
+    pack_payload,
+    pack_payload_pandas,
+    unpack_payload,
+    unpack_payload_pandas,
+)
+
+
+def test_pack_payload(df_all_types):
+    # For a single row dataframe the packing actually has a few more bytes
+    df = dd.from_pandas(
+        pd.concat([df_all_types] * 10, ignore_index=True), npartitions=3
+    )
+    size_before = df.memory_usage(deep=True).sum()
+
+    packed_df = pack_payload(df, group_key=list(df.columns[-2:]))
+
+    size_after = packed_df.memory_usage(deep=True).sum()
+
+    assert (size_after < size_before).compute()
+
+
+def test_pack_payload_empty(df_all_types):
+    # For a single row dataframe the packing actually has a few more bytes
+    df_empty = dd.from_pandas(df_all_types.iloc[:0], npartitions=1)
+
+    group_key = [df_all_types.columns[-1]]
+    pdt.assert_frame_equal(
+        df_empty.compute(),
+        unpack_payload(
+            pack_payload(df_empty, group_key=group_key), unpack_meta=df_empty._meta
+        ).compute(),
+    )
+
+
+def test_pack_payload_pandas(df_all_types):
+    # For a single row dataframe the packing actually has a few more bytes
+    df = pd.concat([df_all_types] * 10, ignore_index=True)
+    size_before = df.memory_usage(deep=True).sum()
+
+    packed_df = pack_payload_pandas(df, group_key=list(df.columns[-2:]))
+
+    size_after = packed_df.memory_usage(deep=True).sum()
+
+    assert size_after < size_before
+
+
+def test_pack_payload_pandas_empty(df_all_types):
+    # For a single row dataframe the packing actually has a few more bytes
+    df_empty = df_all_types.iloc[:0]
+
+    group_key = [df_all_types.columns[-1]]
+    pdt.assert_frame_equal(
+        df_empty,
+        unpack_payload_pandas(
+            pack_payload_pandas(df_empty, group_key=group_key), unpack_meta=df_empty
+        ),
+    )
+
+
+@pytest.mark.parametrize("num_group_cols", [1, 4])
+def test_pack_payload_roundtrip(df_all_types, num_group_cols):
+    group_key = list(df_all_types.columns[-num_group_cols:])
+    df_all_types = dd.from_pandas(df_all_types, npartitions=2)
+    pdt.assert_frame_equal(
+        df_all_types.compute(),
+        unpack_payload(
+            pack_payload(df_all_types, group_key=group_key),
+            unpack_meta=df_all_types._meta,
+        ).compute(),
+    )
+
+
+@pytest.mark.parametrize("num_group_cols", [1, 4])
+def test_pack_payload_pandas_roundtrip(df_all_types, num_group_cols):
+    group_key = list(df_all_types.columns[-num_group_cols:])
+    pdt.assert_frame_equal(
+        df_all_types,
+        unpack_payload_pandas(
+            pack_payload_pandas(df_all_types, group_key=group_key),
+            unpack_meta=df_all_types,
+        ),
+    )

--- a/tests/io/dask/dataframe/test_hashing.py
+++ b/tests/io/dask/dataframe/test_hashing.py
@@ -1,0 +1,73 @@
+import pandas as pd
+import pandas.testing as pdt
+
+from kartothek.io.dask.dataframe import hash_dataset
+
+
+def test_hash_dataset(dataset_with_index_factory):
+    hh = (
+        hash_dataset(factory=dataset_with_index_factory)
+        .compute()
+        .reset_index(drop=True)
+    )
+
+    expected = pd.Series([11462879952839863487, 12568779102514529673], dtype="uint64")
+    assert len(hh) == len(dataset_with_index_factory.partitions)
+    pdt.assert_series_equal(hh, expected)
+
+
+def test_hash_dataset_subset(dataset_with_index_factory):
+    hh = (
+        hash_dataset(factory=dataset_with_index_factory, subset=["TARGET"])
+        .compute()
+        .reset_index(drop=True)
+    )
+
+    expected = pd.Series([11358988112447789330, 826468140851422801], dtype="uint64")
+    assert len(hh) == len(dataset_with_index_factory.partitions)
+    pdt.assert_series_equal(hh, expected)
+
+
+def test_hash_dataset_group_keys(dataset_with_index_factory):
+
+    group_keys = ["L"]
+    hh = hash_dataset(
+        factory=dataset_with_index_factory, group_key=group_keys
+    ).compute()
+
+    expected = pd.Series(
+        [11462879952839863487, 12568779102514529673],
+        dtype="uint64",
+        index=pd.Index([1, 2], name="L"),
+    )
+    pdt.assert_series_equal(hh, expected)
+
+
+def test_hash_dataset_group_keys_subset(dataset_with_index_factory):
+
+    group_keys = ["P"]
+    hh = hash_dataset(
+        factory=dataset_with_index_factory, group_key=group_keys, subset=["TARGET"]
+    ).compute()
+
+    expected = pd.Series(
+        [11358988112447789330, 826468140851422801],
+        index=pd.Index([1, 2], name="P"),
+        dtype="uint64",
+    )
+    pdt.assert_series_equal(hh, expected)
+
+
+def test_hash_dataset_group_keys_subset_subset_groupkey(dataset_with_index_factory):
+
+    group_keys = ["P"]
+    hh = hash_dataset(
+        factory=dataset_with_index_factory, group_key=group_keys, subset=["P", "TARGET"]
+    ).compute()
+
+    expected = pd.Series(
+        [7554402398462747209, 1687604933839263903],
+        index=pd.Index([1, 2], name="P"),
+        dtype="uint64",
+    )
+    pdt.assert_series_equal(hh, expected)

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -11,14 +11,7 @@ import pandas.testing as pdt
 import pytest
 
 from kartothek.core.factory import DatasetFactory
-from kartothek.io.dask._update import (
-    _KTK_HASH_BUCKET,
-    _hash_bucket,
-    pack_payload,
-    pack_payload_pandas,
-    unpack_payload,
-    unpack_payload_pandas,
-)
+from kartothek.io.dask._update import _KTK_HASH_BUCKET, _hash_bucket
 from kartothek.io.dask.dataframe import update_dataset_from_ddf
 from kartothek.io.iter import read_dataset_as_dataframes__iterator
 from kartothek.io.testing.update import *  # noqa
@@ -335,80 +328,3 @@ def test_update_dataset_from_ddf_empty(store_factory, shuffle):
             shuffle=shuffle,
             partition_on=["a"],
         ).compute()
-
-
-def test_pack_payload(df_all_types):
-    # For a single row dataframe the packing actually has a few more bytes
-    df = dd.from_pandas(
-        pd.concat([df_all_types] * 10, ignore_index=True), npartitions=3
-    )
-    size_before = df.memory_usage(deep=True).sum()
-
-    packed_df = pack_payload(df, group_key=list(df.columns[-2:]))
-
-    size_after = packed_df.memory_usage(deep=True).sum()
-
-    assert (size_after < size_before).compute()
-
-
-def test_pack_payload_empty(df_all_types):
-    # For a single row dataframe the packing actually has a few more bytes
-    df_empty = dd.from_pandas(df_all_types.iloc[:0], npartitions=1)
-
-    group_key = [df_all_types.columns[-1]]
-    pdt.assert_frame_equal(
-        df_empty.compute(),
-        unpack_payload(
-            pack_payload(df_empty, group_key=group_key), unpack_meta=df_empty._meta
-        ).compute(),
-    )
-
-
-def test_pack_payload_pandas(df_all_types):
-    # For a single row dataframe the packing actually has a few more bytes
-    df = pd.concat([df_all_types] * 10, ignore_index=True)
-    size_before = df.memory_usage(deep=True).sum()
-
-    packed_df = pack_payload_pandas(df, group_key=list(df.columns[-2:]))
-
-    size_after = packed_df.memory_usage(deep=True).sum()
-
-    assert size_after < size_before
-
-
-def test_pack_payload_pandas_empty(df_all_types):
-    # For a single row dataframe the packing actually has a few more bytes
-    df_empty = df_all_types.iloc[:0]
-
-    group_key = [df_all_types.columns[-1]]
-    pdt.assert_frame_equal(
-        df_empty,
-        unpack_payload_pandas(
-            pack_payload_pandas(df_empty, group_key=group_key), unpack_meta=df_empty
-        ),
-    )
-
-
-@pytest.mark.parametrize("num_group_cols", [1, 4])
-def test_pack_payload_roundtrip(df_all_types, num_group_cols):
-    group_key = list(df_all_types.columns[-num_group_cols:])
-    df_all_types = dd.from_pandas(df_all_types, npartitions=2)
-    pdt.assert_frame_equal(
-        df_all_types.compute(),
-        unpack_payload(
-            pack_payload(df_all_types, group_key=group_key),
-            unpack_meta=df_all_types._meta,
-        ).compute(),
-    )
-
-
-@pytest.mark.parametrize("num_group_cols", [1, 4])
-def test_pack_payload_pandas_roundtrip(df_all_types, num_group_cols):
-    group_key = list(df_all_types.columns[-num_group_cols:])
-    pdt.assert_frame_equal(
-        df_all_types,
-        unpack_payload_pandas(
-            pack_payload_pandas(df_all_types, group_key=group_key),
-            unpack_meta=df_all_types,
-        ),
-    )


### PR DESCRIPTION
# Description:

This should allow for partition or group based hashing of the data and should make things easier if we need to verify data integrity of some sorts.

I also moved the pack/unpack logic to compress the payload into a public package. I think this can be quite useful outside of "standard" kartothek workflows as long as it's not part of dask, yet