### PR TITLE
Fix predicate parsing for "OR" predicates

### DIFF
--- a/kartothek/core/index.py
+++ b/kartothek/core/index.py
@@ -451,13 +451,34 @@ class IndexBase(CopyMixin):
         Parameters
         ----------
         compact:
-            If True, the index will be unique and the Series.values will be a list of partitions/values
+            If True, ensures that the index will be unique. If there a multiple partition values per index, there values
+            will be compacted into a list (see Examples section).
         partitions_as_index:
-            If True, the relation between index values and partitions will be reverted for the output
+            If True, the relation between index values and partitions will be reverted for the output dataframe:
+            partition values will be used as index and the indices will be mapped to the partitions.
         predicates:
             A list of predicates. If a literal within the provided predicates
             references a column which is not part of this index, this literal is
             interpreted as True.
+
+        Examples:
+
+        .. code::
+        >>> index1 = ExplicitSecondaryIndex(
+        ...     column="col", index_dct={1: ["part_1", "part_2"]}, dtype=pa.int64()
+        ... )
+        >>> index1
+            col
+            1    part_1
+            1    part_2
+        >>> index1.as_flat_series(compact=True)
+            col
+            1    [part_1, part_2]
+        >>> index1.as_flat_series(partitions_as_index=True)
+            partition
+            part_1    1
+            part_2    1
+
         """
         check_predicates(predicates)
         table = _index_dct_to_table(

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -601,6 +601,8 @@ class MetaPartition(Iterable):
         index_df = pd.DataFrame(index_df_dct)
 
         filtered_predicates = []
+        # We assume that indices on the partition level have been filtered out already in `dispatch_metapartitions`.
+        # `filtered_predicates` should only contain predicates that can be evaluated on parquet level
         for conjunction in split_predicates:
             predicates = [conjunction.key_part]
             if (

--- a/tests/serialization/test_filter.py
+++ b/tests/serialization/test_filter.py
@@ -209,3 +209,32 @@ def test_filter_df_from_predicates_empty_in(value):
     actual = filter_df_from_predicates(df, predicates)
     expected = df.iloc[[]]
     pdt.assert_frame_equal(actual, expected, check_categorical=False)
+
+
+def test_filter_df_from_predicates_or_predicates():
+    df = pd.DataFrame({"A": range(10), "B": ["A", "B"] * 5, "C": range(-10, 0)})
+
+    predicates = [[("A", "<", 3)], [("A", ">", 5)], [("B", "==", "non-existent")]]
+    actual = filter_df_from_predicates(df, predicates)
+    expected = pd.DataFrame(
+        data={
+            "A": [0, 1, 2, 6, 7, 8, 9],
+            "B": ["A", "B", "A", "A", "B", "A", "B"],
+            "C": [-10, -9, -8, -4, -3, -2, -1],
+        },
+        index=[0, 1, 2, 6, 7, 8, 9],
+    )
+    pdt.assert_frame_equal(actual, expected)
+
+    predicates = [[("A", "<", 3)], [("A", ">", 5)], [("B", "==", "B")]]
+    actual = filter_df_from_predicates(df, predicates)
+    # row for (A == 4) is filtered out
+    expected = pd.DataFrame(
+        data={
+            "A": [0, 1, 2, 3, 5, 6, 7, 8, 9],
+            "B": ["A", "B", "A", "B", "B", "A", "B", "A", "B"],
+            "C": [-10, -9, -8, -7, -5, -4, -3, -2, -1],
+        },
+        index=[0, 1, 2, 3, 5, 6, 7, 8, 9],
+    )
+    pdt.assert_frame_equal(actual, expected)


### PR DESCRIPTION
Predciate evaluation of "OR" connected predicates was not implemented correctly. This could lead to too many files returned by `dispatch_metapartitions`.

Closes #295

