### PR TITLE
Update pandas 1.1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+Version 3.14.0 (2020-XX-YY)
+===========================
+
+Improvements
+^^^^^^^^^^^^
+
+* Expand ``pandas`` version pin to include 1.1.X
+
+
 Version 3.13.1 (2020-08-04)
 ===========================
 * Fix evaluation of "OR"-connected predicates (#295)

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -3,7 +3,7 @@ decorator
 msgpack-python>=0.5.2
 # Currently dask and numpy==1.16.0 clash
 numpy!=1.15.0,!=1.16.0
-pandas>=0.23.0, !=1.0.0 , <1.1 # https://github.com/pandas-dev/pandas/issues/31441
+pandas>=0.23.0, !=1.0.0
 # pyarrow==0.14.0 breaks kartothek
 pyarrow>=0.13.0, !=0.14.0, <0.18.0 # Keep upper bound pinned until we see non-breaking releases in the future
 simplejson

--- a/kartothek/io/testing/read.py
+++ b/kartothek/io/testing/read.py
@@ -81,7 +81,7 @@ def use_dataset_factory(request, dates_as_object):
 
 def _strip_unused_categoricals(df):
     for col in df.columns:
-        if pd.api.types.is_categorical(df[col]):
+        if pd.api.types.is_categorical_dtype(df[col]):
             df[col] = df[col].cat.remove_unused_categories()
     return df
 

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -288,7 +288,7 @@ def align_categories(dfs, categoricals):
         largest_df_categories = set()
         for ix, df in enumerate(dfs):
             ser = df[column]
-            if not pd.api.types.is_categorical(ser):
+            if not pd.api.types.is_categorical_dtype(ser):
                 cats = ser.unique()
                 LOGGER.info(
                     "Encountered non-categorical type where categorical was expected\n"
@@ -339,7 +339,7 @@ def sort_values_categorical(df, column):
             column = column[0]
         else:
             raise ValueError("Can only sort after a single column")
-    if pd.api.types.is_categorical(df[column]):
+    if pd.api.types.is_categorical_dtype(df[column]):
         cat_accesor = df[column].cat
         df[column] = cat_accesor.reorder_categories(
             sorted(cat_accesor.categories), ordered=True

--- a/kartothek/serialization/_generic.py
+++ b/kartothek/serialization/_generic.py
@@ -302,7 +302,7 @@ def filter_df_from_predicates(
 
 
 def _handle_categorical_data(array_like, require_ordered):
-    if require_ordered and pd.api.types.is_categorical(array_like):
+    if require_ordered and pd.api.types.is_categorical_dtype(array_like):
         if isinstance(array_like, pd.Categorical):
             categorical = array_like
         else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ decorator
 msgpack>=0.5.2
 # Currently dask and numpy==1.16.0 clash
 numpy!=1.15.0,!=1.16.0
-pandas>=0.23.0, !=1.0.0 , <1.1 # https://github.com/pandas-dev/pandas/issues/31441
+pandas>=0.23.0, !=1.0.0
 # pyarrow==0.14.0 breaks kartothek
 pyarrow>=0.13.0, !=0.14.0, <0.18.0 # Keep upper bound pinned until we see non-breaking releases in the future
 simplejson

--- a/tests/io/dask/dataframe/test_read.py
+++ b/tests/io/dask/dataframe/test_read.py
@@ -63,7 +63,7 @@ def _read_as_ddf(
     def extract_dataframe(ix):
         df = ddf.iloc[[ix]].copy()
         for col in df.columns:
-            if pd.api.types.is_categorical(df[col]):
+            if pd.api.types.is_categorical_dtype(df[col]):
                 df[col] = df[col].cat.remove_unused_categories()
         return df.reset_index(drop=True)
 

--- a/tests/serialization/test_dataframe.py
+++ b/tests/serialization/test_dataframe.py
@@ -523,10 +523,14 @@ def test_predicate_pushdown_null_col(
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         predicates=predicates,
     )
+    check_datetimelike_compat = (
+        isinstance(value, pd.Timestamp) and not serialiser.type_stable
+    )
     pdt.assert_frame_equal(
         result.reset_index(drop=True),
         expected.reset_index(drop=True),
         check_dtype=serialiser.type_stable,
+        check_datetimelike_compat=check_datetimelike_compat,
     )
 
 

--- a/tests/serialization/test_filter.py
+++ b/tests/serialization/test_filter.py
@@ -160,7 +160,7 @@ def test_filter_df_from_predicates(op, data, value):
 
     predicates = [[("A", op, value)]]
     actual = filter_df_from_predicates(df, predicates)
-    if pd.api.types.is_categorical(df["A"]):
+    if pd.api.types.is_categorical_dtype(df["A"]):
         df["A"] = df["A"].astype(df["A"].cat.as_ordered().dtype)
     if isinstance(value, datetime.date) and (df["A"].dtype == "datetime64[ns]"):
         # silence pandas warning
@@ -183,7 +183,7 @@ def test_filter_df_from_predicates_bool(op, col):
     value = True
     predicates = [[(col, op, value)]]
     actual = filter_df_from_predicates(df, predicates)
-    if pd.api.types.is_categorical(df[col]):
+    if pd.api.types.is_categorical_dtype(df[col]):
         df[col] = df[col].astype(df[col].cat.as_ordered().dtype)
     expected = eval(f"df[df[col] {op} value]")
     pdt.assert_frame_equal(actual, expected, check_categorical=False)


### PR DESCRIPTION
# Description:

Addressing future warnings `is_categorical` and fix tests/adapt to fixed `assert_series_equal` behavior.



- [x] Changelog entry
