### PR TITLE
reduce memory consumption during index write

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 3.14.x (unreleased)
+===========================
+
+Improvements
+^^^^^^^^^^^^
+* Reduce memory consumption during index write.
+
+
 Version 3.14.0 (2020-08-27)
 ===========================
 

--- a/kartothek/core/index.py
+++ b/kartothek/core/index.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 from simplekv import KeyValueStore
+from toolz.itertoolz import partition_all
 
 import kartothek.core._time
 from kartothek.core import naming
@@ -688,9 +689,27 @@ class ExplicitSecondaryIndex(IndexBase):
                 timestamp=quote(self.creation_time.isoformat()),
             )
 
-        table = _index_dct_to_table(self.index_dct, self.column, self.dtype)
+        # The arrow representation of index_dct requires a large amount of memory because strings are duplidated and
+        # flattened into the buffer. To avoid a high peak memory usage, split the index_dct into chunks and only convert
+        # one chunk a time to arrow.
+        parts_iter = partition_all(10_000, self.index_dct.items())
+
+        # Get first table explicit because its schema is required for ParquetWriter.
+        try:
+            table = _index_dct_to_table(dict(next(parts_iter)), self.column, self.dtype)
+        except StopIteration:
+            # index_dct was empty, just pass it entirely
+            table = _index_dct_to_table(self.index_dct, self.column, self.dtype)
+
         buf = pa.BufferOutputStream()
-        pq.write_table(table, buf)
+        with pq.ParquetWriter(buf, schema=table.schema) as writer:
+            writer.write_table(table)
+            del table
+
+            for part in parts_iter:
+                writer.write_table(
+                    _index_dct_to_table(dict(part), self.column, self.dtype)
+                )
 
         store.put(storage_key, buf.getvalue().to_pybytes())
         return storage_key
@@ -916,7 +935,7 @@ def _index_dct_to_table(index_dct: IndexDictType, column: str, dtype: pa.DataTyp
     else:
         labeled_array = pa.array(keys, type=dtype)
 
-    partition_array = pa.array(list(index_dct.values()))
+    partition_array = pa.array(list(index_dct.values()), type=pa.list_(pa.string()))
 
     return pa.Table.from_arrays(
         [labeled_array, partition_array], names=[column, _PARTITION_COLUMN_NAME]

--- a/kartothek/core/index.py
+++ b/kartothek/core/index.py
@@ -689,7 +689,7 @@ class ExplicitSecondaryIndex(IndexBase):
                 timestamp=quote(self.creation_time.isoformat()),
             )
 
-        # The arrow representation of index_dct requires a large amount of memory because strings are duplidated and
+        # The arrow representation of index_dct requires a large amount of memory because strings are duplicated and
         # flattened into the buffer. To avoid a high peak memory usage, split the index_dct into chunks and only convert
         # one chunk a time to arrow.
         parts_iter = partition_all(10_000, self.index_dct.items())

--- a/tests/core/test_index.py
+++ b/tests/core/test_index.py
@@ -834,3 +834,19 @@ def test_unload(with_index_dct):
 def test_fail_type_unsafe():
     with pytest.raises(ValueError, match="Trying to create non-typesafe index"):
         ExplicitSecondaryIndex(column="col", index_dct={})
+
+
+def test_index_large(store):
+    storage_key = "dataset_uuid/some_index.parquet"
+    index1 = ExplicitSecondaryIndex(
+        column="col",
+        index_dct={i: ["part_1"] for i in range(100_000)},
+        index_storage_key=storage_key,
+    )
+    key1 = index1.store(store, "dataset_uuid")
+
+    index2 = ExplicitSecondaryIndex(column="col", index_storage_key=key1).load(store)
+    assert index1 == index2
+
+    index3 = pickle.loads(pickle.dumps(index1))
+    assert index1 == index3


### PR DESCRIPTION
In a particular test case and a maxRSS background (aka usage before index creation) of
570MB this reduces maxRSS from 1.80GB to 970MB.