### PR TITLE
Allow URLs and stores to be passed explicitly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,13 +2,13 @@
 Changelog
 =========
 
-Version 3.14.x (unreleased)
+Version 3.15.0 (unreleased)
 ===========================
 
 Improvements
 ^^^^^^^^^^^^
 * Reduce memory consumption during index write.
-
+* Allow `simplekv` stores and `storefact` URLs to be passed explicitly as input for the `store` arguments
 
 Version 3.14.0 (2020-08-27)
 ===========================

--- a/docs/guide/cube/examples.rst
+++ b/docs/guide/cube/examples.rst
@@ -169,7 +169,7 @@ very comfortable way. It is possible to treat the entire cube as a single, large
 5         8   London      UK 2018-01-02  51.509865  -0.118092
 
 As you can see, we get a list of results back. This is because Kartothek Cube naturally supports partition-by semantic, which is
-more helpful for distributed backends like `Distributed`_ or `Yamal`_:
+more helpful for distributed backends like `Distributed`_:
 
 >>> dfs = query_cube(
 ...     cube=cube,
@@ -425,4 +425,3 @@ geodata++time/table/_common_metadata
 .. _Dask.Bag: https://docs.dask.org/en/latest/bag.html
 .. _Dask.DataFrame: https://docs.dask.org/en/latest/dataframe.html
 .. _simplekv: https://simplekv.readthedocs.io/
-.. _Yamal: https://software.blue-yonder.org/DynamicPricing/generic/yamal/latest/+doc/index.html

--- a/docs/guide/dask_indexing.rst
+++ b/docs/guide/dask_indexing.rst
@@ -10,15 +10,13 @@ Calculating a dask index is usually a very expensive operation which requires da
 
     import numpy as np
     import pandas as pd
-    from functools import partial
     from tempfile import TemporaryDirectory
-    from storefact import get_store_from_url
 
     from kartothek.io.eager import store_dataframes_as_dataset
 
     dataset_dir = TemporaryDirectory()
 
-    store_factory = partial(get_store_from_url, f"hfs://{dataset_dir.name}")
+    store_url = f"hfs://{dataset_dir.name}"
 
     df = pd.DataFrame(
         {
@@ -51,10 +49,10 @@ Calculating a dask index is usually a very expensive operation which requires da
         ddf_indexed.reset_index(),
         table="table",
         dataset_uuid="dataset_ddf_with_index",
-        store=store_factory,
+        store=store_url,
         partition_on="B",
     ).compute()
 
     read_dataset_as_ddf(
-        dataset_uuid=dm.uuid, store=store_factory, dask_index_on="B", table="table"
+        dataset_uuid=dm.uuid, store=store_url, dask_index_on="B", table="table"
     )

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -5,14 +5,12 @@ Setup a store
 
 .. ipython:: python
 
-    from storefact import get_store_from_url
-    from functools import partial
     from tempfile import TemporaryDirectory
 
     # You can, of course, also directly use S3, ABS or anything else
     # supported by :mod:`storefact`
     dataset_dir = TemporaryDirectory()
-    store_factory = partial(get_store_from_url, f"hfs://{dataset_dir.name}")
+    store_url = f"hfs://{dataset_dir.name}"
 
 
 .. ipython:: python
@@ -34,14 +32,12 @@ Setup a store
     }
 
     store_dataframes_as_dataset(
-        store=store_factory, dataset_uuid=dataset_uuid, dfs=[df], metadata=metadata
+        store=store_url, dataset_uuid=dataset_uuid, dfs=[df], metadata=metadata
     )
 
     # Load your data
     # By default the single dataframe is stored in the 'core' table
-    df_from_store = read_table(
-        store=store_factory, dataset_uuid=dataset_uuid, table="table"
-    )
+    df_from_store = read_table(store=store_url, dataset_uuid=dataset_uuid, table="table")
     df_from_store
 
 
@@ -77,7 +73,7 @@ Write
     #  which refers to the created dataset
     dataset = store_dataframes_as_dataset(
         dfs=input_list_of_partitions,
-        store=store_factory,
+        store=store_url,
         dataset_uuid="MyFirstDataset",
         metadata={"dataset": "metadata"},  #  This is optional dataset metadata
         metadata_version=4,
@@ -95,7 +91,7 @@ Read
 
     #  Create the pipeline with a minimal set of configs
     list_of_partitions = read_dataset_as_dataframes(
-        dataset_uuid="MyFirstDataset", store=store_factory
+        dataset_uuid="MyFirstDataset", store=store_url
     )
 
     # In case you were using the dataset created in the Write example
@@ -139,7 +135,7 @@ Write
     #  which refers to the created dataset
     dataset = store_dataframes_as_dataset__iter(
         input_list_of_partitions,
-        store=store_factory,
+        store=store_url,
         dataset_uuid="MyFirstDatasetIter",
         metadata={"dataset": "metadata"},  #  This is optional dataset metadata
         metadata_version=4,
@@ -156,7 +152,7 @@ Read
 
     #  Create the pipeline with a minimal set of configs
     list_of_partitions = read_dataset_as_dataframes__iterator(
-        dataset_uuid="MyFirstDatasetIter", store=store_factory
+        dataset_uuid="MyFirstDatasetIter", store=store_url
     )
     # the iter backend returns a generator object. In our case we want to look at
     # all partitions at once
@@ -203,7 +199,7 @@ Write
     # show the generated task graph.
     task = store_delayed_as_dataset(
         input_list_of_partitions,
-        store=store_factory,
+        store=store_url,
         dataset_uuid="MyFirstDatasetDask",
         metadata={"dataset": "metadata"},  #  This is optional dataset metadata
         metadata_version=4,
@@ -225,6 +221,6 @@ Read
     import pandas as pd
     from kartothek.io.dask.delayed import read_dataset_as_delayed
 
-    tasks = read_dataset_as_delayed(dataset_uuid="MyFirstDatasetDask", store=store_factory)
+    tasks = read_dataset_as_delayed(dataset_uuid="MyFirstDatasetDask", store=store_url)
     tasks
     dask.compute(tasks)

--- a/docs/guide/getting_started.rst
+++ b/docs/guide/getting_started.rst
@@ -63,7 +63,7 @@ what follows is the filepath).
 
     dataset_dir = TemporaryDirectory()
 
-    store_factory = partial(get_store_from_url, f"hfs://{dataset_dir.name}")
+    store_url = f"hfs://{dataset_dir.name}"
 
 .. admonition:: Storage locations
 
@@ -73,13 +73,6 @@ what follows is the filepath).
     - ``hfs``: Local filesystem
     - ``hazure``: AzureBlockBlobStorage
     - ``hs3``:  BotoStore (Amazon S3)
-
-.. admonition:: Store factories
-
-    The reason ``store_factory`` is defined as a ``partial`` callable with the store
-    information as arguments is because, when using distributed computing backends in
-    Kartothek, the connections of the store cannot be safely transferred between
-    processes and thus we pass storage information to workers as a factory function.
 
 Interface
 ---------
@@ -109,7 +102,7 @@ to store the ``DataFrame`` ``df`` that we already have in memory.
     df.dtypes.equals(another_df.dtypes)  # both have the same schema
 
     dm = store_dataframes_as_dataset(
-        store_factory, "a_unique_dataset_identifier", [df, another_df]
+        store_url, "a_unique_dataset_identifier", [df, another_df]
     )
 
 
@@ -187,7 +180,7 @@ For example,
 
     @verbatim
     In [24]: store_dataframes_as_dataset(
-       ....:     store_factory,
+       ....:     store_url,
        ....:     "will_not_work",
        ....:     [df, df2],
        ....: )
@@ -231,7 +224,7 @@ default table name ``table`` and generates a UUID for the partition name.
             },
         ]
 
-        dm = store_dataframes_as_dataset(store_factory, dataset_uuid="two-tables", dfs=dfs)
+        dm = store_dataframes_as_dataset(store_url, dataset_uuid="two-tables", dfs=dfs)
         dm.tables
 
 
@@ -246,7 +239,7 @@ table of the dataset as a pandas DataFrame.
 
     from kartothek.io.eager import read_table
 
-    read_table("a_unique_dataset_identifier", store_factory, table="table")
+    read_table("a_unique_dataset_identifier", store_url, table="table")
 
 
 We can also read a dataframe iteratively, using
@@ -259,7 +252,7 @@ represent the `tables` of the dataset. For example,
     from kartothek.io.iter import read_dataset_as_dataframes__iterator
 
     for partition_index, df_dict in enumerate(
-        read_dataset_as_dataframes__iterator(dataset_uuid="two-tables", store=store_factory)
+        read_dataset_as_dataframes__iterator(dataset_uuid="two-tables", store=store_url)
     ):
         print(f"Partition #{partition_index}")
         for table_name, table_df in df_dict.items():
@@ -284,9 +277,7 @@ function but returns a collection of ``dask.delayed`` objects.
     .. ipython:: python
 
         # Read only values table `core-table` where `f` < 2.5
-        read_table(
-            "two-tables", store_factory, table="core-table", predicates=[[("f", "<", 2.5)]]
-        )
+        read_table("two-tables", store_url, table="core-table", predicates=[[("f", "<", 2.5)]])
 
 
 For a deeper dive into Kartothek you can take a look at

--- a/docs/guide/partitioning.rst
+++ b/docs/guide/partitioning.rst
@@ -36,7 +36,7 @@ first and store the data there with Kartothek:
 
     dataset_dir = TemporaryDirectory()
 
-    store_factory = partial(get_store_from_url, f"hfs://{dataset_dir.name}")
+    store_url = f"hfs://{dataset_dir.name}"
 
     df = pd.DataFrame(
         {
@@ -64,7 +64,7 @@ column all get written to the same partition. To do this, we use the
 .. ipython:: python
 
     dm = store_dataframes_as_dataset(
-        store_factory, "partitioned_dataset", [df], partition_on="B"
+        store_url, "partitioned_dataset", [df], partition_on="B"
     )
 
 Partitioning based on a date column ussually makes sense for timeseries data.
@@ -88,7 +88,7 @@ should be specified as a list:
     duplicate_df.F = "bar"
 
     dm = store_dataframes_as_dataset(
-        store_factory,
+        store_url,
         "another_partitioned_dataset",
         [df, duplicate_df],
         partition_on=["E", "F"],
@@ -118,7 +118,7 @@ For example:
     different_df.dtypes
 
     dm = store_dataframes_as_dataset(
-        store_factory,
+        store_url,
         "multiple_partitioned_tables",
         [{"data": {"table1": df, "table2": different_df}}],
         partition_on="B",
@@ -166,7 +166,7 @@ number of physical input partitions.
     ddf = dd.from_pandas(df, npartitions=10)
 
     dm = update_dataset_from_ddf(
-        ddf, dataset_uuid="no_shuffle", store=store_factory, partition_on="A", table="table"
+        ddf, dataset_uuid="no_shuffle", store=store_url, partition_on="A", table="table"
     ).compute()
     sorted(dm.partitions.keys())
 
@@ -185,7 +185,7 @@ partitioning values of A to be fused into a single file.
     dm = update_dataset_from_ddf(
         ddf,
         dataset_uuid="with_shuffle",
-        store=store_factory,
+        store=store_url,
         partition_on="A",
         shuffle=True,
         table="table",
@@ -233,7 +233,7 @@ When investigating the index, we can also see that a query for a given value in 
     dm = update_dataset_from_ddf(
         ddf,
         dataset_uuid="with_bucketing",
-        store=store_factory,
+        store=store_url,
         partition_on="A",
         shuffle=True,
         table="table",
@@ -243,7 +243,7 @@ When investigating the index, we can also see that a query for a given value in 
     ).compute()
     sorted(dm.partitions.keys())
 
-    dm = dm.load_index("B", store_factory())
+    dm = dm.load_index("B", store_url)
 
     sorted(dm.indices["B"].eval_operator("==", 1))
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,6 +76,7 @@ A Kartothek (or more modern: Zettelkasten/Katalogkasten) is a tool to organize
    Specification <spec/index>
    Type System <spec/type_system>
    DataFrame Serialization <spec/serialization>
+   KeyValueStore Interface <spec/store_interface>
    Storage Layout <spec/storage_layout>
    Partition Indices <spec/partition_indices>
    Efficient Querying <spec/efficient_querying>

--- a/docs/spec/store_interface.rst
+++ b/docs/spec/store_interface.rst
@@ -23,7 +23,7 @@ store but only verifies whether or not the store implements the pickle protocol.
 For all cases where the ``KeyValueStore`` does not implement the pickle
 protocol, or some more complex logic is required to initialize it, kartothek
 also accepts _factories_ which must be a callable returning a ``KeyValueStore``
-(see also ``kartothek.core.typing.STORE_FACTORY_TYPE``).
+(see also ``kartothek.core.typing.StoreFactory``).
 
 For convenience we also offer a `storefact`_ integration and accept store urls
 which proves another easy level of access and is well suited for ad-hoc

--- a/docs/spec/store_interface.rst
+++ b/docs/spec/store_interface.rst
@@ -1,0 +1,33 @@
+.. _store_interface:
+
+=======================
+KeyValueStore Interface
+=======================
+
+All storage interaction use ``simplekv.KeyValueStore`` as an storage layer
+abstraction. This allows convenient access to many different common Key-Value
+stores (ABS, S3, GCS, local filesystem, etc.) and allows an easy switch between
+the storage backends to facilitate a simpler test setup.
+
+Generally, all of our public functions accepting a ``store`` argument accept a
+multitude of different input types and we generally accept all kinds of stores
+inheriting from ``KeyValueStore``, assuming they implement the pickle protocol.
+However, there are storages which simply cannot be distributed across processes
+or network nodes sensibly. A prime Example is the ``simplekv.memory.DictStore``
+which uses a simple python dictionary as a backend store. It is technically
+possible to (de-)serialize the store but once it is deserialized in another
+process, or another node, the store looses its meaning since the stores are
+isolated per process, node, etc. Kartothek does not verify semantics of a given
+store but only verifies whether or not the store implements the pickle protocol.
+
+For all cases where the ``KeyValueStore`` does not implement the pickle
+protocol, or some more complex logic is required to initialize it, kartothek
+also accepts _factories_ which must be a callable returning a ``KeyValueStore``
+(see also ``kartothek.core.typing.STORE_FACTORY_TYPE``).
+
+For convenience we also offer a `storefact`_ integration and accept store urls
+which proves another easy level of access and is well suited for ad-hoc
+investigations.
+
+.. _simplekv: https://simplekv.readthedocs.io/
+.. _storefact: https://storefact.readthedocs.io/

--- a/kartothek/api/discover.py
+++ b/kartothek/api/discover.py
@@ -2,9 +2,7 @@
 Tooling to quickly discover datasets in a given blob store.
 """
 import logging
-from typing import Callable, Dict, Iterable, Optional, Set, Tuple, Union
-
-from simplekv import KeyValueStore
+from typing import Dict, Iterable, Optional, Set, Tuple, Union
 
 from kartothek.api.consistency import check_datasets
 from kartothek.core.cube.constants import (
@@ -20,6 +18,8 @@ from kartothek.core.naming import (
     METADATA_FORMAT_JSON,
     METADATA_FORMAT_MSGPACK,
 )
+from kartothek.core.typing import STORE_TYPE
+from kartothek.core.utils import ensure_store
 from kartothek.utils.converters import converter_str_set_optional
 
 __all__ = (
@@ -33,9 +33,7 @@ __all__ = (
 _logger = logging.getLogger(__name__)
 
 
-def _discover_dataset_meta_files(
-    prefix: str, store: Union[Callable[[], KeyValueStore], KeyValueStore]
-) -> Set[str]:
+def _discover_dataset_meta_files(prefix: str, store: STORE_TYPE) -> Set[str]:
     """
     Get meta file names for all datasets.
 
@@ -51,8 +49,8 @@ def _discover_dataset_meta_files(
     names: Set[str]
         The meta file names
     """
-    if callable(store):
-        store = store()
+
+    store = ensure_store(store)
 
     names = {
         name[: -len(METADATA_BASE_SUFFIX + suffix)]
@@ -63,9 +61,7 @@ def _discover_dataset_meta_files(
     return names
 
 
-def discover_ktk_cube_dataset_ids(
-    uuid_prefix: str, store: Union[Callable[[], KeyValueStore], KeyValueStore]
-) -> Set[str]:
+def discover_ktk_cube_dataset_ids(uuid_prefix: str, store: STORE_TYPE) -> Set[str]:
     """
     Get ktk_cube dataset ids for all datasets.
 
@@ -89,7 +85,7 @@ def discover_ktk_cube_dataset_ids(
 
 def discover_datasets_unchecked(
     uuid_prefix: str,
-    store: Union[Callable[[], KeyValueStore], KeyValueStore],
+    store: STORE_TYPE,
     filter_ktk_cube_dataset_ids: Optional[Union[str, Iterable[str]]] = None,
 ) -> Dict[str, DatasetMetadata]:
     """
@@ -113,8 +109,8 @@ def discover_datasets_unchecked(
     datasets: Dict[str, DatasetMetadata]
         All discovered datasets. Empty Dict if no dataset is found
     """
-    if callable(store):
-        store = store()
+    store = ensure_store(store)
+
     filter_ktk_cube_dataset_ids = converter_str_set_optional(
         filter_ktk_cube_dataset_ids
     )
@@ -144,7 +140,7 @@ def discover_datasets_unchecked(
 
 def discover_datasets(
     cube: Cube,
-    store: Union[Callable[[], KeyValueStore], KeyValueStore],
+    store: STORE_TYPE,
     filter_ktk_cube_dataset_ids: Optional[Union[str, Iterable[str]]] = None,
 ) -> Dict[str, DatasetMetadata]:
     """
@@ -194,7 +190,7 @@ def discover_datasets(
 
 def discover_cube(
     uuid_prefix: str,
-    store: Union[Callable[[], KeyValueStore]],
+    store: STORE_TYPE,
     filter_ktk_cube_dataset_ids: Optional[Union[str, Iterable[str]]] = None,
 ) -> Tuple[Cube, Dict[str, DatasetMetadata]]:
     """

--- a/kartothek/api/discover.py
+++ b/kartothek/api/discover.py
@@ -18,7 +18,7 @@ from kartothek.core.naming import (
     METADATA_FORMAT_JSON,
     METADATA_FORMAT_MSGPACK,
 )
-from kartothek.core.typing import STORE_TYPE
+from kartothek.core.typing import StoreInput
 from kartothek.core.utils import ensure_store
 from kartothek.utils.converters import converter_str_set_optional
 
@@ -33,7 +33,7 @@ __all__ = (
 _logger = logging.getLogger(__name__)
 
 
-def _discover_dataset_meta_files(prefix: str, store: STORE_TYPE) -> Set[str]:
+def _discover_dataset_meta_files(prefix: str, store: StoreInput) -> Set[str]:
     """
     Get meta file names for all datasets.
 
@@ -61,7 +61,7 @@ def _discover_dataset_meta_files(prefix: str, store: STORE_TYPE) -> Set[str]:
     return names
 
 
-def discover_ktk_cube_dataset_ids(uuid_prefix: str, store: STORE_TYPE) -> Set[str]:
+def discover_ktk_cube_dataset_ids(uuid_prefix: str, store: StoreInput) -> Set[str]:
     """
     Get ktk_cube dataset ids for all datasets.
 
@@ -85,7 +85,7 @@ def discover_ktk_cube_dataset_ids(uuid_prefix: str, store: STORE_TYPE) -> Set[st
 
 def discover_datasets_unchecked(
     uuid_prefix: str,
-    store: STORE_TYPE,
+    store: StoreInput,
     filter_ktk_cube_dataset_ids: Optional[Union[str, Iterable[str]]] = None,
 ) -> Dict[str, DatasetMetadata]:
     """
@@ -140,7 +140,7 @@ def discover_datasets_unchecked(
 
 def discover_datasets(
     cube: Cube,
-    store: STORE_TYPE,
+    store: StoreInput,
     filter_ktk_cube_dataset_ids: Optional[Union[str, Iterable[str]]] = None,
 ) -> Dict[str, DatasetMetadata]:
     """
@@ -190,7 +190,7 @@ def discover_datasets(
 
 def discover_cube(
     uuid_prefix: str,
-    store: STORE_TYPE,
+    store: StoreInput,
     filter_ktk_cube_dataset_ids: Optional[Union[str, Iterable[str]]] = None,
 ) -> Tuple[Cube, Dict[str, DatasetMetadata]]:
     """

--- a/kartothek/cli/_info.py
+++ b/kartothek/cli/_info.py
@@ -72,7 +72,7 @@ def _info_dataset(ktk_cube_dataset_id, ds, cube):
 def _collist_string(cols, schema):
     if cols:
         return "\n" + "\n".join(
-            "  - {c}: {t}".format(c=c, t=schema.field_by_name(c).type) for c in cols
+            "  - {c}: {t}".format(c=c, t=schema.field(c).type) for c in cols
         )
     else:
         return ""
@@ -85,8 +85,6 @@ def _collist_string_index(cube, datasets):
             ds = datasets[ktk_cube_dataset_id]
             schema = ds.table_meta[SINGLE_TABLE]
             if col in schema.names:
-                lines.append(
-                    "  - {c}: {t}".format(c=col, t=schema.field_by_name(col).type)
-                )
+                lines.append("  - {c}: {t}".format(c=col, t=schema.field(col).type))
                 break
     return "\n" + "\n".join(lines)

--- a/kartothek/cli/_query.py
+++ b/kartothek/cli/_query.py
@@ -42,7 +42,7 @@ def query(ctx):
         cols = get_dataset_columns(ds)
         all_columns |= cols
         for col in cols:
-            all_types[col] = ds.table_meta[SINGLE_TABLE].field_by_name(col).type
+            all_types[col] = ds.table_meta[SINGLE_TABLE].field(col).type
 
     ipython = _get_ipython()
 

--- a/kartothek/core/common_metadata.py
+++ b/kartothek/core/common_metadata.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import simplejson
+from simplekv import KeyValueStore
 
 from kartothek.core import naming
 from kartothek.core._compat import load_json
@@ -327,7 +328,9 @@ def _get_common_metadata_key(dataset_uuid, table):
     return "{}/{}/{}".format(dataset_uuid, table, naming.TABLE_METADATA_FILE)
 
 
-def read_schema_metadata(dataset_uuid, store, table):
+def read_schema_metadata(
+    dataset_uuid: str, store: KeyValueStore, table: str
+) -> SchemaWrapper:
     """
     Read schema and metadata from store.
 
@@ -349,7 +352,9 @@ def read_schema_metadata(dataset_uuid, store, table):
     return SchemaWrapper(_bytes2schema(store.get(key)), key)
 
 
-def store_schema_metadata(schema, dataset_uuid, store, table):
+def store_schema_metadata(
+    schema: SchemaWrapper, dataset_uuid: str, store: KeyValueStore, table: str
+) -> str:
     """
     Store schema and metadata to store.
 
@@ -373,13 +378,13 @@ def store_schema_metadata(schema, dataset_uuid, store, table):
     return store.put(key, _schema2bytes(schema.internal()))
 
 
-def _schema2bytes(schema):
+def _schema2bytes(schema: SchemaWrapper) -> bytes:
     buf = pa.BufferOutputStream()
     pq.write_metadata(schema, buf, version="2.0", coerce_timestamps="us")
     return buf.getvalue().to_pybytes()
 
 
-def _bytes2schema(data):
+def _bytes2schema(data: bytes) -> SchemaWrapper:
     reader = pa.BufferReader(data)
     schema = pq.read_schema(reader)
     fields = []

--- a/kartothek/core/dataset.py
+++ b/kartothek/core/dataset.py
@@ -23,7 +23,7 @@ from kartothek.core.index import (
 )
 from kartothek.core.naming import EXTERNAL_INDEX_SUFFIX, PARQUET_FILE_SUFFIX
 from kartothek.core.partition import Partition
-from kartothek.core.typing import STORE_TYPE
+from kartothek.core.typing import StoreInput
 from kartothek.core.urlencode import decode_key, quote_indices
 from kartothek.core.utils import ensure_store, verify_metadata_version
 from kartothek.serialization import PredicatesType, columns_in_predicates
@@ -130,7 +130,7 @@ class DatasetMetadataBase(CopyMixin):
         }
 
     @staticmethod
-    def exists(uuid: str, store: STORE_TYPE) -> bool:
+    def exists(uuid: str, store: StoreInput) -> bool:
         """
         Check if  a dataset exists in a storage
 
@@ -156,7 +156,7 @@ class DatasetMetadataBase(CopyMixin):
         return key in store
 
     @staticmethod
-    def storage_keys(uuid: str, store: STORE_TYPE) -> List[str]:
+    def storage_keys(uuid: str, store: StoreInput) -> List[str]:
         """
         Retrieve all keys that belong to the given dataset.
 
@@ -218,7 +218,7 @@ class DatasetMetadataBase(CopyMixin):
     def to_msgpack(self) -> bytes:
         return msgpack.packb(self.to_dict())
 
-    def load_index(self: T, column: str, store: STORE_TYPE) -> T:
+    def load_index(self: T, column: str, store: StoreInput) -> T:
         """
         Load an index into memory.
 
@@ -257,7 +257,7 @@ class DatasetMetadataBase(CopyMixin):
         return self.copy(indices=indices)
 
     def load_all_indices(
-        self: T, store: STORE_TYPE, load_partition_indices: bool = True
+        self: T, store: StoreInput, load_partition_indices: bool = True
     ) -> T:
         """
         Load all registered indices into memory.
@@ -497,7 +497,7 @@ class DatasetMetadata(DatasetMetadataBase):
 
     @staticmethod
     def load_from_buffer(
-        buf, store: STORE_TYPE, format: str = "json"
+        buf, store: StoreInput, format: str = "json"
     ) -> "DatasetMetadata":
         """
         Load a dataset from a (string) buffer.
@@ -523,7 +523,7 @@ class DatasetMetadata(DatasetMetadataBase):
     @staticmethod
     def load_from_store(
         uuid: str,
-        store: STORE_TYPE,
+        store: StoreInput,
         load_schema: bool = True,
         load_all_indices: bool = False,
     ) -> "DatasetMetadata":
@@ -567,7 +567,7 @@ class DatasetMetadata(DatasetMetadataBase):
         return ds
 
     @staticmethod
-    def load_from_dict(dct: Dict, store: STORE_TYPE, load_schema: bool = True):
+    def load_from_dict(dct: Dict, store: StoreInput, load_schema: bool = True):
         """
         Load dataset metadata from a dictionary and resolve any external includes.
 

--- a/kartothek/core/docs.py
+++ b/kartothek/core/docs.py
@@ -7,8 +7,11 @@ from io import StringIO
 
 _PARAMETER_MAPPING = {
     "store": """
-    store: callable
-        Factory function producing a KeyValueStore.""",
+    store: Callable or Str or simplekv.KeyValueStore
+        The store where we can find or store the dataset.
+
+        Can be either ``simplekv.KeyValueStore``, a storefact store url or a
+        generic Callable producing a ``simplekv.KeyValueStore``""",
     "overwrite": """
     overwrite: bool, optional
         If True, allow overwrite of an existing dataset.""",
@@ -65,10 +68,12 @@ _PARAMETER_MAPPING = {
         `merge_datasets__pipeline` key that contains the source dataset uuids for
         the merge.""",
     "output_store": """
-    output_store : callable
-        Factory function producing a KeyValueStore.
+    output_store : Callable or Str or simplekv.KeyValueStore
         If given, the resulting dataset is written to this store. By default
-        the input store""",
+        the input store.
+
+        Can be either ``simplekv.KeyValueStore``, a storefact store url or a
+        generic Callable producing a ``simplekv.KeyValueStore``""",
     "metadata": """
     metadata : dict, optional
         A dictionary used to update the dataset metadata.""",

--- a/kartothek/core/factory.py
+++ b/kartothek/core/factory.py
@@ -4,7 +4,7 @@ import copy
 from typing import TYPE_CHECKING, Any, Optional, TypeVar, cast
 
 from kartothek.core.dataset import DatasetMetadata, DatasetMetadataBase
-from kartothek.core.typing import STORE_TYPE
+from kartothek.core.typing import StoreInput
 from kartothek.core.utils import lazy_store
 
 if TYPE_CHECKING:
@@ -23,7 +23,7 @@ class DatasetFactory(DatasetMetadataBase):
     def __init__(
         self,
         dataset_uuid: str,
-        store_factory: STORE_TYPE,
+        store_factory: StoreInput,
         load_schema: bool = True,
         load_all_indices: bool = False,
         load_dataset_metadata: bool = True,
@@ -161,7 +161,7 @@ class DatasetFactory(DatasetMetadataBase):
 
 def _ensure_factory(
     dataset_uuid: Optional[str],
-    store: STORE_TYPE,
+    store: StoreInput,
     factory: Optional[DatasetFactory],
     load_dataset_metadata: bool,
     load_schema: bool = True,

--- a/kartothek/core/index.py
+++ b/kartothek/core/index.py
@@ -8,7 +8,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-from simplekv import KeyValueStore
 from toolz.itertoolz import partition_all
 
 import kartothek.core._time
@@ -16,7 +15,9 @@ from kartothek.core import naming
 from kartothek.core._mixins import CopyMixin
 from kartothek.core.common_metadata import normalize_type
 from kartothek.core.docs import default_docs
+from kartothek.core.typing import STORE_TYPE
 from kartothek.core.urlencode import quote
+from kartothek.core.utils import lazy_store
 from kartothek.serialization import (
     PredicatesType,
     check_predicates,
@@ -657,7 +658,7 @@ class ExplicitSecondaryIndex(IndexBase):
         else:
             return ExplicitSecondaryIndex(column=column, index_dct=dct_or_str)
 
-    def store(self, store: KeyValueStore, dataset_uuid: str) -> str:
+    def store(self, store: STORE_TYPE, dataset_uuid: str) -> str:
         """
         Store the index as a parquet file
 
@@ -674,6 +675,7 @@ class ExplicitSecondaryIndex(IndexBase):
         dataset_uuid:
         """
         storage_key = None
+        store = lazy_store(store)()
 
         if (
             self.index_storage_key is not None
@@ -714,7 +716,7 @@ class ExplicitSecondaryIndex(IndexBase):
         store.put(storage_key, buf.getvalue().to_pybytes())
         return storage_key
 
-    def load(self, store: KeyValueStore):
+    def load(self, store: STORE_TYPE):
         """
         Load an external index into memory. Returns a new index object that
         contains the index dictionary. Returns itself if the index is internal
@@ -731,6 +733,7 @@ class ExplicitSecondaryIndex(IndexBase):
         """
         if self.loaded:
             return self
+        store = lazy_store(store)()
 
         index_buffer = store.get(self.index_storage_key)
         index_dct, column_type = _parquet_bytes_to_dict(self.column, index_buffer)

--- a/kartothek/core/index.py
+++ b/kartothek/core/index.py
@@ -15,7 +15,7 @@ from kartothek.core import naming
 from kartothek.core._mixins import CopyMixin
 from kartothek.core.common_metadata import normalize_type
 from kartothek.core.docs import default_docs
-from kartothek.core.typing import STORE_TYPE
+from kartothek.core.typing import StoreInput
 from kartothek.core.urlencode import quote
 from kartothek.core.utils import lazy_store
 from kartothek.serialization import (
@@ -658,7 +658,7 @@ class ExplicitSecondaryIndex(IndexBase):
         else:
             return ExplicitSecondaryIndex(column=column, index_dct=dct_or_str)
 
-    def store(self, store: STORE_TYPE, dataset_uuid: str) -> str:
+    def store(self, store: StoreInput, dataset_uuid: str) -> str:
         """
         Store the index as a parquet file
 
@@ -716,7 +716,7 @@ class ExplicitSecondaryIndex(IndexBase):
         store.put(storage_key, buf.getvalue().to_pybytes())
         return storage_key
 
-    def load(self, store: STORE_TYPE):
+    def load(self, store: StoreInput):
         """
         Load an external index into memory. Returns a new index object that
         contains the index dictionary. Returns itself if the index is internal

--- a/kartothek/core/typing.py
+++ b/kartothek/core/typing.py
@@ -2,5 +2,5 @@ from typing import Callable, Union
 
 from simplekv import KeyValueStore
 
-StoreInput = Union[str, KeyValueStore, Callable]
 StoreFactory = Callable[[], KeyValueStore]
+StoreInput = Union[str, KeyValueStore, StoreFactory]

--- a/kartothek/core/typing.py
+++ b/kartothek/core/typing.py
@@ -1,0 +1,6 @@
+from typing import Callable, Union
+
+from simplekv import KeyValueStore
+
+STORE_TYPE = Union[str, KeyValueStore, Callable]
+STORE_FACTORY_TYPE = Callable[[], KeyValueStore]

--- a/kartothek/core/typing.py
+++ b/kartothek/core/typing.py
@@ -2,5 +2,5 @@ from typing import Callable, Union
 
 from simplekv import KeyValueStore
 
-STORE_TYPE = Union[str, KeyValueStore, Callable]
-STORE_FACTORY_TYPE = Callable[[], KeyValueStore]
+StoreInput = Union[str, KeyValueStore, Callable]
+StoreFactory = Callable[[], KeyValueStore]

--- a/kartothek/core/utils.py
+++ b/kartothek/core/utils.py
@@ -6,7 +6,7 @@ from simplekv import KeyValueStore
 from storefact import get_store_from_url
 
 from kartothek.core.naming import MAX_METADATA_VERSION, MIN_METADATA_VERSION
-from kartothek.core.typing import STORE_FACTORY_TYPE, STORE_TYPE
+from kartothek.core.typing import StoreFactory, StoreInput
 
 
 def _verify_metadata_version(metadata_version):
@@ -51,7 +51,7 @@ def ensure_string_type(obj):
         return str(obj)
 
 
-def ensure_store(store: STORE_TYPE) -> KeyValueStore:
+def ensure_store(store: StoreInput) -> KeyValueStore:
     """
     Ensure that the input is a valid KeyValueStore.
     """
@@ -69,7 +69,7 @@ def _factory_from_store(pickled_store):
     return pickle.loads(pickled_store)
 
 
-def lazy_store(store: STORE_TYPE) -> STORE_FACTORY_TYPE:
+def lazy_store(store: StoreInput) -> StoreFactory:
     """
     Create a store factory from the input. Acceptable inputs are
     * Storefact store url
@@ -79,7 +79,7 @@ def lazy_store(store: STORE_TYPE) -> STORE_FACTORY_TYPE:
     If a KeyValueStore is provided, it is verified that the store is serializable
     """
     if callable(store):
-        return cast(STORE_FACTORY_TYPE, store)
+        return cast(StoreFactory, store)
     elif isinstance(store, KeyValueStore):
         try:
             pickled_store = pickle.dumps(store)
@@ -91,9 +91,9 @@ Please consult https://kartothek.readthedocs.io/en/stable/spec/store_interface.h
         return partial(_factory_from_store, pickled_store)
     elif isinstance(store, str):
         ret_val = partial(get_store_from_url, store)
-        ret_val = cast(STORE_FACTORY_TYPE, ret_val)  # type: ignore
+        ret_val = cast(StoreFactory, ret_val)  # type: ignore
         return ret_val
     else:
         raise TypeError(
-            f"Provided incompatible store type. Got {type(store)} but expected {STORE_TYPE}."
+            f"Provided incompatible store type. Got {type(store)} but expected {StoreInput}."
         )

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 from dask.delayed import Delayed
 
-from kartothek.core.typing import STORE_FACTORY_TYPE
+from kartothek.core.typing import StoreFactory
 from kartothek.io.dask.compression import pack_payload, unpack_payload_pandas
 from kartothek.io_components.metapartition import (
     MetaPartition,
@@ -44,7 +44,7 @@ def update_dask_partitions_shuffle(
     secondary_indices: List[str],
     metadata_version: int,
     partition_on: List[str],
-    store_factory: STORE_FACTORY_TYPE,
+    store_factory: StoreFactory,
     df_serializer: DataFrameSerializer,
     dataset_uuid: str,
     num_buckets: int,
@@ -139,7 +139,7 @@ def update_dask_partitions_one_to_one(
     secondary_indices: List[str],
     metadata_version: int,
     partition_on: List[str],
-    store_factory: STORE_FACTORY_TYPE,
+    store_factory: StoreFactory,
     df_serializer: DataFrameSerializer,
     dataset_uuid: str,
     sort_partitions_by: Optional[str],
@@ -186,7 +186,7 @@ def _store_partition(
     table: str,
     dataset_uuid: str,
     partition_on: Optional[List[str]],
-    store_factory: STORE_FACTORY_TYPE,
+    store_factory: StoreFactory,
     df_serializer: DataFrameSerializer,
     metadata_version: int,
     unpacked_meta: pd.DataFrame,

--- a/kartothek/io/dask/_update.py
+++ b/kartothek/io/dask/_update.py
@@ -1,13 +1,13 @@
 from functools import partial
-from typing import Callable, List, Optional
+from typing import List, Optional
 
 import dask.array as da
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
 from dask.delayed import Delayed
-from simplekv import KeyValueStore
 
+from kartothek.core.typing import STORE_FACTORY_TYPE
 from kartothek.io.dask.compression import pack_payload, unpack_payload_pandas
 from kartothek.io_components.metapartition import (
     MetaPartition,
@@ -17,9 +17,6 @@ from kartothek.io_components.utils import sort_values_categorical
 from kartothek.serialization import DataFrameSerializer
 
 from ._utils import map_delayed
-
-StoreFactoryType = Callable[[], KeyValueStore]
-
 
 _KTK_HASH_BUCKET = "__KTK_HASH_BUCKET"
 
@@ -47,7 +44,7 @@ def update_dask_partitions_shuffle(
     secondary_indices: List[str],
     metadata_version: int,
     partition_on: List[str],
-    store_factory: StoreFactoryType,
+    store_factory: STORE_FACTORY_TYPE,
     df_serializer: DataFrameSerializer,
     dataset_uuid: str,
     num_buckets: int,
@@ -142,7 +139,7 @@ def update_dask_partitions_one_to_one(
     secondary_indices: List[str],
     metadata_version: int,
     partition_on: List[str],
-    store_factory: StoreFactoryType,
+    store_factory: STORE_FACTORY_TYPE,
     df_serializer: DataFrameSerializer,
     dataset_uuid: str,
     sort_partitions_by: Optional[str],
@@ -189,7 +186,7 @@ def _store_partition(
     table: str,
     dataset_uuid: str,
     partition_on: Optional[List[str]],
-    store_factory: StoreFactoryType,
+    store_factory: STORE_FACTORY_TYPE,
     df_serializer: DataFrameSerializer,
     metadata_version: int,
     unpacked_meta: pd.DataFrame,

--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -7,7 +7,7 @@ import dask.bag as db
 from kartothek.core import naming
 from kartothek.core.docs import default_docs
 from kartothek.core.factory import _ensure_factory
-from kartothek.core.utils import _check_callable
+from kartothek.core.utils import lazy_store
 from kartothek.core.uuid import gen_uuid
 from kartothek.io.dask._utils import (
     _cast_categorical_to_index_cat,
@@ -203,7 +203,7 @@ def store_bag_as_dataset(
     -------
     A dask.bag.Item dataset object.
     """
-    _check_callable(store)
+    store = lazy_store(store)
     if dataset_uuid is None:
         dataset_uuid = gen_uuid()
 

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -246,6 +246,7 @@ def update_dataset_from_ddf(
     """
     partition_on = normalize_arg("partition_on", partition_on)
     secondary_indices = normalize_arg("secondary_indices", secondary_indices)
+    store = normalize_arg("store", store)
     delete_scope = dask.delayed(normalize_arg)("delete_scope", delete_scope)
 
     if table is None:
@@ -313,6 +314,8 @@ def update_dataset_from_ddf(
     )
 
 
+@default_docs
+@normalize_args
 def collect_dataset_metadata(
     store: Optional[Callable[[], KeyValueStore]] = None,
     dataset_uuid: Optional[str] = None,
@@ -333,12 +336,6 @@ def collect_dataset_metadata(
 
     Parameters
     ----------
-    store
-      A factory function providing a KeyValueStore
-    dataset_uuid
-      The dataset's unique identifier
-    table_name
-      Name of the kartothek table for which to retrieve the statistics
     predicates
       Kartothek predicates to apply filters on the data for which to gather statistics
 
@@ -348,8 +345,6 @@ def collect_dataset_metadata(
 
     frac
       Fraction of the total number of partitions to use for gathering statistics. `frac == 1.0` will use all partitions.
-    factory
-       A DatasetFactory holding the store and UUID to the source dataset.
 
     Returns
     -------
@@ -417,6 +412,7 @@ def _hash_partition(part):
 
 
 @default_docs
+@normalize_args
 def hash_dataset(
     store: Optional[Callable[[], KeyValueStore]] = None,
     dataset_uuid: Optional[str] = None,

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -11,7 +11,7 @@ from kartothek.core import naming
 from kartothek.core.docs import default_docs
 from kartothek.core.factory import _ensure_factory
 from kartothek.core.naming import DEFAULT_METADATA_VERSION
-from kartothek.core.utils import _check_callable
+from kartothek.core.utils import lazy_store
 from kartothek.core.uuid import gen_uuid
 from kartothek.io_components.delete import (
     delete_common_metadata,
@@ -63,6 +63,7 @@ def _delete_tl_metadata(dataset_factory, *args):
 
 
 @default_docs
+@normalize_args
 def delete_dataset__delayed(dataset_uuid=None, store=None, factory=None):
     """
     Parameters
@@ -94,6 +95,7 @@ def delete_dataset__delayed(dataset_uuid=None, store=None, factory=None):
 
 
 @default_docs
+@normalize_args
 def garbage_collect_dataset__delayed(
     dataset_uuid=None, store=None, chunk_size=100, factory=None
 ):
@@ -143,6 +145,7 @@ def _load_and_merge_mps(mp_list, store, label_merger, metadata_merger, merge_tas
 
 
 @default_docs
+@normalize_args
 def merge_datasets_as_delayed(
     left_dataset_uuid,
     right_dataset_uuid,
@@ -210,7 +213,7 @@ def merge_datasets_as_delayed(
             ... ]
 
     """
-    _check_callable(store)
+    store = lazy_store(store)
 
     mps = align_datasets(
         left_dataset_uuid=left_dataset_uuid,
@@ -243,6 +246,7 @@ def _load_and_concat_metapartitions(list_of_mps, *args, **kwargs):
 
 
 @default_docs
+@normalize_args
 def read_dataset_as_delayed_metapartitions(
     dataset_uuid=None,
     store=None,
@@ -371,6 +375,7 @@ def read_dataset_as_delayed(
 
 
 @default_docs
+@normalize_args
 def read_table_as_delayed(
     dataset_uuid=None,
     store=None,
@@ -452,6 +457,7 @@ def update_dataset_from_delayed(
     ----------
     """
     partition_on = normalize_arg("partition_on", partition_on)
+    store = normalize_arg("store", store)
     secondary_indices = normalize_arg("secondary_indices", secondary_indices)
     delete_scope = dask.delayed(normalize_arg)("delete_scope", delete_scope)
 
@@ -513,7 +519,7 @@ def store_delayed_as_dataset(
     -------
     A dask.delayed dataset object.
     """
-    _check_callable(store)
+    store = lazy_store(store)
     if dataset_uuid is None:
         dataset_uuid = gen_uuid()
 

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -47,6 +47,7 @@ from kartothek.io_components.write import raise_if_dataset_exists
 
 
 @default_docs
+@normalize_args
 def delete_dataset(dataset_uuid=None, store=None, factory=None):
     """
     Delete the entire dataset from the store.
@@ -81,7 +82,6 @@ def delete_dataset(dataset_uuid=None, store=None, factory=None):
 
 
 @default_docs
-@normalize_args
 def read_dataset_as_dataframes(
     dataset_uuid: Optional[str] = None,
     store=None,
@@ -148,7 +148,6 @@ def read_dataset_as_dataframes(
 
 
 @default_docs
-@normalize_args
 def read_dataset_as_metapartitions(
     dataset_uuid=None,
     store=None,
@@ -750,6 +749,7 @@ def update_dataset_from_dataframes(
 
 
 @default_docs
+@normalize_args
 def build_dataset_indices(store, dataset_uuid, columns, factory=None):
     """
     Function which builds a :class:`~kartothek.core.index.ExplicitSecondaryIndex`.
@@ -790,6 +790,7 @@ def build_dataset_indices(store, dataset_uuid, columns, factory=None):
 
 
 @default_docs
+@normalize_args
 def garbage_collect_dataset(dataset_uuid=None, store=None, factory=None):
     """
     Remove auxiliary files that are no longer tracked by the dataset.

--- a/kartothek/io/iter.py
+++ b/kartothek/io/iter.py
@@ -31,6 +31,7 @@ from kartothek.io_components.write import (
 
 
 @default_docs
+@normalize_args
 def read_dataset_as_metapartitions__iterator(
     dataset_uuid=None,
     store=None,
@@ -107,6 +108,7 @@ def read_dataset_as_metapartitions__iterator(
 
 
 @default_docs
+@normalize_args
 def read_dataset_as_dataframes__iterator(
     dataset_uuid=None,
     store=None,

--- a/kartothek/io/testing/build_cube.py
+++ b/kartothek/io/testing/build_cube.py
@@ -1036,7 +1036,7 @@ def test_overwrite_rollback_ktk_cube(driver, function_store):
     assert isinstance(ds_enrich.indices["p"], PartitionIndex)
     assert set(ds_enrich.indices["i2"].index_dct.keys()) == {20, 21, 22, 23}
 
-    assert ds_source.table_meta[SINGLE_TABLE].field_by_name("v1").type == pa.int64()
+    assert ds_source.table_meta[SINGLE_TABLE].field("v1").type == pa.int64()
 
 
 def test_overwrite_rollback_ktk(driver, function_store):
@@ -1107,8 +1107,8 @@ def test_overwrite_rollback_ktk(driver, function_store):
 
     assert len(ds_source.partitions) == 1
 
-    assert ds_source.table_meta["ktk_source"].field_by_name("v1").type == pa.int64()
-    assert ds_source.table_meta["ktk_enrich"].field_by_name("v1").type == pa.int64()
+    assert ds_source.table_meta["ktk_source"].field("v1").type == pa.int64()
+    assert ds_source.table_meta["ktk_enrich"].field("v1").type == pa.int64()
 
 
 @pytest.mark.parametrize("none_first", [False, True])

--- a/kartothek/io/testing/utils.py
+++ b/kartothek/io/testing/utils.py
@@ -2,8 +2,6 @@ import string
 
 import numpy as np
 import pandas as pd
-import storefact
-from simplekv.decorator import StoreDecorator
 
 from kartothek.io.eager import store_dataframes_as_dataset
 from kartothek.io_components.metapartition import SINGLE_TABLE
@@ -37,13 +35,3 @@ def create_dataset(dataset_uuid, store_factory, metadata_version):
         dataset_uuid=dataset_uuid,
         metadata_version=metadata_version,
     )
-
-
-class NoPickleDecorator(StoreDecorator):
-    def __getstate__(self):
-        raise RuntimeError("do NOT pickle this object!")
-
-
-def no_pickle_store_from_url(url):
-    store = storefact.get_store_from_url(url)
-    return NoPickleDecorator(store)

--- a/kartothek/io_components/cube/query/_intention.py
+++ b/kartothek/io_components/cube/query/_intention.py
@@ -123,7 +123,7 @@ def _test_condition_types(conditions, datasets):
                 meta = get_dataset_schema(dataset)
                 if col not in meta.names:
                     continue
-                pa_type = meta.field_by_name(col).type
+                pa_type = meta.field(col).type
 
                 if pa.types.is_null(pa_type):
                     # ignore all-NULL columns

--- a/kartothek/io_components/merge.py
+++ b/kartothek/io_components/merge.py
@@ -1,8 +1,8 @@
 import logging
 
 from kartothek.core.dataset import DatasetMetadata
+from kartothek.core.utils import ensure_store
 from kartothek.io_components.metapartition import MetaPartition
-from kartothek.io_components.utils import _instantiate_store
 
 LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ def align_datasets(left_dataset_uuid, right_dataset_uuid, store, match_how="exac
     list
 
     """
-    store = _instantiate_store(store)
+    store = ensure_store(store)
     left_dataset = DatasetMetadata.load_from_store(uuid=left_dataset_uuid, store=store)
     right_dataset = DatasetMetadata.load_from_store(
         uuid=right_dataset_uuid, store=store

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1,21 +1,17 @@
-# -*- coding: utf-8 -*-
-
-
 import inspect
 import io
 import logging
 import os
 import time
 import warnings
-from collections import Iterable, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 from copy import copy
 from functools import wraps
-from typing import Any, Callable, Dict, Iterator, Optional, cast
+from typing import Any, Dict, Iterable, Iterator, Optional, cast
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-from simplekv import KeyValueStore
 
 from kartothek.core import naming
 from kartothek.core.common_metadata import (
@@ -30,16 +26,18 @@ from kartothek.core.index import ExplicitSecondaryIndex, IndexBase
 from kartothek.core.index import merge_indices as merge_indices_algo
 from kartothek.core.naming import get_partition_file_prefix
 from kartothek.core.partition import Partition
+from kartothek.core.typing import STORE_TYPE
 from kartothek.core.urlencode import decode_key, quote_indices
-from kartothek.core.utils import ensure_string_type, verify_metadata_version
-from kartothek.core.uuid import gen_uuid
-from kartothek.io_components.utils import (
-    _ensure_valid_indices,
-    _instantiate_store,
-    combine_metadata,
+from kartothek.core.utils import (
+    ensure_store,
+    ensure_string_type,
+    verify_metadata_version,
 )
+from kartothek.core.uuid import gen_uuid
+from kartothek.io_components.utils import _ensure_valid_indices, combine_metadata
 from kartothek.serialization import (
     DataFrameSerializer,
+    PredicatesType,
     default_serializer,
     filter_df_from_predicates,
 )
@@ -61,6 +59,8 @@ _METADATA_SCHEMA = {
     "serialized_size": np.dtype(int),
     "number_rows_per_row_group": np.dtype(int),
 }
+
+_MULTI_TABLE_DICT_LIST = Dict[str, Iterable[str]]
 
 
 def _predicates_to_named(predicates):
@@ -87,9 +87,7 @@ def _initialize_store_for_metapartition(method, method_args, method_kwargs):
 
     for store_variable in ["store", "storage"]:
         if store_variable in method_kwargs:
-            method_kwargs[store_variable] = _instantiate_store(
-                method_kwargs[store_variable]
-            )
+            method_kwargs[store_variable] = ensure_store(method_kwargs[store_variable])
         else:
             method = cast(object, method)
             args = inspect.getfullargspec(method).args
@@ -98,7 +96,7 @@ def _initialize_store_for_metapartition(method, method_args, method_kwargs):
                 ix = args.index(store_variable)
                 # reduce index since the argspec and method_args start counting differently due to self
                 ix -= 1
-                instantiated_store = _instantiate_store(method_args[ix])
+                instantiated_store = ensure_store(method_args[ix])
                 new_args = []
                 for ix_method, arg in enumerate(method_args):
                     if ix_method != ix:
@@ -625,14 +623,14 @@ class MetaPartition(Iterable):
     @_apply_to_list
     def load_dataframes(
         self,
-        store,
-        tables=None,
-        columns=None,
-        predicate_pushdown_to_io=True,
-        categoricals=None,
-        dates_as_object=False,
-        predicates=None,
-    ):
+        store: STORE_TYPE,
+        tables: _MULTI_TABLE_DICT_LIST = None,
+        columns: _MULTI_TABLE_DICT_LIST = None,
+        predicate_pushdown_to_io: bool = True,
+        categoricals: _MULTI_TABLE_DICT_LIST = None,
+        dates_as_object: bool = False,
+        predicates: PredicatesType = None,
+    ) -> "MetaPartition":
         """
         Load the dataframes of the partitions from store into memory.
 
@@ -775,7 +773,9 @@ class MetaPartition(Iterable):
         return self.copy(data=new_data)
 
     @_apply_to_list
-    def load_all_table_meta(self, store, dataset_uuid):
+    def load_all_table_meta(
+        self, store: STORE_TYPE, dataset_uuid: str
+    ) -> "MetaPartition":
         """
         Loads all table metadata in memory and stores it under the `tables` attribute
 
@@ -784,7 +784,9 @@ class MetaPartition(Iterable):
             self._load_table_meta(dataset_uuid, table, store)
         return self
 
-    def _load_table_meta(self, dataset_uuid, table, store):
+    def _load_table_meta(
+        self, dataset_uuid: str, table: str, store: STORE_TYPE
+    ) -> "MetaPartition":
         if table not in self.table_meta:
             _common_metadata = read_schema_metadata(
                 dataset_uuid=dataset_uuid, store=store, table=table
@@ -927,7 +929,9 @@ class MetaPartition(Iterable):
         return self.copy(files={}, data=new_data, table_meta=new_table_meta)
 
     @_apply_to_list
-    def validate_schema_compatible(self, store, dataset_uuid):
+    def validate_schema_compatible(
+        self, store: STORE_TYPE, dataset_uuid: str
+    ) -> "MetaPartition":
         """
         Validates that the currently held DataFrames match the schema of the existing dataset.
 
@@ -966,12 +970,12 @@ class MetaPartition(Iterable):
     @_apply_to_list
     def store_dataframes(
         self,
-        store,
-        dataset_uuid,
-        df_serializer=None,
-        store_metadata=False,
-        metadata_storage_format=None,
-    ):
+        store: STORE_TYPE,
+        dataset_uuid: str,
+        df_serializer: Optional[DataFrameSerializer] = None,
+        store_metadata: bool = False,
+        metadata_storage_format: Optional[str] = None,
+    ) -> "MetaPartition":
         """
         Stores all dataframes of the MetaPartitions and registers the saved
         files under the `files` atrribute. The dataframe itself is deleted from memory.
@@ -1545,15 +1549,16 @@ class MetaPartition(Iterable):
         return new_mp
 
     @_apply_to_list
-    def delete_from_store(self, dataset_uuid, store):
+    def delete_from_store(
+        self, dataset_uuid: Any, store: STORE_TYPE
+    ) -> "MetaPartition":
+        store = ensure_store(store)
         # Delete data first
         for file_key in self.files.values():
             store.delete(file_key)
         return self.copy(files={}, data={}, metadata={})
 
-    def get_parquet_metadata(
-        self, store: Callable[[], KeyValueStore], table_name: str
-    ) -> pd.DataFrame:
+    def get_parquet_metadata(self, store: STORE_TYPE, table_name: str) -> pd.DataFrame:
         """
         Retrieve the parquet metadata for the MetaPartition.
         Especially relevant for calculating dataset statistics.
@@ -1573,8 +1578,7 @@ class MetaPartition(Iterable):
         if not isinstance(table_name, str):
             raise TypeError("Expecting a string for parameter `table_name`.")
 
-        if callable(store):
-            store = store()
+        store = ensure_store(store)
 
         data = {}
         if table_name in self.files:

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -26,7 +26,7 @@ from kartothek.core.index import ExplicitSecondaryIndex, IndexBase
 from kartothek.core.index import merge_indices as merge_indices_algo
 from kartothek.core.naming import get_partition_file_prefix
 from kartothek.core.partition import Partition
-from kartothek.core.typing import STORE_TYPE
+from kartothek.core.typing import StoreInput
 from kartothek.core.urlencode import decode_key, quote_indices
 from kartothek.core.utils import (
     ensure_store,
@@ -623,7 +623,7 @@ class MetaPartition(Iterable):
     @_apply_to_list
     def load_dataframes(
         self,
-        store: STORE_TYPE,
+        store: StoreInput,
         tables: _MULTI_TABLE_DICT_LIST = None,
         columns: _MULTI_TABLE_DICT_LIST = None,
         predicate_pushdown_to_io: bool = True,
@@ -774,7 +774,7 @@ class MetaPartition(Iterable):
 
     @_apply_to_list
     def load_all_table_meta(
-        self, store: STORE_TYPE, dataset_uuid: str
+        self, store: StoreInput, dataset_uuid: str
     ) -> "MetaPartition":
         """
         Loads all table metadata in memory and stores it under the `tables` attribute
@@ -785,7 +785,7 @@ class MetaPartition(Iterable):
         return self
 
     def _load_table_meta(
-        self, dataset_uuid: str, table: str, store: STORE_TYPE
+        self, dataset_uuid: str, table: str, store: StoreInput
     ) -> "MetaPartition":
         if table not in self.table_meta:
             _common_metadata = read_schema_metadata(
@@ -930,7 +930,7 @@ class MetaPartition(Iterable):
 
     @_apply_to_list
     def validate_schema_compatible(
-        self, store: STORE_TYPE, dataset_uuid: str
+        self, store: StoreInput, dataset_uuid: str
     ) -> "MetaPartition":
         """
         Validates that the currently held DataFrames match the schema of the existing dataset.
@@ -970,7 +970,7 @@ class MetaPartition(Iterable):
     @_apply_to_list
     def store_dataframes(
         self,
-        store: STORE_TYPE,
+        store: StoreInput,
         dataset_uuid: str,
         df_serializer: Optional[DataFrameSerializer] = None,
         store_metadata: bool = False,
@@ -1550,7 +1550,7 @@ class MetaPartition(Iterable):
 
     @_apply_to_list
     def delete_from_store(
-        self, dataset_uuid: Any, store: STORE_TYPE
+        self, dataset_uuid: Any, store: StoreInput
     ) -> "MetaPartition":
         store = ensure_store(store)
         # Delete data first
@@ -1558,7 +1558,7 @@ class MetaPartition(Iterable):
             store.delete(file_key)
         return self.copy(files={}, data={}, metadata={})
 
-    def get_parquet_metadata(self, store: STORE_TYPE, table_name: str) -> pd.DataFrame:
+    def get_parquet_metadata(self, store: StoreInput, table_name: str) -> pd.DataFrame:
         """
         Retrieve the parquet metadata for the MetaPartition.
         Especially relevant for calculating dataset statistics.

--- a/kartothek/io_components/read.py
+++ b/kartothek/io_components/read.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from kartothek.core.factory import DatasetFactory
 from kartothek.core.index import ExplicitSecondaryIndex
-from kartothek.core.typing import STORE_TYPE
+from kartothek.core.typing import StoreInput
 from kartothek.io_components.metapartition import MetaPartition
 from kartothek.io_components.utils import normalize_args
 from kartothek.serialization import (
@@ -21,7 +21,7 @@ def dispatch_metapartitions_from_factory(
     label_filter: Optional[Callable] = None,
     concat_partitions_on_primary_index: bool = False,
     predicates: PredicatesType = None,
-    store: Optional[STORE_TYPE] = None,
+    store: Optional[StoreInput] = None,
     dispatch_by: None = None,
     dispatch_metadata: bool = False,
 ) -> Iterator[MetaPartition]:
@@ -34,7 +34,7 @@ def dispatch_metapartitions_from_factory(
     label_filter: Optional[Callable],
     concat_partitions_on_primary_index: bool,
     predicates: PredicatesType,
-    store: Optional[STORE_TYPE],
+    store: Optional[StoreInput],
     dispatch_by: List[str],
     dispatch_metadata: bool,
 ) -> Iterator[List[MetaPartition]]:
@@ -47,7 +47,7 @@ def dispatch_metapartitions_from_factory(
     label_filter: Optional[Callable] = None,
     concat_partitions_on_primary_index: bool = False,
     predicates: PredicatesType = None,
-    store: Optional[STORE_TYPE] = None,
+    store: Optional[StoreInput] = None,
     dispatch_by: Optional[List[str]] = None,
     dispatch_metadata: bool = False,
 ) -> Union[Iterator[MetaPartition], Iterator[List[MetaPartition]]]:
@@ -155,7 +155,7 @@ def dispatch_metapartitions_from_factory(
 
 def dispatch_metapartitions(
     dataset_uuid: str,
-    store: STORE_TYPE,
+    store: StoreInput,
     load_dataset_metadata: bool = True,
     keep_indices: bool = True,
     keep_table_meta: bool = True,

--- a/kartothek/io_components/read.py
+++ b/kartothek/io_components/read.py
@@ -2,12 +2,12 @@ import warnings
 from typing import Callable, Iterator, List, Optional, Set, Union, cast, overload
 
 import pandas as pd
-from simplekv import KeyValueStore
 
 from kartothek.core.factory import DatasetFactory
 from kartothek.core.index import ExplicitSecondaryIndex
+from kartothek.core.typing import STORE_TYPE
 from kartothek.io_components.metapartition import MetaPartition
-from kartothek.io_components.utils import _make_callable, normalize_args
+from kartothek.io_components.utils import normalize_args
 from kartothek.serialization import (
     PredicatesType,
     check_predicates,
@@ -21,7 +21,7 @@ def dispatch_metapartitions_from_factory(
     label_filter: Optional[Callable] = None,
     concat_partitions_on_primary_index: bool = False,
     predicates: PredicatesType = None,
-    store: Optional[Callable[[], KeyValueStore]] = None,
+    store: Optional[STORE_TYPE] = None,
     dispatch_by: None = None,
     dispatch_metadata: bool = False,
 ) -> Iterator[MetaPartition]:
@@ -34,7 +34,7 @@ def dispatch_metapartitions_from_factory(
     label_filter: Optional[Callable],
     concat_partitions_on_primary_index: bool,
     predicates: PredicatesType,
-    store: Optional[Callable[[], KeyValueStore]],
+    store: Optional[STORE_TYPE],
     dispatch_by: List[str],
     dispatch_metadata: bool,
 ) -> Iterator[List[MetaPartition]]:
@@ -47,7 +47,7 @@ def dispatch_metapartitions_from_factory(
     label_filter: Optional[Callable] = None,
     concat_partitions_on_primary_index: bool = False,
     predicates: PredicatesType = None,
-    store: Optional[Callable[[], KeyValueStore]] = None,
+    store: Optional[STORE_TYPE] = None,
     dispatch_by: Optional[List[str]] = None,
     dispatch_metadata: bool = False,
 ) -> Union[Iterator[MetaPartition], Iterator[List[MetaPartition]]]:
@@ -155,7 +155,7 @@ def dispatch_metapartitions_from_factory(
 
 def dispatch_metapartitions(
     dataset_uuid: str,
-    store: Union[KeyValueStore, Callable[[], KeyValueStore]],
+    store: STORE_TYPE,
     load_dataset_metadata: bool = True,
     keep_indices: bool = True,
     keep_table_meta: bool = True,
@@ -167,7 +167,7 @@ def dispatch_metapartitions(
 ) -> Union[Iterator[MetaPartition], Iterator[List[MetaPartition]]]:
     dataset_factory = DatasetFactory(
         dataset_uuid=dataset_uuid,
-        store_factory=cast(Callable[[], KeyValueStore], _make_callable(store)),
+        store_factory=store,
         load_schema=True,
         load_all_indices=False,
         load_dataset_metadata=load_dataset_metadata,

--- a/kartothek/io_components/update.py
+++ b/kartothek/io_components/update.py
@@ -7,7 +7,7 @@ update of the content of existing partitions.
 
 
 from kartothek.core.index import PartitionIndex
-from kartothek.io_components.utils import _instantiate_store
+from kartothek.core.utils import ensure_store
 from kartothek.io_components.write import store_dataset_from_partitions
 
 
@@ -29,7 +29,7 @@ def update_dataset_from_partitions(
     metadata,
     metadata_merger,
 ):
-    store = _instantiate_store(store_factory)
+    store = ensure_store(store_factory)
 
     if ds_factory:
         ds_factory = ds_factory.load_all_indices()

--- a/kartothek/io_components/write.py
+++ b/kartothek/io_components/write.py
@@ -14,7 +14,7 @@ from kartothek.core.common_metadata import (
 from kartothek.core.dataset import DatasetMetadataBuilder
 from kartothek.core.index import ExplicitSecondaryIndex, IndexBase, PartitionIndex
 from kartothek.core.partition import Partition
-from kartothek.core.typing import STORE_TYPE
+from kartothek.core.typing import StoreInput
 from kartothek.core.utils import ensure_store
 from kartothek.io_components.metapartition import (
     SINGLE_TABLE,
@@ -27,7 +27,7 @@ SINGLE_CATEGORY = SINGLE_TABLE
 
 
 def persist_indices(
-    store: STORE_TYPE, dataset_uuid: str, indices: Dict[str, IndexBase]
+    store: StoreInput, dataset_uuid: str, indices: Dict[str, IndexBase]
 ) -> Dict[str, str]:
     store = ensure_store(store)
     output_filenames = {}
@@ -98,7 +98,7 @@ def persist_common_metadata(partition_list, update_dataset, store, dataset_uuid)
 
 def store_dataset_from_partitions(
     partition_list,
-    store: STORE_TYPE,
+    store: StoreInput,
     dataset_uuid,
     dataset_metadata=None,
     metadata_merger=None,

--- a/kartothek/io_components/write.py
+++ b/kartothek/io_components/write.py
@@ -2,6 +2,7 @@
 
 
 from collections import defaultdict
+from typing import Dict, cast
 
 from kartothek.core import naming
 from kartothek.core.common_metadata import (
@@ -11,24 +12,24 @@ from kartothek.core.common_metadata import (
     validate_shared_columns,
 )
 from kartothek.core.dataset import DatasetMetadataBuilder
-from kartothek.core.index import ExplicitSecondaryIndex, PartitionIndex
+from kartothek.core.index import ExplicitSecondaryIndex, IndexBase, PartitionIndex
 from kartothek.core.partition import Partition
+from kartothek.core.typing import STORE_TYPE
+from kartothek.core.utils import ensure_store
 from kartothek.io_components.metapartition import (
     SINGLE_TABLE,
     MetaPartition,
     partition_labels_from_mps,
 )
-from kartothek.io_components.utils import (
-    _instantiate_store,
-    combine_metadata,
-    extract_duplicates,
-)
+from kartothek.io_components.utils import combine_metadata, extract_duplicates
 
 SINGLE_CATEGORY = SINGLE_TABLE
 
 
-def persist_indices(store, dataset_uuid, indices):
-    store = _instantiate_store(store)
+def persist_indices(
+    store: STORE_TYPE, dataset_uuid: str, indices: Dict[str, IndexBase]
+) -> Dict[str, str]:
+    store = ensure_store(store)
     output_filenames = {}
     for column, index in indices.items():
         # backwards compat
@@ -43,6 +44,7 @@ def persist_indices(store, dataset_uuid, indices):
             )
         elif isinstance(index, PartitionIndex):
             continue
+        index = cast(ExplicitSecondaryIndex, index)
         output_filenames[column] = index.store(store=store, dataset_uuid=dataset_uuid)
     return output_filenames
 
@@ -96,7 +98,7 @@ def persist_common_metadata(partition_list, update_dataset, store, dataset_uuid)
 
 def store_dataset_from_partitions(
     partition_list,
-    store,
+    store: STORE_TYPE,
     dataset_uuid,
     dataset_metadata=None,
     metadata_merger=None,
@@ -104,7 +106,7 @@ def store_dataset_from_partitions(
     remove_partitions=None,
     metadata_storage_format=naming.DEFAULT_METADATA_STORAGE_FORMAT,
 ):
-    store = _instantiate_store(store)
+    store = ensure_store(store)
 
     if update_dataset:
         dataset_builder = DatasetMetadataBuilder.from_dataset(update_dataset)
@@ -236,7 +238,7 @@ def update_indices(dataset_builder, store, add_partitions, remove_partitions):
 
 def raise_if_dataset_exists(dataset_uuid, store):
     try:
-        store_instance = _instantiate_store(store)
+        store_instance = ensure_store(store)
         for form in ["msgpack", "json"]:
             key = naming.metadata_key_from_uuid(uuid=dataset_uuid, format=form)
             if key in store_instance:

--- a/kartothek/serialization/_generic.py
+++ b/kartothek/serialization/_generic.py
@@ -12,11 +12,12 @@ Available constants
 **LiteralValue** - A type indicating the value of a predicate literal
 """
 
-from typing import Dict, List, Optional, Set, Tuple, TypeVar
+from typing import Dict, Iterable, List, Optional, Set, Tuple, TypeVar
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import is_list_like
+from simplekv import KeyValueStore
 
 from kartothek.serialization._util import _check_contains_null
 
@@ -49,15 +50,15 @@ class DataFrameSerializer:
     @classmethod
     def restore_dataframe(
         cls,
-        store,
-        key,
-        filter_query=None,
-        columns=None,
-        predicate_pushdown_to_io=True,
-        categories=None,
-        predicates=None,
-        date_as_object=False,
-    ):
+        store: KeyValueStore,
+        key: str,
+        filter_query: Optional[str] = None,
+        columns: Optional[Iterable[str]] = None,
+        predicate_pushdown_to_io: bool = True,
+        categories: Optional[Iterable[str]] = None,
+        predicates: Optional[PredicatesType] = None,
+        date_as_object: bool = False,
+    ) -> pd.DataFrame:
         """
         Load a DataFrame from the specified store. The key is also used to
         detect the used format.
@@ -126,7 +127,7 @@ class DataFrameSerializer:
             "The specified file format for '{}' is not supported".format(key)
         )
 
-    def store(self, store, key_prefix, df):
+    def store(self, store: KeyValueStore, key_prefix: str, df: pd.DataFrame) -> str:
         """
         Persist a DataFrame to the specified store.
 

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -6,15 +6,18 @@ This module contains functionality for persisting/serialising DataFrames.
 
 
 import datetime
+from typing import Iterable, Optional
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 from pyarrow.parquet import ParquetFile
+from simplekv import KeyValueStore
 
 from ._generic import (
     DataFrameSerializer,
+    PredicatesType,
     check_predicates,
     filter_df,
     filter_df_from_predicates,
@@ -84,14 +87,14 @@ class ParquetSerializer(DataFrameSerializer):
 
     @staticmethod
     def restore_dataframe(
-        store,
-        key,
-        filter_query=None,
-        columns=None,
-        predicate_pushdown_to_io=True,
-        categories=None,
-        predicates=None,
-        date_as_object=False,
+        store: KeyValueStore,
+        key: str,
+        filter_query: Optional[str] = None,
+        columns: Optional[Iterable[str]] = None,
+        predicate_pushdown_to_io: bool = True,
+        categories: Optional[Iterable[str]] = None,
+        predicates: Optional[PredicatesType] = None,
+        date_as_object: bool = False,
     ):
         check_predicates(predicates)
         # If we want to do columnar access we can benefit from partial reads

--- a/tests/api/test_discover.py
+++ b/tests/api/test_discover.py
@@ -2,6 +2,7 @@ from collections import Counter
 
 import pandas as pd
 import pytest
+from simplekv import KeyValueStore
 
 from kartothek.api.discover import (
     discover_cube,
@@ -298,7 +299,7 @@ class TestDiscoverDatasetsUnchecked:
             overwrite=True,
         )
 
-        class StoreMock:
+        class StoreMock(KeyValueStore):
             def __init__(self, store):
                 self._store = store
                 self._iter_keys_called = 0

--- a/tests/io/eager/test_commit.py
+++ b/tests/io/eager/test_commit.py
@@ -22,7 +22,6 @@ from kartothek.io_components.metapartition import SINGLE_TABLE
 
 
 def test_commit_dataset_from_metapartition(dataset_function, store):
-
     new_data = {
         "data": {
             SINGLE_TABLE: pd.DataFrame(

--- a/tests/io_components/test_dataset_metadata_factory.py
+++ b/tests/io_components/test_dataset_metadata_factory.py
@@ -3,11 +3,12 @@ from copy import copy
 from functools import partial
 
 import pytest
+from simplekv import KeyValueStore
 
 from kartothek.core.factory import DatasetFactory
 
 
-class CountStore:
+class CountStore(KeyValueStore):
     def __init__(self, inner):
         self.inner = inner
         self.get_count = 0


### PR DESCRIPTION
# Description:

This allows to pass either store urls, simplekv stores or callables as the store argument. the type annotations helped really out in this case. Eventually I imagine low level classes should phase out any ambiguity and simply deal with KV stores.

This obviously assumes that KV stores can be properly pickled but I don't see this as a relevant issue anymore. If this is an issue for anybody I can revert that change and only allow store URLs.

There may be a few leftovers in docs, etc. but I tried to get the essentials (e.g. in the guide/getting started)

- [x] Closes #233
- [x] Changelog entry
