### PR TITLE
Allow filtering missings using predicates

### DIFF
--- a/kartothek/core/docs.py
+++ b/kartothek/core/docs.py
@@ -131,6 +131,10 @@ _PARAMETER_MAPPING = {
 
         Available operators are: `==`, `!=`, `<=`, `>=`, `<`, `>` and `in`.
 
+        Filtering for missings is supported with operators `==`, `!=` and
+        `in` and values `np.nan` and `None` for float and string columns
+        respectively.
+
         .. admonition:: Categorical data
 
             When using order sensitive operators on categorical data we will

--- a/kartothek/serialization/_generic.py
+++ b/kartothek/serialization/_generic.py
@@ -456,9 +456,15 @@ def filter_array_like(
 
     with np.errstate(invalid="ignore"):
         if op == "==":
-            np.logical_and(array_like == value, mask, out=out)
+            if pd.isnull(value):
+                np.logical_and(pd.isnull(array_like), mask, out=out)
+            else:
+                np.logical_and(array_like == value, mask, out=out)
         elif op == "!=":
-            np.logical_and(array_like != value, mask, out=out)
+            if pd.isnull(value):
+                np.logical_and(~pd.isnull(array_like), mask, out=out)
+            else:
+                np.logical_and(array_like != value, mask, out=out)
         elif op == "<=":
             np.logical_and(array_like <= value, mask, out=out)
         elif op == ">=":
@@ -469,13 +475,25 @@ def filter_array_like(
             np.logical_and(array_like > value, mask, out=out)
         elif op == "in":
             value = np.asarray(value)
-            np.logical_and(
-                np.isin(array_like, value)
-                if len(value) > 0
-                else np.zeros(len(array_like), dtype=bool),
-                mask,
-                out=out,
-            )
+            if any(pd.isnull(value)):
+                np.logical_and(
+                    pd.isnull(array_like)
+                    | (
+                        np.isin(array_like, value)
+                        if len(value) > 0
+                        else np.zeros(len(array_like), dype=bool)
+                    ),
+                    mask,
+                    out=out,
+                )
+            else:
+                np.logical_and(
+                    np.isin(array_like, value)
+                    if len(value) > 0
+                    else np.zeros(len(array_like), dtype=bool),
+                    mask,
+                    out=out,
+                )
         else:
             raise NotImplementedError("op not supported")
 

--- a/kartothek/serialization/_generic.py
+++ b/kartothek/serialization/_generic.py
@@ -206,7 +206,7 @@ def check_predicates(predicates: PredicatesType) -> None:
                 raise ValueError(
                     f"Invalid predicates: Clause {clause_idx} in conjunction {conjunction_idx} "
                     f"with null value and operator {op}. Only operators supporting null values "
-                    "are '==' and '!='."
+                    "are '==', '!=' and 'in'."
                 )
 
 

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -445,10 +445,18 @@ def _predicate_accepts(predicate, row_meta, arrow_schema, parquet_reader):
     if isinstance(val, float):
         min_value -= _epsilon(min_value)
         max_value += _epsilon(max_value)
+
+    # TODO: What to do for "<=", "<", ">", ">=" np.nan?
     if op == "==":
-        return (min_value <= val) and (max_value >= val)
+        if np.isnan(val):
+            return parquet_statistics.null_count > 0
+        else:
+            return (min_value <= val) and (max_value >= val)
     elif op == "!=":
-        return not ((min_value >= val) and (max_value <= val))
+        if np.isnan(val):
+            return parquet_statistics.null_count < row_meta.num_rows
+        else:
+            return not ((min_value >= val) and (max_value <= val))
     elif op == "<=":
         return min_value <= val
     elif op == ">=":
@@ -463,7 +471,9 @@ def _predicate_accepts(predicate, row_meta, arrow_schema, parquet_reader):
         # We accept the predicate if there is any value in the provided array which is equal to or between
         # the parquet min and max statistics. Otherwise, it is rejected.
         for x in val:
-            if min_value <= x <= max_value:
+            if np.isnan(x) and parquet_statistics.null_count > 0:
+                return True
+            elif min_value <= x <= max_value:
                 return True
         return False
     else:

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -448,7 +448,7 @@ def _predicate_accepts(predicate, row_meta, arrow_schema, parquet_reader):
         min_value -= _epsilon(min_value)
         max_value += _epsilon(max_value)
 
-    # TODO: What to do for "<=", "<", ">", ">=" np.nan?
+    # op can only be "==" or "!=" for scalar null values.
     if op == "==":
         if pd.isnull(val):
             return parquet_statistics.null_count > 0

--- a/tests/serialization/test_dataframe.py
+++ b/tests/serialization/test_dataframe.py
@@ -607,6 +607,27 @@ def test_predicate_parsing_null_values(
 
 
 @pytest.mark.parametrize(
+    "op, value", [("<", np.nan), ("<=", np.nan), (">", np.nan), (">=", np.nan)]
+)
+@predicate_serialisers
+@pytest.mark.parametrize("predicate_pushdown_to_io", [True, False])
+def test_predicate_parsing_null_values_failing(
+    store, op, value, predicate_pushdown_to_io, serialiser
+):
+    df = pd.DataFrame({"u": pd.Series([1.0, np.nan])})
+    key = serialiser.store(store, "prefix", df)
+
+    predicates = [[(df.columns[0], op, value)]]
+    with pytest.raises(ValueError, match="Only operators supporting null values"):
+        serialiser.restore_dataframe(
+            store,
+            key,
+            predicate_pushdown_to_io=predicate_pushdown_to_io,
+            predicates=predicates,
+        )
+
+
+@pytest.mark.parametrize(
     "column, expected_null_count",
     [
         ("no_nulls_int", (0, 0, 0)),

--- a/tests/serialization/test_dataframe.py
+++ b/tests/serialization/test_dataframe.py
@@ -606,18 +606,16 @@ def test_predicate_parsing_null_values(
     )
 
 
-@pytest.mark.parametrize(
-    "op, value", [("<", np.nan), ("<=", np.nan), (">", np.nan), (">=", np.nan)]
-)
+@pytest.mark.parametrize("op", ["<", "<=", ">", ">="])
 @predicate_serialisers
 @pytest.mark.parametrize("predicate_pushdown_to_io", [True, False])
 def test_predicate_parsing_null_values_failing(
-    store, op, value, predicate_pushdown_to_io, serialiser
+    store, op, predicate_pushdown_to_io, serialiser
 ):
     df = pd.DataFrame({"u": pd.Series([1.0, np.nan])})
     key = serialiser.store(store, "prefix", df)
 
-    predicates = [[(df.columns[0], op, value)]]
+    predicates = [[(df.columns[0], op, np.nan)]]
     with pytest.raises(ValueError, match="Only operators supporting null values"):
         serialiser.restore_dataframe(
             store,

--- a/tests/serialization/test_dataframe.py
+++ b/tests/serialization/test_dataframe.py
@@ -584,7 +584,7 @@ def test_predicate_pushdown_null_col(
     ],
 )
 @predicate_serialisers
-@pytest.mark.parametrize("predicate_pushdown_to_io", [False])
+@pytest.mark.parametrize("predicate_pushdown_to_io", [True, False])
 def test_predicate_parsing_null_values(
     store, df, op, value, expected_index, predicate_pushdown_to_io, serialiser
 ):


### PR DESCRIPTION
Closes #296.

Sorry that I did not get back to this earlier. This implements a simple solution as suggested by @lr4d to filter by missings in predicates. This will not work with `predicate_pushdown_to_io` (see test). I am using `pd.isnull` instead of `np.isnan` as the former works for object columns. Passing `[[("x", "==", np.nan)]]` for an object column will raise an error due to a dtype mismatch, not sure what the expected behaviour would be here. Also not sure what the expected behaviour would be for `<`, `<=`, `>`, `>=` operators together with missings.