### PR TITLE
Deprecation warning for multi table support

### DIFF
--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import warnings
 from collections import defaultdict
 from functools import partial
 
@@ -68,6 +69,12 @@ def read_dataset_as_metapartitions_bag(
     -------
     A dask.bag object containing the metapartions.
     """
+    if tables is not None or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     ds_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
         store=store,
@@ -151,6 +158,12 @@ def read_dataset_as_dataframe_bag(
     dask.bag
         A dask.bag which contains the metapartitions and mapped to a function for retrieving the data.
     """
+    if tables is not None or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     mps = read_dataset_as_metapartitions_bag(
         dataset_uuid=dataset_uuid,
         store=store,

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -66,6 +66,12 @@ def read_dataset_as_ddf(
 
         For details on performance, see also `dispatch_by`
     """
+    if table is not SINGLE_TABLE or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     if dask_index_on is not None and not isinstance(dask_index_on, str):
         raise TypeError(
             f"The paramter `dask_index_on` must be a string but got {type(dask_index_on)}"
@@ -244,6 +250,12 @@ def update_dataset_from_ddf(
 
             Only columns with data types which can be hashed are allowed to be used in this.
     """
+    if table is not SINGLE_TABLE:
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     partition_on = normalize_arg("partition_on", partition_on)
     secondary_indices = normalize_arg("secondary_indices", secondary_indices)
     delete_scope = dask.delayed(normalize_arg)("delete_scope", delete_scope)
@@ -369,6 +381,12 @@ def collect_dataset_metadata(
       If no metadata could be retrieved, raise an error.
 
     """
+    if table_name is not SINGLE_TABLE:
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     if not 0.0 < frac <= 1.0:
         raise ValueError(
             f"Invalid value for parameter `frac`: {frac}."
@@ -451,6 +469,12 @@ def hash_dataset(
     group_key:
         If provided, calculate hash per group instead of per partition
     """
+    if table is not SINGLE_TABLE:
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     dataset_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
         store=store,

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-
-
+import warnings
 from collections import defaultdict
 from functools import partial
 
@@ -271,6 +270,12 @@ def read_dataset_as_delayed_metapartitions(
     ----------
 
     """
+    if tables is not None or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     ds_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
         store=store,
@@ -352,6 +357,12 @@ def read_dataset_as_delayed(
     Parameters
     ----------
     """
+    if tables is not None or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     mps = read_dataset_as_delayed_metapartitions(
         dataset_uuid=dataset_uuid,
         store=store,
@@ -404,6 +415,12 @@ def read_table_as_delayed(
     Parameters
     ----------
     """
+    if table is not SINGLE_TABLE or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     if not isinstance(columns, dict):
         columns = {table: columns}
     mps = read_dataset_as_delayed_metapartitions(

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -124,6 +124,12 @@ def read_dataset_as_dataframes(
 
     """
 
+    if tables is not None or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     ds_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
         store=_make_callable(store),
@@ -191,6 +197,12 @@ def read_dataset_as_metapartitions(
         >>> list_mps = read_dataset_as_metapartitions('dataset_uuid', store, 'core')
 
     """
+
+    if tables is not None or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
 
     ds_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
@@ -279,6 +291,13 @@ def read_table(
         >>> df = read_table(store, 'dataset_uuid', 'core')
 
     """
+
+    if table is not SINGLE_TABLE or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     if concat_partitions_on_primary_index is not False:
         warnings.warn(
             "The keyword `concat_partitions_on_primary_index` is deprecated and will be removed in the next major release.",

--- a/kartothek/io/iter.py
+++ b/kartothek/io/iter.py
@@ -60,6 +60,11 @@ def read_dataset_as_metapartitions__iterator(
     ----------
 
     """
+    if tables is not None or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
 
     ds_factory = _ensure_factory(
         dataset_uuid=dataset_uuid,
@@ -159,6 +164,12 @@ def read_dataset_as_dataframes__iterator(
             {'core': pd.DataFrame, 'lookup': pd.DataFrame}
         ]
     """
+    if tables is not None or isinstance(columns, dict):
+        warnings.warn(
+            "Deprecation Warning: Multi-table support will be deprecated in upcoming major release.",
+            DeprecationWarning,
+        )
+
     mp_iter = read_dataset_as_metapartitions__iterator(
         dataset_uuid=dataset_uuid,
         store=store,


### PR DESCRIPTION
Deprecation warning for multi table support

# Description:

Updated the read functions in kartothek (`read_dataset_as.*` and `read_table.*`) with a check to provide the warning for deprecation of multi table support in next major release.

