### PR TITLE
Missing typing_extensions requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,15 +76,27 @@ jobs:
         # nightlies and the latest release would otherwise work together.
         run: conda install -c arrow-nightlies arrow-cpp pyarrow
         if: matrix.pyarrow == 'nightly'
-      - name: Conda Install conda-requirements.txt + conda-test-requirements.txt
+      - name: Conda Install conda-requirements.txt
         # run this AFTER pyarrow, since this is less restrictive (so conda doesn't spend too much time downgrading)
-        run: conda install --file=conda-requirements.txt --file=conda-test-requirements.txt
+        run: conda install --file=conda-requirements.txt
+      - name: Pip Install kartothek
+        run: pip install --no-deps .
+      - name: Test import
+        run: |
+          python -c "import kartothek"
+          python -c "import kartothek.api"
+          python -c "import kartothek.cli"
+          python -c "import kartothek.core"
+          python -c "import kartothek.io"
+          python -c "import kartothek.io_components"
+          python -c "import kartothek.serialization"
+          python -c "import kartothek.utils"
+      - name: Conda install test requirements
+        run: conda install --file=conda-test-requirements.txt
       - name: Pip Instal NumFOCUS nightly
         # NumFOCUS nightly wheels, contains numpy and pandas
         run: env PRE_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple" pip install --pre --upgrade --timeout=60 -f $PRE_WHEELS pandas numpy
         if: matrix.numfocus_nightly
-      - name: Pip Install kartothek
-        run: pip install --no-deps -e .
       - name: Conda Export
         run: conda list --export
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 3.15.1 (2020-09-28)
+===========================
+* Fix a packaging issue where `typing_extensions` was not properly specified as
+  a requirement for python versions below 3.8
+
 Version 3.15.0 (2020-09-28)
 ===========================
 

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -9,6 +9,7 @@ simplejson
 simplekv
 storefact
 toolz
+typing_extensions # Some backports of the py3.8 typing module
 urlquote>=1.1.3
 zstandard
 attrs

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ simplejson
 simplekv
 storefact
 toolz
+typing_extensions; python_version<"3.8"  # Some backports of the py3.8 typing module
 urlquote>=1.1.3
 zstandard
 attrs


### PR DESCRIPTION
# Description:

The released wheel only works for py3.8 :/

This change in CI tests the import of the package before we install the test requirements. Alternatively we could setup a fresh env after wheel build and verify the wheel itself. This one is _probably_ the fastest (haven't verified)
