### PR TITLE
Fix get_parquet_metadata sometimes returning empty statistics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 3.16.1 (2020-10-??)
+===========================
+* Fix an issue where :func:`~kartothek.io.dask.dataframe.collect_dataset_metadata` would return
+  improper rowgroup statistics
+
+
 Version 3.16.0 (2020-09-29)
 ===========================
 


### PR DESCRIPTION
# Description:

This addresses https://issues.apache.org/jira/browse/ARROW-10146 by not relying on the AttributeError. I encountered hitting this for non-empty files which would otherwise cause wrong statistics. I couldn't track down what makes those files special, therefore no test :(