### PR TITLE
Do not call get_parquet_metadata at graph construction time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 3.16.1 (2020-10-??)
+===========================
+
+* Fix an issue where :func:`~kartothek.io.dask.dataframe.collect_dataset_metadata` would execute
+  ``get_parquet_metadata`` at graph construction time
+
 Version 3.16.0 (2020-09-29)
 ===========================
 

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -511,7 +511,8 @@ def collect_dataset_metadata(
                     mp, store=dataset_factory.store_factory, table_name=table_name
                 )
                 for mp in mps
-            ]
+            ],
+            meta=_METADATA_SCHEMA,
         )
     else:
         df = pd.DataFrame(columns=_METADATA_SCHEMA.keys())


### PR DESCRIPTION
# Description:

Without this, the function is already executed once during graph construction to determine the schema 
