### PR TITLE
maint: remove utils._make_callable

### DIFF
--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -4,7 +4,7 @@ This module is a collection of helper functions
 import collections
 import inspect
 import logging
-from typing import Callable, List, Optional, TypeVar, Union, overload
+from typing import List, Optional, TypeVar, Union, overload
 
 import decorator
 import pandas as pd
@@ -415,39 +415,6 @@ def raise_if_indices_overlap(partition_on, secondary_indices):
         raise RuntimeError(
             f"Cannot create secondary index on partition columns: {partition_secondary_overlap}"
         )
-
-
-class NoPickleFactory:
-    def __init__(self, obj):
-        self.obj = obj
-
-    def __call__(self):
-        return self.obj
-
-    def __getstate__(self):
-        raise TypeError("Serialization not allowed. Please use a proper store factory.")
-
-
-# Better typing of this is currently not possible: https://github.com/python/typing/issues/614
-# @overload
-# def _make_callable(obj: None) -> None:
-#     ...
-#
-# @overload
-# def _make_callable(obj: Any) -> Callable:
-#     ...
-
-
-def _make_callable(obj) -> Optional[Callable]:
-    """
-    Converting a plain store to a simple callable is perfectly fine for
-    eager/iter/etc backends. Must not be used if the store/factory is serialized.
-    """
-    if obj is None:
-        return obj
-    if not callable(obj):
-        return NoPickleFactory(obj)
-    return obj
 
 
 class NoDefault:


### PR DESCRIPTION
# Description:

A bit of maintenance. The `_make_callable` has been replaced by the `lazy_store` which is automatically called by ensure_factory