### PR TITLE
Disable pip interop in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
         run: |
           conda config --set always_yes yes
           conda config --set changeps1 no
-          conda config --set pip_interop_enabled True
 
       # Installation into the `test` environment
       - name: Conda Install Pyarrow (non-nightly)


### PR DESCRIPTION
Fixes #381

Otherwise `conda` thinks it needs to upgrade the installed `kartothek` version. We otherwise only use conda packages in the CI and thus the best way is to tell conda not to touch any `pip`/`pypi` installed packages instead of guessing what to do with them. The problems in #380 didn't occur much earlier as `conda` always installed the latest release and that was mostly fine in CI.

- [x] Closes #xxxx
- [ ] Changelog entry (don't think this is needed here)
