### PR TITLE
CI: test pandas nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         include:
           - numfocus_nightly: true
             os: "ubuntu-latest"
-            pyarrow: "0.17.1"
+            pyarrow: "2.0.0"
             python: "3.8"
           - numfocus_nightly: false
             os: "macos-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: conda install --file=conda-test-requirements.txt
       - name: Pip Instal NumFOCUS nightly
         # NumFOCUS nightly wheels, contains numpy and pandas
-        run: env PRE_WHEELS="https://pypi.anaconda.org/scipy-wheels-nightly/simple" pip install --pre --upgrade --timeout=60 -f $PRE_WHEELS pandas numpy
+        run: pip install --pre --upgrade --timeout=60 --extra-index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple pandas numpy
         if: matrix.numfocus_nightly
       - name: Conda Export
         run: conda list --export

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,8 @@ jobs:
       # Linters
       - name: Flake8
         run: flake8
-      - name: Mypy
-        run: mypy .
+      # - name: Mypy
+      #   run: mypy .
       - name: Black
         run: black --check .
       - name: blacken-docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,9 @@ jobs:
       # Linters
       - name: Flake8
         run: flake8
-      # - name: Mypy
-      #   run: mypy .
+      - name: Mypy
+        run: mypy .
+        if: !matrix.numfocus_nightly
       - name: Black
         run: black --check .
       - name: blacken-docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         run: flake8
       - name: Mypy
         run: mypy .
-        if: !matrix.numfocus_nightly
+        if: ${{ !matrix.numfocus_nightly }}
       - name: Black
         run: black --check .
       - name: blacken-docs


### PR DESCRIPTION
I was checking if kartothek tested against pandas nightly / rc (to otherwise do a test PR to check pandas 1.2.0rc), and noticed that the current spelling of the pip install didn't actually work to install pandas from the nightly wheels.
