### PR TITLE
cubes: add option to suppress auto index creation for dimension columns

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,14 @@
 Changelog
 =========
 
-Version 3.17.3 (2010-12-04)
+
+Version 3.X.Y (2021-01-DD; unreleased)
+======================================
+
+* Add ``cube.suppress_index_on`` to switch off the default index creation for dimension columns
+
+
+Version 3.17.3 (2020-12-04)
 ===========================
 
 * Allow ``pyarrow==2`` as a dependency.

--- a/kartothek/api/consistency.py
+++ b/kartothek/api/consistency.py
@@ -197,8 +197,10 @@ def _check_indices(datasets: Dict[str, DatasetMetadata], cube: Cube) -> None:
     """
     Check if required indices are present in given datasets.
 
-    For all datasets the primary indices must be equal to ``ds.partition_keys``. For the seed dataset secondary
-    indices for all dimension columns are expected.
+    For all datasets the primary indices must be equal to ``ds.partition_keys``. For the seed dataset, secondary
+    indices for all dimension columns except ``cube.suppress_index_on`` are expected.
+
+    Additional indices are accepted and will not bew reported as error.
 
     Parameters
     ----------
@@ -219,7 +221,9 @@ def _check_indices(datasets: Dict[str, DatasetMetadata], cube: Cube) -> None:
         any_indices = set(cube.index_columns) & columns
 
         if ktk_cube_dataset_id == cube.seed_dataset:
-            secondary_indices |= set(cube.dimension_columns)
+            secondary_indices |= set(cube.dimension_columns) - set(
+                cube.suppress_index_on
+            )
 
         for types_untyped, elements in (
             ((PartitionIndex,), primary_indices),

--- a/kartothek/api/discover.py
+++ b/kartothek/api/discover.py
@@ -9,6 +9,7 @@ from kartothek.core.cube.constants import (
     KTK_CUBE_METADATA_DIMENSION_COLUMNS,
     KTK_CUBE_METADATA_KEY_IS_SEED,
     KTK_CUBE_METADATA_PARTITION_COLUMNS,
+    KTK_CUBE_METADATA_SUPPRESS_INDEX_ON,
     KTK_CUBE_UUID_SEPERATOR,
 )
 from kartothek.core.cube.cube import Cube
@@ -305,6 +306,7 @@ def discover_cube(
         partition_columns=partition_columns,
         index_columns=index_columns,
         seed_dataset=seed_dataset,
+        suppress_index_on=seed_ds.metadata.get(KTK_CUBE_METADATA_SUPPRESS_INDEX_ON),
     )
 
     datasets = check_datasets(datasets, cube)

--- a/kartothek/core/cube/constants.py
+++ b/kartothek/core/cube/constants.py
@@ -41,5 +41,8 @@ KTK_CUBE_METADATA_DIMENSION_COLUMNS = "ktk_cube_dimension_columns"
 #: Metadata key to store partition columns
 KTK_CUBE_METADATA_PARTITION_COLUMNS = "ktk_cube_partition_columns"
 
+#: Metadata key to store the set of dimension columns index creation is suppressed for
+KTK_CUBE_METADATA_SUPPRESS_INDEX_ON = "ktk_cube_suppress_index_on"
+
 #: Character sequence used to seperate cube and dataset UUID
 KTK_CUBE_UUID_SEPERATOR = "++"

--- a/kartothek/io/dask/common_cube.py
+++ b/kartothek/io/dask/common_cube.py
@@ -516,9 +516,6 @@ def _multiplex_store_dataset_from_partitions_flat(
     result = {}
     for k, v in dct.items():
         if update:
-            print(
-                f"_multiplex_store_dataset_from_partitions_flat: {k} delete scope: {delete_scopes.get(k, [])}"
-            )
             ds_factory = metadata_factory_from_dataset(
                 existing_datasets[k], with_schema=True, store=store
             )

--- a/kartothek/io/dask/dataframe_cube.py
+++ b/kartothek/io/dask/dataframe_cube.py
@@ -95,7 +95,7 @@ def build_cube_from_dataframe(
 
         indices_to_build = set(cube.index_columns) & set(ddf.columns)
         if table_name == cube.seed_dataset:
-            indices_to_build |= set(cube.dimension_columns)
+            indices_to_build |= set(cube.dimension_columns) - cube.suppress_index_on
         indices_to_build -= set(partition_on_checked[table_name])
 
         ddf = ddf.map_partitions(

--- a/kartothek/io/testing/append_cube.py
+++ b/kartothek/io/testing/append_cube.py
@@ -5,6 +5,7 @@ from kartothek.core.cube.constants import (
     KTK_CUBE_METADATA_DIMENSION_COLUMNS,
     KTK_CUBE_METADATA_KEY_IS_SEED,
     KTK_CUBE_METADATA_PARTITION_COLUMNS,
+    KTK_CUBE_METADATA_SUPPRESS_INDEX_ON,
 )
 from kartothek.core.cube.cube import Cube
 from kartothek.core.dataset import DatasetMetadata
@@ -307,6 +308,7 @@ def test_metadata(driver, function_store, existing_cube):
         KTK_CUBE_METADATA_DIMENSION_COLUMNS,
         KTK_CUBE_METADATA_KEY_IS_SEED,
         KTK_CUBE_METADATA_PARTITION_COLUMNS,
+        KTK_CUBE_METADATA_SUPPRESS_INDEX_ON,
     }
     assert ds_source.metadata["a"] == 12
     assert ds_source.metadata["b"] == 11
@@ -318,6 +320,7 @@ def test_metadata(driver, function_store, existing_cube):
     assert ds_source.metadata[KTK_CUBE_METADATA_PARTITION_COLUMNS] == list(
         existing_cube.partition_columns
     )
+    assert ds_source.metadata[KTK_CUBE_METADATA_SUPPRESS_INDEX_ON] == []
 
     ds_enrich = DatasetMetadata.load_from_store(
         existing_cube.ktk_dataset_uuid("enrich"), function_store()
@@ -329,6 +332,7 @@ def test_metadata(driver, function_store, existing_cube):
         KTK_CUBE_METADATA_DIMENSION_COLUMNS,
         KTK_CUBE_METADATA_KEY_IS_SEED,
         KTK_CUBE_METADATA_PARTITION_COLUMNS,
+        KTK_CUBE_METADATA_SUPPRESS_INDEX_ON,
     }
     assert ds_enrich.metadata["a"] == 20
     assert ds_enrich.metadata["b"] == 21
@@ -339,3 +343,4 @@ def test_metadata(driver, function_store, existing_cube):
     assert ds_enrich.metadata[KTK_CUBE_METADATA_PARTITION_COLUMNS] == list(
         existing_cube.partition_columns
     )
+    assert ds_source.metadata[KTK_CUBE_METADATA_SUPPRESS_INDEX_ON] == []

--- a/kartothek/io_components/cube/write.py
+++ b/kartothek/io_components/cube/write.py
@@ -15,6 +15,7 @@ from kartothek.core.cube.constants import (
     KTK_CUBE_METADATA_DIMENSION_COLUMNS,
     KTK_CUBE_METADATA_KEY_IS_SEED,
     KTK_CUBE_METADATA_PARTITION_COLUMNS,
+    KTK_CUBE_METADATA_SUPPRESS_INDEX_ON,
     KTK_CUBE_METADATA_VERSION,
 )
 from kartothek.core.cube.cube import Cube
@@ -124,6 +125,7 @@ def prepare_ktk_metadata(cube, ktk_cube_dataset_id, metadata):
         ktk_cube_dataset_id == cube.seed_dataset
     )
     ds_metadata[KTK_CUBE_METADATA_PARTITION_COLUMNS] = list(cube.partition_columns)
+    ds_metadata[KTK_CUBE_METADATA_SUPPRESS_INDEX_ON] = list(cube.suppress_index_on)
 
     return ds_metadata
 
@@ -372,7 +374,7 @@ def prepare_data_for_ktk(
     # calculate indices
     indices_to_build = set(cube.index_columns) & df_columns_set
     if ktk_cube_dataset_id == cube.seed_dataset:
-        indices_to_build |= set(cube.dimension_columns)
+        indices_to_build |= set(cube.dimension_columns) - set(cube.suppress_index_on)
     indices_to_build -= set(partition_on)
 
     mp = mp.build_indices(indices_to_build)

--- a/tests/cli/test_info.py
+++ b/tests/cli/test_info.py
@@ -50,7 +50,8 @@ Metadata:
     "ktk_cube_partition_columns": [
       "p",
       "q"
-    ]
+    ],
+    "ktk_cube_suppress_index_on": []
   }
 Dimension Columns:
   - y: int64
@@ -75,7 +76,8 @@ Metadata:
     "ktk_cube_partition_columns": [
       "p",
       "q"
-    ]
+    ],
+    "ktk_cube_suppress_index_on": []
   }
 Dimension Columns:
   - x: int64

--- a/tests/core/cube/test_cube.py
+++ b/tests/core/cube/test_cube.py
@@ -10,6 +10,7 @@ def test_defaults():
     assert isinstance(cube.seed_dataset, str)
 
     assert cube.index_columns == set()
+    assert cube.suppress_index_on == set()
 
 
 def test_converters():
@@ -19,6 +20,7 @@ def test_converters():
         uuid_prefix=b"my_prefix",
         seed_dataset=b"my_seed",
         index_columns=b"my_index",
+        suppress_index_on=b"my_dim",
     )
 
     assert cube.dimension_columns == ("my_dim",)
@@ -35,6 +37,8 @@ def test_converters():
 
     assert cube.index_columns == {"my_index"}
     assert all(isinstance(s, str) for s in cube.index_columns)
+
+    assert cube.suppress_index_on == {"my_dim"}
 
 
 def test_frozen():
@@ -119,6 +123,21 @@ def test_init_fail_index_columns_subsetof_partition_columns():
     assert (
         str(exc.value)
         == "index_columns cannot share columns with partition_columns, but share the following: q, r"
+    )
+
+
+def test_init_fail_suppress_index_on_not_subsetof_dimension_columns():
+    with pytest.raises(ValueError) as exc:
+        Cube(
+            dimension_columns=["x", "y", "z"],
+            partition_columns=["p", "q", "r"],
+            uuid_prefix="cube",
+            index_columns=[],
+            suppress_index_on=["x", "a", "b"],
+        )
+    assert (
+        str(exc.value)
+        == "suppress_index_on must be a subset of dimension_columns, but it has additional values: a, b"
     )
 
 

--- a/tests/io_components/cube/test_write.py
+++ b/tests/io_components/cube/test_write.py
@@ -4,6 +4,7 @@ from kartothek.core.cube.constants import (
     KTK_CUBE_METADATA_DIMENSION_COLUMNS,
     KTK_CUBE_METADATA_KEY_IS_SEED,
     KTK_CUBE_METADATA_PARTITION_COLUMNS,
+    KTK_CUBE_METADATA_SUPPRESS_INDEX_ON,
 )
 from kartothek.core.cube.cube import Cube
 from kartothek.io_components.cube.write import (
@@ -28,6 +29,7 @@ def test_prepare_ktk_metadata_simple(cube):
         KTK_CUBE_METADATA_DIMENSION_COLUMNS: ["x"],
         KTK_CUBE_METADATA_PARTITION_COLUMNS: ["p"],
         KTK_CUBE_METADATA_KEY_IS_SEED: True,
+        KTK_CUBE_METADATA_SUPPRESS_INDEX_ON: [],
     }
 
 
@@ -37,6 +39,18 @@ def test_prepare_ktk_metadata_no_source(cube):
         KTK_CUBE_METADATA_DIMENSION_COLUMNS: ["x"],
         KTK_CUBE_METADATA_PARTITION_COLUMNS: ["p"],
         KTK_CUBE_METADATA_KEY_IS_SEED: False,
+        KTK_CUBE_METADATA_SUPPRESS_INDEX_ON: [],
+    }
+
+
+def test_prepare_ktk_metadata_suppress_index_on(cube):
+    cube = cube.copy(suppress_index_on=["x"])
+    metadata = prepare_ktk_metadata(cube, "no_source", None)
+    assert metadata == {
+        KTK_CUBE_METADATA_DIMENSION_COLUMNS: ["x"],
+        KTK_CUBE_METADATA_PARTITION_COLUMNS: ["p"],
+        KTK_CUBE_METADATA_KEY_IS_SEED: False,
+        KTK_CUBE_METADATA_SUPPRESS_INDEX_ON: ["x"],
     }
 
 
@@ -50,6 +64,7 @@ def test_prepare_ktk_metadata_usermeta(cube):
         KTK_CUBE_METADATA_DIMENSION_COLUMNS: ["x"],
         KTK_CUBE_METADATA_PARTITION_COLUMNS: ["p"],
         KTK_CUBE_METADATA_KEY_IS_SEED: False,
+        KTK_CUBE_METADATA_SUPPRESS_INDEX_ON: [],
         "user_key0": "value0",
     }
 


### PR DESCRIPTION
For large datasets, the automatic index creation can be a performance problem. Also, at some point of dataset size, there is the risk that the 2GB limit pyarrow has is hit. Therefore, it is desirable to switch off thye current default behaviour of creating a secondary index for all dimension columns.

This change would keep the current default of creating an index for all dimension columns. It adds  `cube.suppress_index_on`, which can be set to the subset of dimension columns to suppress the index creation for.
