### PR TITLE
fix zstd/zstandard import error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ Version 3.X.Y (2021-01-DD; unreleased)
 ======================================
 
 * Add ``cube.suppress_index_on`` to switch off the default index creation for dimension columns
-
+* Fixed the import issue of zstd module for `kartothek.core _zmsgpack`.
 
 Version 3.17.3 (2020-12-04)
 ===========================

--- a/kartothek/core/_zmsgpack.py
+++ b/kartothek/core/_zmsgpack.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 import msgpack
-import zstd  # type: ignore
+try:
+    import zstandard as zstd
+except ImportError:
+    # zstandard < 0.15.0
+    import zstd  # type: ignore
 
 
 def packb(obj):

--- a/kartothek/core/_zmsgpack.py
+++ b/kartothek/core/_zmsgpack.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import msgpack
+
 try:
     import zstandard as zstd
 except ImportError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,3 @@ attrs
 click
 prompt-toolkit
 pyyaml
-zstd

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ attrs
 click
 prompt-toolkit
 pyyaml
+zstd


### PR DESCRIPTION
# Description:

The _zmsgpack.py (kartothek.core.cube) uses zstd module for the compressor and decompressor technique. I have updated the requirements.txt with the module name.



- [ ] Closes The build failure of https://travis-ci.com/github/JDASoftwareGroup/kartothek_hive_integration_test/builds/213539032

