### PR TITLE
Ensure updates on neither cube nor plain datasets corrupt indices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 3.18.1 (2021-02-XY)
+===========================
+
+* Fix an issue where updates on cubes or updates on datatsets using
+  dask.dataframe might not update all secondary indices, resulting in a corrupt
+  state after the update
 
 Version 3.18.0 (2021-01-25)
 ===========================

--- a/docs/guide/mutating_datasets.rst
+++ b/docs/guide/mutating_datasets.rst
@@ -331,7 +331,7 @@ When garbage collection is called, the files are removed.
 Mutating indexed datasets
 -------------------------
 
-If the to-be-updated dataset was created with an index, every update on this dataset will update the index automatically and ensure the dataset will never end up in an inconsistent state. This even holds true in case the update function does not specify any or only partially the indices. Consider the following example
+The mutating operation will update all indices that currently exist for the dataset. This even holds true in case the update function does not specify any or only partially the indices. Consider the following example
 
 .. ipython:: python
 
@@ -368,4 +368,3 @@ This is even true if only a subset is given
     dm = dm.load_all_indices(store_url)
     dm.indices["i1"].observed_values()
     dm.indices["i2"].observed_values()
-

--- a/docs/guide/mutating_datasets.rst
+++ b/docs/guide/mutating_datasets.rst
@@ -1,4 +1,4 @@
-
+.. _mutating_datasets:
 
 Mutating Datasets
 =================
@@ -286,6 +286,8 @@ consists of two rows corresponding to ``B=2013-01-02`` (from ``df``) and four ro
 Thus, the original partition with the two rows corresponding to ``B=2013-01-03`` from ``df``
 has been completely replaced.
 
+
+
 Garbage collection
 ------------------
 
@@ -324,3 +326,46 @@ When garbage collection is called, the files are removed.
     files_before.difference(store.keys())  # Show files removed
 
 .. _storefact: https://github.com/blue-yonder/storefact
+
+
+Mutating indexed datasets
+-------------------------
+
+If the to-be-updated dataset was created with an index, every update on this dataset will update the index automatically and ensure the dataset will never end up in an inconsistent state. This even holds true in case the update function does not specify any or only partially the indices. Consider the following example
+
+.. ipython:: python
+
+    df = pd.DataFrame({"payload": range(10), "i1": 0, "i2": ["a"] * 5 + ["b"] * 5})
+    dm = store_dataframes_as_dataset(
+        store_url, "indexed_dataset", [df], secondary_indices=["i1", "i2"]
+    )
+    dm = dm.load_all_indices(store_url)
+    dm.indices["i1"].observed_values()
+    dm.indices["i2"].observed_values()
+
+    new_df = pd.DataFrame({"payload": range(10), "i1": 1, "i2": "c"})
+
+If we do not specify anything, kartothek will infer the indices and update them correctly
+
+.. ipython:: python
+
+    dm = update_dataset_from_dataframes([new_df], store=store_url, dataset_uuid=dm.uuid)
+
+    dm = dm.load_all_indices(store_url)
+    dm.indices["i1"].observed_values()
+    dm.indices["i2"].observed_values()
+
+
+This is even true if only a subset is given
+
+.. ipython:: python
+
+    new_df = pd.DataFrame({"payload": range(10), "i1": 2, "i2": "d"})
+    dm = update_dataset_from_dataframes(
+        [new_df], store=store_url, dataset_uuid=dm.uuid, secondary_indices="i1"
+    )
+
+    dm = dm.load_all_indices(store_url)
+    dm.indices["i1"].observed_values()
+    dm.indices["i2"].observed_values()
+

--- a/kartothek/api/consistency.py
+++ b/kartothek/api/consistency.py
@@ -200,7 +200,7 @@ def _check_indices(datasets: Dict[str, DatasetMetadata], cube: Cube) -> None:
     For all datasets the primary indices must be equal to ``ds.partition_keys``. For the seed dataset, secondary
     indices for all dimension columns except ``cube.suppress_index_on`` are expected.
 
-    Additional indices are accepted and will not bew reported as error.
+    Additional indices are accepted and will not be reported as error.
 
     Parameters
     ----------

--- a/kartothek/io/dask/_shuffle.py
+++ b/kartothek/io/dask/_shuffle.py
@@ -12,6 +12,12 @@ from kartothek.io_components.metapartition import MetaPartition
 from kartothek.io_components.write import write_partition
 from kartothek.serialization import DataFrameSerializer
 
+try:
+    from typing_extensions import Literal  # type: ignore
+except ImportError:
+    from typing import Literal  # type: ignore
+
+
 _KTK_HASH_BUCKET = "__KTK_HASH_BUCKET"
 
 
@@ -35,7 +41,7 @@ def _hash_bucket(df: pd.DataFrame, subset: Optional[Sequence[str]], num_buckets:
 def shuffle_store_dask_partitions(
     ddf: dd.DataFrame,
     table: str,
-    secondary_indices: Optional[Union[str, Sequence[str]]],
+    secondary_indices: Optional[Union[Literal[False], Sequence[str]]],
     metadata_version: int,
     partition_on: List[str],
     store_factory: StoreFactory,

--- a/kartothek/io/dask/_shuffle.py
+++ b/kartothek/io/dask/_shuffle.py
@@ -9,7 +9,7 @@ import pandas as pd
 from kartothek.core.typing import StoreFactory
 from kartothek.io.dask.compression import pack_payload, unpack_payload_pandas
 from kartothek.io_components.metapartition import MetaPartition
-from kartothek.io_components.utils import INFERRED_INDICES
+from kartothek.io_components.utils import InferredIndices
 from kartothek.io_components.write import write_partition
 from kartothek.serialization import DataFrameSerializer
 
@@ -36,7 +36,7 @@ def _hash_bucket(df: pd.DataFrame, subset: Optional[Sequence[str]], num_buckets:
 def shuffle_store_dask_partitions(
     ddf: dd.DataFrame,
     table: str,
-    secondary_indices: Optional[INFERRED_INDICES],
+    secondary_indices: Optional[InferredIndices],
     metadata_version: int,
     partition_on: List[str],
     store_factory: StoreFactory,
@@ -132,7 +132,7 @@ def shuffle_store_dask_partitions(
 
 def _unpack_store_partition(
     df: pd.DataFrame,
-    secondary_indices: Optional[INFERRED_INDICES],
+    secondary_indices: Optional[InferredIndices],
     sort_partitions_by: List[str],
     table: str,
     dataset_uuid: str,

--- a/kartothek/io/dask/bag_cube.py
+++ b/kartothek/io/dask/bag_cube.py
@@ -442,6 +442,10 @@ def update_cube_from_bag(
     metadata_dict: dask.bag.Bag
         A dask bag object containing the compute graph to append to the cube returning the dict of dataset metadata
         objects. The bag has a single partition with a single element.
+
+    See Also
+    --------
+    :ref:`mutating_datasets`
     """
     return append_to_cube_from_bag_internal(
         data=data,

--- a/kartothek/io/dask/common_cube.py
+++ b/kartothek/io/dask/common_cube.py
@@ -33,7 +33,6 @@ from kartothek.io_components.cube.write import (
     prepare_ktk_partition_on,
 )
 from kartothek.io_components.metapartition import (
-    SINGLE_TABLE,
     MetaPartition,
     parse_input_to_metapartition,
 )
@@ -67,13 +66,14 @@ def ensure_valid_cube_indices(
     required_indices = set(cube.index_columns)
     suppress_index_on = set(cube.suppress_index_on)
     for ds in existing_datasets.values():
-        dataset_columns = set(ds.table_meta[SINGLE_TABLE].names)
-        table_indices = required_indices & dataset_columns
-        compatible_indices = _ensure_compatible_indices(ds, table_indices)
-        if compatible_indices:
-            dataset_indices = set(compatible_indices)
-            suppress_index_on -= dataset_indices
-            required_indices |= dataset_indices
+        for internal_table in ds.table_meta:
+            dataset_columns = set(ds.table_meta[internal_table].names)
+            table_indices = required_indices & dataset_columns
+            compatible_indices = _ensure_compatible_indices(ds, table_indices)
+            if compatible_indices:
+                dataset_indices = set(compatible_indices)
+                suppress_index_on -= dataset_indices
+                required_indices |= dataset_indices
     # Need to remove dimension columns since they *are* technically indices but
     # the cube interface class declares them as not indexed just to add them
     # later on, assuming it is not blacklisted

--- a/kartothek/io/dask/common_cube.py
+++ b/kartothek/io/dask/common_cube.py
@@ -71,9 +71,9 @@ def ensure_valid_cube_indices(
         table_indices = required_indices & dataset_columns
         compatible_indices = _ensure_compatible_indices(ds, table_indices)
         if compatible_indices:
-            required_indices = set(compatible_indices)
-            suppress_index_on -= required_indices
-            required_indices |= required_indices
+            dataset_indices = set(compatible_indices)
+            suppress_index_on -= dataset_indices
+            required_indices |= dataset_indices
     # Need to remove dimension columns since they *are* technically indices but
     # the cube interface class declares them as not indexed just to add them
     # later on, assuming it is not blacklisted

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -49,6 +49,11 @@ from ._shuffle import shuffle_store_dask_partitions
 from ._utils import _maybe_get_categoricals_from_index
 from .delayed import read_table_as_delayed
 
+try:
+    from typing_extensions import Literal  # type: ignore
+except ImportError:
+    from typing import Literal  # type: ignore
+
 
 @default_docs
 @normalize_args
@@ -321,7 +326,7 @@ def _write_dataframe_partitions(
     store: StoreFactory,
     dataset_uuid: str,
     table: str,
-    secondary_indices: List[str],
+    secondary_indices: Union[Literal[False], List[str]],
     shuffle: bool,
     repartition_ratio: Optional[SupportsFloat],
     num_buckets: int,
@@ -415,7 +420,8 @@ def update_dataset_from_ddf(
         ds_factory=factory,
     )
 
-    _ensure_compatible_indices(ds_factory, secondary_indices)
+    inferred_indices = _ensure_compatible_indices(ds_factory, secondary_indices)
+    del secondary_indices
 
     if ds_factory is not None:
         check_single_table_dataset(ds_factory, table)
@@ -425,7 +431,7 @@ def update_dataset_from_ddf(
         store=store,
         dataset_uuid=dataset_uuid or ds_factory.dataset_uuid,
         table=table,
-        secondary_indices=secondary_indices,
+        secondary_indices=inferred_indices,
         shuffle=shuffle,
         repartition_ratio=repartition_ratio,
         num_buckets=num_buckets,

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -32,7 +32,7 @@ from kartothek.io_components.metapartition import (
 from kartothek.io_components.read import dispatch_metapartitions_from_factory
 from kartothek.io_components.update import update_dataset_from_partitions
 from kartothek.io_components.utils import (
-    INFERRED_INDICES,
+    InferredIndices,
     _ensure_compatible_indices,
     check_single_table_dataset,
     normalize_arg,
@@ -322,7 +322,7 @@ def _write_dataframe_partitions(
     store: StoreFactory,
     dataset_uuid: str,
     table: str,
-    secondary_indices: Optional[INFERRED_INDICES],
+    secondary_indices: Optional[InferredIndices],
     shuffle: bool,
     repartition_ratio: Optional[SupportsFloat],
     num_buckets: int,

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -32,6 +32,7 @@ from kartothek.io_components.metapartition import (
 from kartothek.io_components.read import dispatch_metapartitions_from_factory
 from kartothek.io_components.update import update_dataset_from_partitions
 from kartothek.io_components.utils import (
+    INFERRED_INDICES,
     _ensure_compatible_indices,
     check_single_table_dataset,
     normalize_arg,
@@ -48,11 +49,6 @@ from kartothek.serialization import DataFrameSerializer, PredicatesType
 from ._shuffle import shuffle_store_dask_partitions
 from ._utils import _maybe_get_categoricals_from_index
 from .delayed import read_table_as_delayed
-
-try:
-    from typing_extensions import Literal  # type: ignore
-except ImportError:
-    from typing import Literal  # type: ignore
 
 
 @default_docs
@@ -326,7 +322,7 @@ def _write_dataframe_partitions(
     store: StoreFactory,
     dataset_uuid: str,
     table: str,
-    secondary_indices: Union[Literal[False], List[str]],
+    secondary_indices: Optional[INFERRED_INDICES],
     shuffle: bool,
     repartition_ratio: Optional[SupportsFloat],
     num_buckets: int,

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -398,6 +398,10 @@ def update_dataset_from_ddf(
 ):
     """
     Update a dataset from a dask.dataframe.
+
+    See Also
+    --------
+    :ref:`mutating_datasets`
     """
     partition_on = normalize_arg("partition_on", partition_on)
     secondary_indices = normalize_arg("secondary_indices", secondary_indices)

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -464,6 +464,10 @@ def update_dataset_from_delayed(
 
     Parameters
     ----------
+
+    See Also
+    --------
+    :ref:`mutating_datasets`
     """
     partition_on = normalize_arg("partition_on", partition_on)
     store = normalize_arg("store", store)

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -749,12 +749,13 @@ def update_dataset_from_dataframes(
         partition_on=partition_on,
     )
 
-    secondary_indices = _ensure_compatible_indices(ds_factory, secondary_indices)
+    inferred_indices = _ensure_compatible_indices(ds_factory, secondary_indices)
+    del secondary_indices
 
     mp = parse_input_to_metapartition(
         df_list,
         metadata_version=metadata_version,
-        expected_secondary_indices=secondary_indices,
+        expected_secondary_indices=inferred_indices,
     )
 
     if sort_partitions_by:
@@ -763,8 +764,8 @@ def update_dataset_from_dataframes(
     if partition_on:
         mp = mp.partition_on(partition_on)
 
-    if secondary_indices:
-        mp = mp.build_indices(secondary_indices)
+    if inferred_indices:
+        mp = mp.build_indices(inferred_indices)
 
     mp = mp.store_dataframes(
         store=store, dataset_uuid=dataset_uuid, df_serializer=df_serializer

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -728,6 +728,10 @@ def update_dataset_from_dataframes(
     Returns
     -------
     The dataset metadata object (:class:`~kartothek.core.dataset.DatasetMetadata`).
+
+    See Also
+    --------
+    :ref:`mutating_datasets`
     """
     if load_dynamic_metadata is not True:
         warnings.warn(

--- a/kartothek/io/iter.py
+++ b/kartothek/io/iter.py
@@ -220,6 +220,10 @@ def update_dataset_from_dataframes__iter(
     Returns
     -------
     The dataset metadata object (:class:`~kartothek.core.dataset.DatasetMetadata`).
+
+    See Also
+    --------
+    :ref:`mutating_datasets`
     """
     if load_dynamic_metadata is not True:
         warnings.warn(

--- a/kartothek/io/testing/build_cube.py
+++ b/kartothek/io/testing/build_cube.py
@@ -1119,6 +1119,7 @@ def test_overwrite_rollback_ktk(driver, function_store):
         store=function_store,
         dataset_uuid=cube.ktk_dataset_uuid(cube.seed_dataset),
         metadata_version=KTK_CUBE_METADATA_VERSION,
+        secondary_indices=["i1", "i2"],
     )
 
     df_source2 = pd.DataFrame(

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1800,6 +1800,8 @@ def parse_input_to_metapartition(
     elif isinstance(obj, MetaPartition):
         return obj
     else:
-        raise ValueError("Unexpected type: {}".format(type(obj)))
+        raise ValueError(
+            f"Unexpected type during parsing encountered: ({type(obj)}, {obj})"
+        )
 
     return mp

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -42,6 +42,12 @@ from kartothek.serialization import (
     filter_df_from_predicates,
 )
 
+try:
+    from typing_extensions import Literal  # type: ignore
+except ImportError:
+    from typing import Literal  # type: ignore
+
+
 LOGGER = logging.getLogger(__name__)
 
 SINGLE_TABLE = "table"
@@ -1647,7 +1653,9 @@ def partition_labels_from_mps(mps):
 
 
 def parse_input_to_metapartition(
-    obj, metadata_version=None, expected_secondary_indices=False
+    obj: Optional[Union[Dict, pd.DataFrame, Sequence, MetaPartition]],
+    metadata_version: Optional[int] = None,
+    expected_secondary_indices: Optional[Union[Literal[False], Sequence[str]]] = False,
 ) -> MetaPartition:
     """
     Parses given user input and returns a MetaPartition

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -34,19 +34,17 @@ from kartothek.core.utils import (
     verify_metadata_version,
 )
 from kartothek.core.uuid import gen_uuid
-from kartothek.io_components.utils import _ensure_valid_indices, combine_metadata
+from kartothek.io_components.utils import (
+    INFERRED_INDICES,
+    _ensure_valid_indices,
+    combine_metadata,
+)
 from kartothek.serialization import (
     DataFrameSerializer,
     PredicatesType,
     default_serializer,
     filter_df_from_predicates,
 )
-
-try:
-    from typing_extensions import Literal  # type: ignore
-except ImportError:
-    from typing import Literal  # type: ignore
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -67,6 +65,7 @@ _METADATA_SCHEMA = {
 }
 
 _MULTI_TABLE_DICT_LIST = Dict[str, Iterable[str]]
+METAPARTITION_INPUT_TYPE = Union[Dict, pd.DataFrame, Sequence, "MetaPartition"]
 
 
 def _predicates_to_named(predicates):
@@ -1653,9 +1652,9 @@ def partition_labels_from_mps(mps):
 
 
 def parse_input_to_metapartition(
-    obj: Optional[Union[Dict, pd.DataFrame, Sequence, MetaPartition]],
+    obj: METAPARTITION_INPUT_TYPE,
     metadata_version: Optional[int] = None,
-    expected_secondary_indices: Optional[Union[Literal[False], Sequence[str]]] = False,
+    expected_secondary_indices: Optional[INFERRED_INDICES] = False,
 ) -> MetaPartition:
     """
     Parses given user input and returns a MetaPartition

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -35,7 +35,7 @@ from kartothek.core.utils import (
 )
 from kartothek.core.uuid import gen_uuid
 from kartothek.io_components.utils import (
-    INFERRED_INDICES,
+    InferredIndices,
     _ensure_valid_indices,
     combine_metadata,
 )
@@ -65,7 +65,7 @@ _METADATA_SCHEMA = {
 }
 
 _MULTI_TABLE_DICT_LIST = Dict[str, Iterable[str]]
-METAPARTITION_INPUT_TYPE = Union[Dict, pd.DataFrame, Sequence, "MetaPartition"]
+MetaPartitionInput = Union[Dict, pd.DataFrame, Sequence, "MetaPartition"]
 
 
 def _predicates_to_named(predicates):
@@ -1652,9 +1652,9 @@ def partition_labels_from_mps(mps):
 
 
 def parse_input_to_metapartition(
-    obj: METAPARTITION_INPUT_TYPE,
+    obj: MetaPartitionInput,
     metadata_version: Optional[int] = None,
-    expected_secondary_indices: Optional[INFERRED_INDICES] = False,
+    expected_secondary_indices: Optional[InferredIndices] = False,
 ) -> MetaPartition:
     """
     Parses given user input and returns a MetaPartition

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -20,7 +20,7 @@ except ImportError:
     from typing import Literal  # type: ignore
 
 # Literal false is sentinel, see function body of `_ensure_compatible_indices` for details
-INFERRED_INDICES = Union[Literal[False], List[str]]
+InferredIndices = Union[Literal[False], List[str]]
 
 signature = inspect.signature
 
@@ -114,7 +114,7 @@ def _combine_metadata(dataset_metadata, append_to_list):
 
 def _ensure_compatible_indices(
     dataset: Optional[DatasetMetadataBase], secondary_indices: Optional[Iterable[str]],
-) -> INFERRED_INDICES:
+) -> InferredIndices:
     if dataset:
         ds_secondary_indices = list(dataset.secondary_indices.keys())
 

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -4,13 +4,13 @@ This module is a collection of helper functions
 import collections
 import inspect
 import logging
-from typing import List, Optional, Sequence, TypeVar, Union, overload
+from typing import Iterable, List, Optional, TypeVar, Union, overload
 
 import decorator
 import pandas as pd
 
-from kartothek.core.dataset import DatasetMetadata
-from kartothek.core.factory import DatasetFactory, _ensure_factory
+from kartothek.core.dataset import DatasetMetadata, DatasetMetadataBase
+from kartothek.core.factory import _ensure_factory
 from kartothek.core.typing import StoreFactory, StoreInput
 from kartothek.core.utils import ensure_store, lazy_store
 
@@ -19,6 +19,8 @@ try:
 except ImportError:
     from typing import Literal  # type: ignore
 
+# Literal false is sentinel, see function body of `_ensure_compatible_indices` for details
+INFERRED_INDICES = Union[Literal[False], List[str]]
 
 signature = inspect.signature
 
@@ -111,9 +113,8 @@ def _combine_metadata(dataset_metadata, append_to_list):
 
 
 def _ensure_compatible_indices(
-    dataset: Optional[Union[DatasetMetadata, DatasetFactory]],
-    secondary_indices: Optional[Sequence[str]],
-) -> Union[Literal[False], List[str]]:
+    dataset: Optional[DatasetMetadataBase], secondary_indices: Optional[Iterable[str]],
+) -> INFERRED_INDICES:
     if dataset:
         ds_secondary_indices = list(dataset.secondary_indices.keys())
 

--- a/kartothek/io_components/write.py
+++ b/kartothek/io_components/write.py
@@ -29,12 +29,18 @@ from kartothek.io_components.utils import (
 )
 from kartothek.serialization import DataFrameSerializer
 
+try:
+    from typing_extensions import Literal  # type: ignore
+except ImportError:
+    from typing import Literal  # type: ignore
+
+
 SINGLE_CATEGORY = SINGLE_TABLE
 
 
 def write_partition(
     partition_df: Any,  # TODO: Establish typing for parse_input_to_metapartition
-    secondary_indices: Optional[Union[str, Sequence[str]]],
+    secondary_indices: Optional[Union[Literal[False], Sequence[str]]],
     sort_partitions_by: Optional[Union[str, Sequence[str]]],
     dataset_uuid: str,
     partition_on: Optional[Union[str, Sequence[str]]],

--- a/kartothek/io_components/write.py
+++ b/kartothek/io_components/write.py
@@ -17,14 +17,14 @@ from kartothek.core.partition import Partition
 from kartothek.core.typing import StoreFactory, StoreInput
 from kartothek.core.utils import ensure_store
 from kartothek.io_components.metapartition import (
-    METAPARTITION_INPUT_TYPE,
     SINGLE_TABLE,
     MetaPartition,
+    MetaPartitionInput,
     parse_input_to_metapartition,
     partition_labels_from_mps,
 )
 from kartothek.io_components.utils import (
-    INFERRED_INDICES,
+    InferredIndices,
     combine_metadata,
     extract_duplicates,
     sort_values_categorical,
@@ -35,8 +35,8 @@ SINGLE_CATEGORY = SINGLE_TABLE
 
 
 def write_partition(
-    partition_df: METAPARTITION_INPUT_TYPE,
-    secondary_indices: Optional[INFERRED_INDICES],
+    partition_df: MetaPartitionInput,
+    secondary_indices: Optional[InferredIndices],
     sort_partitions_by: Optional[Union[str, Sequence[str]]],
     dataset_uuid: str,
     partition_on: Optional[Union[str, Sequence[str]]],
@@ -50,7 +50,7 @@ def write_partition(
     like partitioning, bucketing (NotImplemented), indexing, etc. in the correct order.
     """
     store = ensure_store(store_factory)
-    parse_input: METAPARTITION_INPUT_TYPE
+    parse_input: MetaPartitionInput
     if isinstance(partition_df, pd.DataFrame) and dataset_table_name:
         parse_input = [{"data": {dataset_table_name: partition_df}}]
     else:

--- a/kartothek/io_components/write.py
+++ b/kartothek/io_components/write.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import partial
-from typing import Any, Dict, Optional, Sequence, Union, cast
+from typing import Dict, Optional, Sequence, Union, cast
 
 import pandas as pd
 
@@ -17,30 +17,26 @@ from kartothek.core.partition import Partition
 from kartothek.core.typing import StoreFactory, StoreInput
 from kartothek.core.utils import ensure_store
 from kartothek.io_components.metapartition import (
+    METAPARTITION_INPUT_TYPE,
     SINGLE_TABLE,
     MetaPartition,
     parse_input_to_metapartition,
     partition_labels_from_mps,
 )
 from kartothek.io_components.utils import (
+    INFERRED_INDICES,
     combine_metadata,
     extract_duplicates,
     sort_values_categorical,
 )
 from kartothek.serialization import DataFrameSerializer
 
-try:
-    from typing_extensions import Literal  # type: ignore
-except ImportError:
-    from typing import Literal  # type: ignore
-
-
 SINGLE_CATEGORY = SINGLE_TABLE
 
 
 def write_partition(
-    partition_df: Any,  # TODO: Establish typing for parse_input_to_metapartition
-    secondary_indices: Optional[Union[Literal[False], Sequence[str]]],
+    partition_df: METAPARTITION_INPUT_TYPE,
+    secondary_indices: Optional[INFERRED_INDICES],
     sort_partitions_by: Optional[Union[str, Sequence[str]]],
     dataset_uuid: str,
     partition_on: Optional[Union[str, Sequence[str]]],
@@ -54,6 +50,7 @@ def write_partition(
     like partitioning, bucketing (NotImplemented), indexing, etc. in the correct order.
     """
     store = ensure_store(store_factory)
+    parse_input: METAPARTITION_INPUT_TYPE
     if isinstance(partition_df, pd.DataFrame) and dataset_table_name:
         parse_input = [{"data": {dataset_table_name: partition_df}}]
     else:

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -2,6 +2,7 @@ import pickle
 
 import dask
 import dask.dataframe as dd
+import pandas as pd
 import pytest
 
 from kartothek.io.dask.dataframe import update_dataset_from_ddf
@@ -18,8 +19,11 @@ def _unwrap_partition(part):
 
 
 def _update_dataset(partitions, *args, **kwargs):
-    # TODO: fix the parsing below to adapt for all supported formats (see: parse_input_to_metapartition)
-    if any(partitions):
+    # TODO: Simplify once parse_input_to_metapartition is removed / obsolete
+    if isinstance(partitions, pd.DataFrame):
+        table_name = "core"
+        partitions = dd.from_pandas(partitions, npartitions=1)
+    elif any(partitions):
         table_name = next(iter(dict(partitions[0]["data"]).keys()))
         delayed_partitions = [
             dask.delayed(_unwrap_partition)(part) for part in partitions

--- a/tests/io/dask/delayed/test_update.py
+++ b/tests/io/dask/delayed/test_update.py
@@ -18,6 +18,8 @@ def _unwrap_partition(part):
 
 
 def _update_dataset(partitions, *args, **kwargs):
+    if not isinstance(partitions, list):
+        partitions = [partitions]
     tasks = update_dataset_from_delayed(partitions, *args, **kwargs)
 
     s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)

--- a/tests/io/iter/test_update.py
+++ b/tests/io/iter/test_update.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import pandas as pd
 import pytest
 
 from kartothek.io.iter import update_dataset_from_dataframes__iter
@@ -12,5 +13,7 @@ def bound_update_dataset():
 
 
 def _update_dataset(df_list, *args, **kwargs):
+    if isinstance(df_list, pd.DataFrame):
+        df_list = [df_list]
     df_generator = (x for x in df_list)
     return update_dataset_from_dataframes__iter(df_generator, *args, **kwargs)


### PR DESCRIPTION
# Description:

This fixes an issue where cubes could remove or blacklist index columns and update a dataset/cube. This would then not update said index any longer leaving the dataset in a corrupt state. The only way to consistently deal with this would be to remove the index entirely or to update it. The behaviour for plain datasets, so far, was to update the index regardlessly if the input was omitted. I needed to change that logic slightly but I think the behaviour is still ok. This way the two interfaces area again a bit closer together.

The fix is very pragmatic but everything else would require a rework of the interface and refactoring of a lot of code :/