### PR TITLE
use string data type instead of np.unicode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         numfocus_nightly: [false]
         os: ["ubuntu-latest"]
-        pyarrow: ["0.17.1", "1.0.0", "2.0.0", "nightly"]
+        pyarrow: ["0.17.1", "1.0.1", "2.0.0", "nightly"]
         python: ["3.6", "3.7", "3.8"]
         include:
           - numfocus_nightly: true

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -4,7 +4,7 @@ msgpack-python>=0.5.2
 # Currently dask and numpy==1.16.0 clash
 numpy!=1.15.0,!=1.16.0
 pandas>=0.23.0, !=1.0.0
-pyarrow>=0.17.1, <3
+pyarrow>=0.17.1,!=1.0.0, <3
 simplejson
 simplekv
 storefact

--- a/kartothek/core/testing.py
+++ b/kartothek/core/testing.py
@@ -62,7 +62,7 @@ def get_dataframe_not_nested():
             "float64": pd.Series([1.0], dtype=np.float64),
             "date": pd.Series([date(2018, 1, 1)], dtype=object),
             "datetime64": pd.Series(["2018-01-01"], dtype="datetime64[ns]"),
-            "unicode": pd.Series(["Ö"], dtype=np.unicode),
+            "unicode": pd.Series(["Ö"], dtype=str),
             "null": pd.Series([None], dtype=object),
             # Adding a byte type with value as byte sequence which can not be encoded as UTF8
             "byte": pd.Series([gen_uuid_object().bytes], dtype=object),

--- a/kartothek/serialization/testing.py
+++ b/kartothek/serialization/testing.py
@@ -55,7 +55,7 @@ def get_dataframe_not_nested(n):
                 [datetime(2018, 1, x % 31 + 1) for x in range(1, n + 1)],
                 dtype="datetime64[ns]",
             ),
-            "unicode": pd.Series([str(x) for x in range(n)], dtype=np.unicode),
+            "unicode": pd.Series([str(x) for x in range(n)], dtype=str),
             "null": pd.Series([None] * n, dtype=object),
             "bytes": pd.Series(binaries, dtype=np.object),
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ msgpack>=0.5.2
 # Currently dask and numpy==1.16.0 clash
 numpy!=1.15.0,!=1.16.0
 pandas>=0.23.0, !=1.0.0
-pyarrow>=0.17.1, <3
+pyarrow>=0.17.1,!=1.0.0, <3
 simplejson
 simplekv
 storefact


### PR DESCRIPTION
# Description:

The explicitness of the unicode is no longer necessary since we left py2 a long time ago

- [x] Closes #396
