### PR TITLE
add retries for ParquetSerializer.restore_dataframe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 Version 3.1X.X (2021-XX-XX)
 ===========================
 
-* Add retries to  :func:`~kartothek.serialization.parquet.ParquetSerializer.restore_dataframe`
+* Add retries to  :func:`~kartothek.serialization._parquet.ParquetSerializer.restore_dataframe`
 
 
 Version 3.18.0 (2021-01-25)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 3.1X.X (2021-XX-XX)
+===========================
+
+* Add retries to  :func:`~kartothek.serialization.parquet.ParquetSerializer.restore_dataframe`
+
 
 Version 3.18.0 (2021-01-25)
 ===========================

--- a/kartothek/serialization/_io_buffer.py
+++ b/kartothek/serialization/_io_buffer.py
@@ -10,6 +10,14 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
+class BufferReadError(IOError):
+    """
+    Internal kartothek error while attempting to read from buffer
+    """
+
+    pass
+
+
 class BlockBuffer(io.BufferedIOBase):
     """
     Block-based buffer.
@@ -111,7 +119,7 @@ class BlockBuffer(io.BufferedIOBase):
                 f"Expected raw read to return {size} bytes, but instead got {len(data)}"
             )
             _logger.error(err)
-            raise IOError(err)
+            raise BufferReadError(err)
 
         # fill blocks
         for i in range(n):
@@ -135,7 +143,7 @@ class BlockBuffer(io.BufferedIOBase):
         if size < 0:
             msg = f"Expected size >= 0, but got start={start}, size={size}"
             _logger.error(msg)
-            raise AssertionError(msg)
+            raise BufferReadError(msg)
 
         block = start // self._blocksize
         offset = start % self._blocksize

--- a/kartothek/serialization/_io_buffer.py
+++ b/kartothek/serialization/_io_buffer.py
@@ -111,7 +111,7 @@ class BlockBuffer(io.BufferedIOBase):
                 f"Expected raw read to return {size} bytes, but instead got {len(data)}"
             )
             _logger.error(err)
-            raise AssertionError(err)
+            raise IOError(err)
 
         # fill blocks
         for i in range(n):

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -213,7 +213,8 @@ class ParquetSerializer(DataFrameSerializer):
                     predicates=predicates,
                     date_as_object=date_as_object,
                 )
-            except (AssertionError, OSError):
+            except (AssertionError, OSError) as err:
+                raised_error = err
                 _logger.warning(
                     msg=(
                         f"Failed to restore dataframe, attempt {nb_retry + 1} of {MAX_NB_RETRIES} with parameters "
@@ -232,7 +233,7 @@ class ParquetSerializer(DataFrameSerializer):
             f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
             f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
             f"date_as_object: {date_as_object}, predicates: {predicates}."
-        )
+        ) from raised_error
 
     def store(self, store, key_prefix, df):
         key = "{}.parquet".format(key_prefix)

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -140,7 +140,7 @@ class ParquetSerializer(DataFrameSerializer):
             "Failed to restore dataframe after {MAX_NB_RETRIES} attempts. Parameters: "
             f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
             f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
-            f"predicates: {predicates}, date_as_object: {date_as_object}."
+            f"date_as_object: {date_as_object}, predicates: {predicates}."
         )
 
     def store(self, store, key_prefix, df):

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -6,6 +6,8 @@ This module contains functionality for persisting/serialising DataFrames.
 
 
 import datetime
+import logging
+import time
 from typing import Iterable, Optional
 
 import numpy as np
@@ -33,8 +35,12 @@ try:
 except ImportError:
     HAVE_BOTO = False
 
+_logger = logging.getLogger(__name__)
+
 
 EPOCH_ORDINAL = datetime.date(1970, 1, 1).toordinal()
+MAX_NB_RETRIES = 6  # longest retry backoff = BACKOFF_TIME * 2**(MAX_NB_RETRIES - 2)
+BACKOFF_TIME = 0.01  # 10 ms
 
 
 def _empty_table_from_schema(parquet_file):
@@ -63,6 +69,14 @@ def _reset_dictionary_columns(table, exclude=None):
 
     table = table.cast(schema)
     return table
+
+
+class ParquetReadError(IOError):
+    """
+    Internal kartothek error while attempting to read Parquet file
+    """
+
+    pass
 
 
 class ParquetSerializer(DataFrameSerializer):
@@ -95,85 +109,39 @@ class ParquetSerializer(DataFrameSerializer):
         categories: Optional[Iterable[str]] = None,
         predicates: Optional[PredicatesType] = None,
         date_as_object: bool = False,
-    ):
-        check_predicates(predicates)
-        # If we want to do columnar access we can benefit from partial reads
-        # otherwise full read en block is the better option.
-        if (not predicate_pushdown_to_io) or (columns is None and predicates is None):
-            with pa.BufferReader(store.get(key)) as reader:
-                table = pq.read_pandas(reader, columns=columns)
-        else:
-            if HAVE_BOTO and isinstance(store, BotoStore):
-                # Parquet and seeks on S3 currently leak connections thus
-                # we omit column projection to the store.
-                reader = pa.BufferReader(store.get(key))
-            else:
-                reader = store.open(key)
-                # Buffer at least 4 MB in requests. This is chosen because the default block size of the Azure
-                # storage client is 4MB.
-                reader = BlockBuffer(reader, 4 * 1024 * 1024)
+    ) -> pd.DataFrame:
+        for nb_retry in range(MAX_NB_RETRIES):
             try:
-                parquet_file = ParquetFile(reader)
-                if predicates and parquet_file.metadata.num_rows > 0:
-                    # We need to calculate different predicates for predicate
-                    # pushdown and the later DataFrame filtering. This is required
-                    # e.g. in the case where we have an `in` predicate as this has
-                    # different normalized values.
-                    columns_to_io = _columns_for_pushdown(columns, predicates)
-                    predicates_for_pushdown = _normalize_predicates(
-                        parquet_file, predicates, True
-                    )
-                    predicates = _normalize_predicates(parquet_file, predicates, False)
-                    tables = _read_row_groups_into_tables(
-                        parquet_file, columns_to_io, predicates_for_pushdown
-                    )
-
-                    if len(tables) == 0:
-                        table = _empty_table_from_schema(parquet_file)
-                    else:
-                        table = pa.concat_tables(tables)
-                else:
-                    # ARROW-5139 Column projection with empty columns returns a table w/out index
-                    if columns == []:
-                        # Create an arrow table with expected index length.
-                        df = (
-                            parquet_file.schema.to_arrow_schema()
-                            .empty_table()
-                            .to_pandas(date_as_object=date_as_object)
-                        )
-                        index = pd.Int64Index(
-                            pd.RangeIndex(start=0, stop=parquet_file.metadata.num_rows)
-                        )
-                        df = pd.DataFrame(df, index=index)
-                        # convert back to table to keep downstream code untouched by this patch
-                        table = pa.Table.from_pandas(df)
-                    else:
-                        table = pq.read_pandas(reader, columns=columns)
-            finally:
-                reader.close()
-
-        if columns is not None:
-            missing_columns = set(columns) - set(table.schema.names)
-            if missing_columns:
-                raise ValueError(
-                    "Columns cannot be found in stored dataframe: {missing}".format(
-                        missing=", ".join(sorted(missing_columns))
-                    )
+                return _restore_dataframe(
+                    store=store,
+                    key=key,
+                    filter_query=filter_query,
+                    columns=columns,
+                    predicate_pushdown_to_io=predicate_pushdown_to_io,
+                    categories=categories,
+                    predicates=predicates,
+                    date_as_object=date_as_object,
                 )
+            except (AssertionError, OSError):
+                _logger.warning(
+                    msg=(
+                        f"Failed to restore dataframe, attempt {nb_retry} of {MAX_NB_RETRIES} with parameters "
+                        f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
+                        f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
+                        f"predicates: {predicates}, date_as_object: {date_as_object}."
+                    ),
+                    exc_info=True,
+                )
+                # we don't sleep when we're done with the last attempt
+                if nb_retry < (MAX_NB_RETRIES - 1):
+                    time.sleep(BACKOFF_TIME * 2 ** nb_retry)
 
-        table = _reset_dictionary_columns(table, exclude=categories)
-        df = table.to_pandas(categories=categories, date_as_object=date_as_object)
-        df.columns = df.columns.map(ensure_unicode_string_type)
-        if predicates:
-            df = filter_df_from_predicates(
-                df, predicates, strict_date_types=date_as_object
-            )
-        else:
-            df = filter_df(df, filter_query)
-        if columns is not None:
-            return df.reindex(columns=columns, copy=False)
-        else:
-            return df
+        raise ParquetReadError(
+            "Failed to restore dataframe after {MAX_NB_RETRIES} attempts. Parameters: "
+            f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
+            f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
+            f"predicates: {predicates}, date_as_object: {date_as_object}."
+        )
 
     def store(self, store, key_prefix, df):
         key = "{}.parquet".format(key_prefix)
@@ -193,6 +161,94 @@ class ParquetSerializer(DataFrameSerializer):
         )
         store.put(key, buf.getvalue().to_pybytes())
         return key
+
+
+def _restore_dataframe(
+    store: KeyValueStore,
+    key: str,
+    filter_query: Optional[str] = None,
+    columns: Optional[Iterable[str]] = None,
+    predicate_pushdown_to_io: bool = True,
+    categories: Optional[Iterable[str]] = None,
+    predicates: Optional[PredicatesType] = None,
+    date_as_object: bool = False,
+) -> pd.DataFrame:
+    check_predicates(predicates)
+    # If we want to do columnar access we can benefit from partial reads
+    # otherwise full read en block is the better option.
+    if (not predicate_pushdown_to_io) or (columns is None and predicates is None):
+        with pa.BufferReader(store.get(key)) as reader:
+            table = pq.read_pandas(reader, columns=columns)
+    else:
+        if HAVE_BOTO and isinstance(store, BotoStore):
+            # Parquet and seeks on S3 currently leak connections thus
+            # we omit column projection to the store.
+            reader = pa.BufferReader(store.get(key))
+        else:
+            reader = store.open(key)
+            # Buffer at least 4 MB in requests. This is chosen because the default block size of the Azure
+            # storage client is 4MB.
+            reader = BlockBuffer(reader, 4 * 1024 * 1024)
+        try:
+            parquet_file = ParquetFile(reader)
+            if predicates and parquet_file.metadata.num_rows > 0:
+                # We need to calculate different predicates for predicate
+                # pushdown and the later DataFrame filtering. This is required
+                # e.g. in the case where we have an `in` predicate as this has
+                # different normalized values.
+                columns_to_io = _columns_for_pushdown(columns, predicates)
+                predicates_for_pushdown = _normalize_predicates(
+                    parquet_file, predicates, True
+                )
+                predicates = _normalize_predicates(parquet_file, predicates, False)
+                tables = _read_row_groups_into_tables(
+                    parquet_file, columns_to_io, predicates_for_pushdown
+                )
+
+                if len(tables) == 0:
+                    table = _empty_table_from_schema(parquet_file)
+                else:
+                    table = pa.concat_tables(tables)
+            else:
+                # ARROW-5139 Column projection with empty columns returns a table w/out index
+                if columns == []:
+                    # Create an arrow table with expected index length.
+                    df = (
+                        parquet_file.schema.to_arrow_schema()
+                        .empty_table()
+                        .to_pandas(date_as_object=date_as_object)
+                    )
+                    index = pd.Int64Index(
+                        pd.RangeIndex(start=0, stop=parquet_file.metadata.num_rows)
+                    )
+                    df = pd.DataFrame(df, index=index)
+                    # convert back to table to keep downstream code untouched by this patch
+                    table = pa.Table.from_pandas(df)
+                else:
+                    table = pq.read_pandas(reader, columns=columns)
+        finally:
+            reader.close()
+
+    if columns is not None:
+        missing_columns = set(columns) - set(table.schema.names)
+        if missing_columns:
+            raise ValueError(
+                "Columns cannot be found in stored dataframe: {missing}".format(
+                    missing=", ".join(sorted(missing_columns))
+                )
+            )
+
+    table = _reset_dictionary_columns(table, exclude=categories)
+    df = table.to_pandas(categories=categories, date_as_object=date_as_object)
+    df.columns = df.columns.map(ensure_unicode_string_type)
+    if predicates:
+        df = filter_df_from_predicates(df, predicates, strict_date_types=date_as_object)
+    else:
+        df = filter_df(df, filter_query)
+    if columns is not None:
+        return df.reindex(columns=columns, copy=False)
+    else:
+        return df
 
 
 def _columns_for_pushdown(columns, predicates):

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -125,7 +125,7 @@ class ParquetSerializer(DataFrameSerializer):
             except (AssertionError, OSError):
                 _logger.warning(
                     msg=(
-                        f"Failed to restore dataframe, attempt {nb_retry} of {MAX_NB_RETRIES} with parameters "
+                        f"Failed to restore dataframe, attempt {nb_retry + 1} of {MAX_NB_RETRIES} with parameters "
                         f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
                         f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
                         f"predicates: {predicates}, date_as_object: {date_as_object}."

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -137,7 +137,7 @@ class ParquetSerializer(DataFrameSerializer):
                     time.sleep(BACKOFF_TIME * 2 ** nb_retry)
 
         raise ParquetReadError(
-            "Failed to restore dataframe after {MAX_NB_RETRIES} attempts. Parameters: "
+            f"Failed to restore dataframe after {MAX_NB_RETRIES} attempts. Parameters: "
             f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
             f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
             f"date_as_object: {date_as_object}, predicates: {predicates}."

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -201,6 +201,9 @@ class ParquetSerializer(DataFrameSerializer):
         predicates: Optional[PredicatesType] = None,
         date_as_object: bool = False,
     ) -> pd.DataFrame:
+        # XXX: We have been seeing weired `IOError` while reading Parquet files from Azure Blob Store,
+        # thus, we implement retries at this point. This code should not live forever, it should be removed
+        # once the underlying cause has been resolved
         for nb_retry in range(MAX_NB_RETRIES):
             try:
                 return cls._restore_dataframe(
@@ -213,7 +216,9 @@ class ParquetSerializer(DataFrameSerializer):
                     predicates=predicates,
                     date_as_object=date_as_object,
                 )
-            except (AssertionError, OSError) as err:
+            # We only retry OSErrors (note that IOError inherits from OSError), as these kind of errors may benefit
+            # from retries.
+            except OSError as err:
                 raised_error = err
                 _logger.warning(
                     msg=(


### PR DESCRIPTION
Retries in this setup go from 10ms to 160 ms (specifically: `0.01 0.02 0.04 0.08 0.16` seconds).

This supersedes the first commit from https://github.com/JDASoftwareGroup/kartothek/pull/397.


- [ ] Closes #xxxx
- [x] Changelog entry
