### PR TITLE
Add optional Parquet serializer to cube interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,6 @@ Version 3.18.1 (2021-02-XY)
 * Fix an issue where updates on cubes or updates on datatsets using
   dask.dataframe might not update all secondary indices, resulting in a corrupt
   state after the update
-
-Version <unreleased>
-===========================
-
 * Expose compression type and row group chunk size in Cube interface via optional
   parameter of type :class:`~kartothek.serialization.ParquetSerializer`.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-Version 3.18.1 (2021-02-XY)
+Version 3.19.0 (2021-02-XY)
 ===========================
 
 * Fix an issue where updates on cubes or updates on datatsets using

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ Version 3.18.1 (2021-02-XY)
   dask.dataframe might not update all secondary indices, resulting in a corrupt
   state after the update
 
+Version <unreleased>
+===========================
+
+* Expose compression type and row group chunk size in Cube interface via optional
+  parameter of type :class:`~kartothek.serialization.ParquetSerializer`.
+
 Version 3.18.0 (2021-01-25)
 ===========================
 
@@ -17,7 +23,7 @@ Version 3.18.0 (2021-01-25)
 * Fix a bug in :func:`~kartothek.io_components.read.dispatch_metapartitions_from_factory` where
   `dispatch_by=[]` would be treated like `dispatch_by=None`, not merging all dataset partitions into
   a single partitions.
-  
+
 Version 3.17.3 (2020-12-04)
 ===========================
 

--- a/kartothek/core/cube/constants.py
+++ b/kartothek/core/cube/constants.py
@@ -23,7 +23,7 @@ __all__ = (
 #
 
 
-#: DataFrame serializer that is be used to write data.
+#: Default DataFrame serializer that is be used to write data if not specified otherwise.
 KTK_CUBE_DF_SERIALIZER = ParquetSerializer(compression="ZSTD")
 
 #: Storage format for kartothek metadata that is be used by default.

--- a/kartothek/io/dask/bag_cube.py
+++ b/kartothek/io/dask/bag_cube.py
@@ -46,6 +46,7 @@ def build_cube_from_bag(
     metadata=None,
     overwrite=False,
     partition_on=None,
+    df_serializer=None,
 ):
     """
     Create dask computation graph that builds a cube with the data supplied from a dask bag.
@@ -68,6 +69,8 @@ def build_cube_from_bag(
     partition_on: Optional[Dict[str, Iterable[str]]]
         Optional parition-on attributes for datasets (dictionary mapping :term:`Dataset ID` -> columns).
         See :ref:`Dimensionality and Partitioning Details` for details.
+    df_serializer: Optional[ParquetSerializer]
+        Optional Dataframe to Parquet serializer
 
     Returns
     -------
@@ -83,6 +86,7 @@ def build_cube_from_bag(
         metadata=metadata,
         overwrite=overwrite,
         partition_on=partition_on,
+        df_serializer=df_serializer,
     )
 
 
@@ -94,6 +98,7 @@ def extend_cube_from_bag(
     metadata=None,
     overwrite=False,
     partition_on=None,
+    df_serializer=None,
 ):
     """
     Create dask computation graph that extends a cube by the data supplied from a dask bag.
@@ -117,6 +122,8 @@ def extend_cube_from_bag(
     partition_on: Optional[Dict[str, Iterable[str]]]
         Optional parition-on attributes for datasets (dictionary mapping :term:`Dataset ID` -> columns).
         See :ref:`Dimensionality and Partitioning Details` for details.
+    df_serializer: Optional[ParquetSerializer]
+        Optional Dataframe to Parquet serializer
 
     Returns
     -------
@@ -132,6 +139,7 @@ def extend_cube_from_bag(
         metadata=metadata,
         overwrite=overwrite,
         partition_on=partition_on,
+        df_serializer=df_serializer,
     )
 
 
@@ -365,7 +373,9 @@ def cleanup_cube_bag(cube, store, blocksize=100):
     )
 
 
-def append_to_cube_from_bag(data, cube, store, ktk_cube_dataset_ids, metadata=None):
+def append_to_cube_from_bag(
+    data, cube, store, ktk_cube_dataset_ids, metadata=None, df_serializer=None
+):
     """
     Append data to existing cube.
 
@@ -394,6 +404,8 @@ def append_to_cube_from_bag(data, cube, store, ktk_cube_dataset_ids, metadata=No
     metadata: Optional[Dict[str, Dict[str, Any]]]
         Metadata for every dataset, optional. For every dataset, only given keys are updated/replaced. Deletion of
         metadata keys is not possible.
+    df_serializer: Optional[ParquetSerializer]
+        Optional Dataframe to Parquet serializer
 
     Returns
     -------
@@ -407,11 +419,18 @@ def append_to_cube_from_bag(data, cube, store, ktk_cube_dataset_ids, metadata=No
         store=store,
         ktk_cube_dataset_ids=ktk_cube_dataset_ids,
         metadata=metadata,
+        df_serializer=df_serializer,
     )
 
 
 def update_cube_from_bag(
-    data, cube, store, remove_conditions, ktk_cube_dataset_ids, metadata=None
+    data,
+    cube,
+    store,
+    remove_conditions,
+    ktk_cube_dataset_ids,
+    metadata=None,
+    df_serializer=None,
 ):
     """
     Remove partitions and append data to existing cube.
@@ -436,6 +455,8 @@ def update_cube_from_bag(
     metadata: Optional[Dict[str, Dict[str, Any]]]
         Metadata for every dataset, optional. For every dataset, only given keys are updated/replaced. Deletion of
         metadata keys is not possible.
+    df_serializer: Optional[ParquetSerializer]
+        Optional Dataframe to Parquet serializer
 
     Returns
     -------
@@ -454,6 +475,7 @@ def update_cube_from_bag(
         remove_conditions=remove_conditions,
         ktk_cube_dataset_ids=ktk_cube_dataset_ids,
         metadata=metadata,
+        df_serializer=df_serializer,
     )
 
 

--- a/kartothek/io/dask/bag_cube.py
+++ b/kartothek/io/dask/bag_cube.py
@@ -1,13 +1,14 @@
 """
 Dask.Bag IO.
 """
-from typing import Any, Callable, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import dask.bag as db
 from simplekv import KeyValueStore
 
 from kartothek.api.discover import discover_datasets_unchecked
 from kartothek.core.cube.cube import Cube
+from kartothek.core.typing import StoreFactory
 from kartothek.io.dask.common_cube import (
     append_to_cube_from_bag_internal,
     build_cube_from_bag_internal,
@@ -46,7 +47,7 @@ __all__ = (
 def build_cube_from_bag(
     data: db.Bag,
     cube: Cube,
-    store: Callable[[], KeyValueStore],
+    store: StoreFactory,
     ktk_cube_dataset_ids: Optional[Iterable[str]] = None,
     metadata: Optional[Dict[str, Dict[str, Any]]] = None,
     overwrite: bool = False,
@@ -216,7 +217,7 @@ def delete_cube_bag(cube, store, blocksize=100, datasets=None):
     ----------
     cube: Cube
         Cube specification.
-    store: Callable[[], simplekv.KeyValueStore]
+    store: StoreFactory
         KV store.
     blocksize: int
         Number of keys to delete at once.
@@ -259,9 +260,9 @@ def copy_cube_bag(
     ----------
     cube: Cube
         Cube specification.
-    src_store: Callable[[], simplekv.KeyValueStore]
+    src_store: StoreFactory
         Source KV store.
-    tgt_store: Callable[[], simplekv.KeyValueStore]
+    tgt_store: StoreFactory
         Target KV store.
     overwrite: bool
         If possibly existing datasets in the target store should be overwritten.
@@ -355,7 +356,7 @@ def cleanup_cube_bag(cube, store, blocksize=100):
     ----------
     cube: Cube
         Cube specification.
-    store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    store: Union[simplekv.KeyValueStore, StoreFactory]
         KV store.
     blocksize: int
         Number of keys to delete at once.
@@ -381,7 +382,7 @@ def cleanup_cube_bag(cube, store, blocksize=100):
 def append_to_cube_from_bag(
     data: db.Bag,
     cube: Cube,
-    store: Callable[[], KeyValueStore],
+    store: StoreFactory,
     ktk_cube_dataset_ids: Optional[Iterable[str]],
     metadata: Optional[Dict[str, Dict[str, Any]]] = None,
     df_serializer: Optional[ParquetSerializer] = None,
@@ -436,7 +437,7 @@ def append_to_cube_from_bag(
 def update_cube_from_bag(
     data: db.Bag,
     cube: Cube,
-    store: Callable[[], KeyValueStore],
+    store: StoreFactory,
     remove_conditions,
     ktk_cube_dataset_ids: Optional[Iterable[str]],
     metadata: Optional[Dict[str, Dict[str, Any]]] = None,

--- a/kartothek/io/dask/common_cube.py
+++ b/kartothek/io/dask/common_cube.py
@@ -3,7 +3,7 @@ Common code for dask backends.
 """
 from collections import defaultdict
 from functools import partial
-from typing import Any, Callable, Dict, Iterable, Optional, Set
+from typing import Any, Dict, Iterable, Optional, Set
 
 import dask.bag as db
 from simplekv import KeyValueStore
@@ -17,6 +17,7 @@ from kartothek.core.cube.constants import (
 )
 from kartothek.core.cube.cube import Cube
 from kartothek.core.dataset import DatasetMetadataBase
+from kartothek.core.typing import StoreFactory
 from kartothek.io_components.cube.append import check_existing_datasets
 from kartothek.io_components.cube.common import check_blocksize, check_store_factory
 from kartothek.io_components.cube.query import load_group, plan_query, quick_concat
@@ -88,7 +89,7 @@ def ensure_valid_cube_indices(
 def build_cube_from_bag_internal(
     data: db.Bag,
     cube: Cube,
-    store: Callable[[], KeyValueStore],
+    store: StoreFactory,
     ktk_cube_dataset_ids: Optional[Iterable[str]],
     metadata: Optional[Dict[str, Dict[str, Any]]],
     overwrite: bool,
@@ -365,7 +366,7 @@ def query_cube_bag_internal(
 def append_to_cube_from_bag_internal(
     data: db.Bag,
     cube: Cube,
-    store: Callable[[], KeyValueStore],
+    store: StoreFactory,
     ktk_cube_dataset_ids: Optional[Iterable[str]],
     metadata: Optional[Dict[str, Dict[str, Any]]],
     remove_conditions=None,
@@ -625,7 +626,7 @@ def _multiplex_store_dataset_from_partitions_flat(
 def _multiplex_store(
     data: db.Bag,
     cube: Cube,
-    store: Callable[[], KeyValueStore],
+    store: StoreFactory,
     df_serializer: Optional[ParquetSerializer] = None,
 ) -> db.Bag:
     result = {}

--- a/kartothek/io/dask/common_cube.py
+++ b/kartothek/io/dask/common_cube.py
@@ -3,7 +3,7 @@ Common code for dask backends.
 """
 from collections import defaultdict
 from functools import partial
-from typing import Any, Dict, Iterable, Optional, Set
+from typing import Any, Dict, Iterable, Mapping, Optional, Set
 
 import dask.bag as db
 from simplekv import KeyValueStore
@@ -56,7 +56,7 @@ __all__ = (
 
 
 def ensure_valid_cube_indices(
-    existing_datasets: Dict[str, DatasetMetadataBase], cube: Cube
+    existing_datasets: Mapping[str, DatasetMetadataBase], cube: Cube
 ) -> Cube:
     """
     Parse all existing datasets and infer the required set of indices. We do not

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -15,7 +15,6 @@ import dask
 import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-from simplekv import KeyValueStore
 
 from kartothek.core.common_metadata import empty_dataframe_from_schema
 from kartothek.core.docs import default_docs
@@ -455,7 +454,7 @@ def update_dataset_from_ddf(
 @default_docs
 @normalize_args
 def collect_dataset_metadata(
-    store: Optional[Callable[[], KeyValueStore]] = None,
+    store: Optional[StoreFactory] = None,
     dataset_uuid: Optional[str] = None,
     table_name: str = SINGLE_TABLE,
     predicates: Optional[PredicatesType] = None,

--- a/kartothek/io/dask/dataframe_cube.py
+++ b/kartothek/io/dask/dataframe_cube.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, Dict, Iterable, Optional, Union
 import dask
 import dask.bag as db
 import dask.dataframe as dd
-import simplekv
 from dask.delayed import Delayed
+from simplekv import KeyValueStore
 
 from kartothek.api.discover import discover_datasets_unchecked
 from kartothek.core.cube.cube import Cube
@@ -42,7 +42,7 @@ __all__ = (
 def build_cube_from_dataframe(
     data: Union[dd.DataFrame, Dict[str, dd.DataFrame]],
     cube: Cube,
-    store: Callable[[], simplekv.KeyValueStore],
+    store: Callable[[], KeyValueStore],
     metadata: Optional[Dict[str, Dict[str, Any]]] = None,
     overwrite: bool = False,
     partition_on: Optional[Dict[str, Iterable[str]]] = None,
@@ -134,13 +134,13 @@ def build_cube_from_dataframe(
 
 
 def extend_cube_from_dataframe(
-    data,
-    cube,
-    store,
-    metadata=None,
-    overwrite=False,
-    partition_on=None,
-    df_serializer=None,
+    data: Union[dd.DataFrame, Dict[str, dd.DataFrame]],
+    cube: Cube,
+    store: KeyValueStore,
+    metadata: Optional[Dict[str, Dict[str, Any]]] = None,
+    overwrite: bool = False,
+    partition_on: Optional[Dict[str, Iterable[str]]] = None,
+    df_serializer: Optional[ParquetSerializer] = None,
 ):
     """
     Create dask computation graph that extends a cube by the data supplied from a dask dataframe.
@@ -149,20 +149,22 @@ def extend_cube_from_dataframe(
 
     Parameters
     ----------
-    data: Union[dask.DataFrame, Dict[str, dask.DataFrame]
+    data:
         Data that should be written to the cube. If only a single dataframe is given, it is assumed to be the seed
         dataset.
-    cube: kartothek.core.cube.cube.Cube
+    cube:
         Cube specification.
-    store: simplekv.KeyValueStore
+    store:
         Store to which the data should be written to.
-    metadata: Optional[Dict[str, Dict[str, Any]]]
+    metadata:
         Metadata for every dataset.
-    overwrite: bool
+    overwrite:
         If possibly existing datasets should be overwritten.
-    partition_on: Optional[Dict[str, Iterable[str]]]
+    partition_on:
         Optional parition-on attributes for datasets (dictionary mapping :term:`Dataset ID` -> columns).
         See :ref:`Dimensionality and Partitioning Details` for details.
+    df_serializer:
+        Optional Dataframe to Parquet serializer
 
     Returns
     -------
@@ -249,7 +251,13 @@ def query_cube_dataframe(
     )
 
 
-def append_to_cube_from_dataframe(data, cube, store, metadata=None, df_serializer=None):
+def append_to_cube_from_dataframe(
+    data: db.Bag,
+    cube: Cube,
+    store: KeyValueStore,
+    metadata: Optional[Dict[str, Dict[str, Any]]] = None,
+    df_serializer: Optional[ParquetSerializer] = None,
+) -> db.Bag:
     """
     Append data to existing cube.
 
@@ -267,16 +275,16 @@ def append_to_cube_from_dataframe(data, cube, store, metadata=None, df_serialize
 
     Parameters
     ----------
-    data: dask.Bag
+    data:
         Bag containing dataframes
-    cube: kartothek.core.cube.cube.Cube
+    cube:
         Cube specification.
-    store: simplekv.KeyValueStore
+    store:
         Store to which the data should be written to.
-    metadata: Optional[Dict[str, Dict[str, Any]]]
+    metadata:
         Metadata for every dataset, optional. For every dataset, only given keys are updated/replaced. Deletion of
         metadata keys is not possible.
-    df_serializer: Optional[ParquetSerializer]
+    df_serializer:
         Optional Dataframe to Parquet serializer
 
     Returns

--- a/kartothek/io/dask/dataframe_cube.py
+++ b/kartothek/io/dask/dataframe_cube.py
@@ -1,7 +1,7 @@
 """
 Dask.DataFrame IO.
 """
-from typing import Any, Callable, Dict, Iterable, Optional, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 import dask
 import dask.bag as db
@@ -12,6 +12,7 @@ from simplekv import KeyValueStore
 from kartothek.api.discover import discover_datasets_unchecked
 from kartothek.core.cube.cube import Cube
 from kartothek.core.docs import default_docs
+from kartothek.core.typing import StoreFactory
 from kartothek.io.dask.common_cube import (
     append_to_cube_from_bag_internal,
     extend_cube_from_bag_internal,
@@ -42,7 +43,7 @@ __all__ = (
 def build_cube_from_dataframe(
     data: Union[dd.DataFrame, Dict[str, dd.DataFrame]],
     cube: Cube,
-    store: Callable[[], KeyValueStore],
+    store: StoreFactory,
     metadata: Optional[Dict[str, Dict[str, Any]]] = None,
     overwrite: bool = False,
     partition_on: Optional[Dict[str, Iterable[str]]] = None,

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -3,6 +3,7 @@ from functools import partial
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, cast
 
 import pandas as pd
+from simplekv import KeyValueStore
 
 from kartothek.core.common_metadata import (
     empty_dataframe_from_schema,
@@ -44,6 +45,7 @@ from kartothek.io_components.utils import (
 )
 from kartothek.io_components.write import raise_if_dataset_exists
 from kartothek.serialization import DataFrameSerializer
+from kartothek.serialization._parquet import ParquetSerializer
 
 
 @default_docs
@@ -499,16 +501,16 @@ def _maybe_infer_files_attribute(metapartition, dataset_uuid):
 @default_docs
 @normalize_args
 def store_dataframes_as_dataset(
-    store,
-    dataset_uuid,
-    dfs,
-    metadata=None,
-    partition_on=None,
-    df_serializer=None,
-    overwrite=False,
+    store: KeyValueStore,
+    dataset_uuid: str,
+    dfs: List[Union[pd.DataFrame, Dict[str, pd.DataFrame]]],
+    metadata: Optional[Dict[str, Dict[str, Any]]] = None,
+    partition_on: Optional[List[str]] = None,
+    df_serializer: Optional[ParquetSerializer] = None,
+    overwrite: bool = False,
     secondary_indices=None,
-    metadata_storage_format=DEFAULT_METADATA_STORAGE_FORMAT,
-    metadata_version=DEFAULT_METADATA_VERSION,
+    metadata_storage_format: str = DEFAULT_METADATA_STORAGE_FORMAT,
+    metadata_version: int = DEFAULT_METADATA_VERSION,
 ):
     """
     Utility function to store a list of dataframes as a partitioned dataset with multiple tables (files).
@@ -517,7 +519,7 @@ def store_dataframes_as_dataset(
 
     Parameters
     ----------
-    dfs: List[Union[pd.DataFrame, Dict[str, pd.DataFrame]]]
+    dfs:
         The dataframe(s) to be stored.
 
     Returns
@@ -613,15 +615,15 @@ def create_empty_dataset_header(
 @default_docs
 @normalize_args
 def write_single_partition(
-    store=None,
-    dataset_uuid=None,
+    store: Optional[KeyValueStore] = None,
+    dataset_uuid: Optional[str] = None,
     data=None,
-    metadata=None,
-    df_serializer=None,
-    overwrite=False,
+    metadata: Optional[Dict[str, Dict[str, Any]]] = None,
+    df_serializer: Optional[ParquetSerializer] = None,
+    overwrite: bool = False,
     metadata_merger=None,
-    metadata_version=DEFAULT_METADATA_VERSION,
-    partition_on=None,
+    metadata_version: int = DEFAULT_METADATA_VERSION,
+    partition_on: Optional[List[str]] = None,
     factory=None,
     secondary_indices=None,
 ):
@@ -701,14 +703,14 @@ def write_single_partition(
 @normalize_args
 def update_dataset_from_dataframes(
     df_list: List[Union[pd.DataFrame, Dict[str, pd.DataFrame]]],
-    store=None,
+    store: Optional[KeyValueStore] = None,
     dataset_uuid: Optional[str] = None,
     delete_scope=None,
     metadata=None,
-    df_serializer=None,
+    df_serializer: Optional[ParquetSerializer] = None,
     metadata_merger: Callable = None,
     central_partition_metadata: bool = True,
-    default_metadata_version=DEFAULT_METADATA_VERSION,
+    default_metadata_version: int = DEFAULT_METADATA_VERSION,
     partition_on: Optional[List[str]] = None,
     load_dynamic_metadata: bool = True,
     sort_partitions_by: Optional[str] = None,
@@ -722,7 +724,7 @@ def update_dataset_from_dataframes(
 
     Parameters
     ----------
-    df_list: List[Union[pd.DataFrame, Dict[str, pd.DataFrame]]]
+    df_list:
         The dataframe(s) to be stored.
 
     Returns

--- a/kartothek/io/eager_cube.py
+++ b/kartothek/io/eager_cube.py
@@ -58,7 +58,15 @@ __all__ = (
 )
 
 
-def build_cube(data, cube, store, metadata=None, overwrite=False, partition_on=None):
+def build_cube(
+    data,
+    cube,
+    store,
+    metadata=None,
+    overwrite=False,
+    partition_on=None,
+    df_serializer=None,
+):
     """
     Store given dataframes as Ktk_cube cube.
 
@@ -168,6 +176,8 @@ def build_cube(data, cube, store, metadata=None, overwrite=False, partition_on=N
     partition_on: Optional[Dict[str, Iterable[str]]]
         Optional parition-on attributes for datasets (dictionary mapping :term:`Dataset ID` -> columns).
         See :ref:`Dimensionality and Partitioning Details` for details.
+    df_serializer: Optional[ParquetSerializer]
+        Optional Dataframe to Parquet serializer
 
     Returns
     -------
@@ -197,7 +207,7 @@ def build_cube(data, cube, store, metadata=None, overwrite=False, partition_on=N
             partition_on=list(partition_on[ktk_cube_dataset_id]),
             metadata_storage_format=KTK_CUBE_METADATA_STORAGE_FORMAT,
             metadata_version=KTK_CUBE_METADATA_VERSION,
-            df_serializer=KTK_CUBE_DF_SERIALIZER,
+            df_serializer=df_serializer or KTK_CUBE_DF_SERIALIZER,
             overwrite=overwrite,
         )
 
@@ -206,7 +216,15 @@ def build_cube(data, cube, store, metadata=None, overwrite=False, partition_on=N
     )
 
 
-def extend_cube(data, cube, store, metadata=None, overwrite=False, partition_on=None):
+def extend_cube(
+    data,
+    cube,
+    store,
+    metadata=None,
+    overwrite=False,
+    partition_on=None,
+    df_serializer=None,
+):
     """
     Store given dataframes into an existing Kartothek cube.
 
@@ -228,6 +246,8 @@ def extend_cube(data, cube, store, metadata=None, overwrite=False, partition_on=
     partition_on: Optional[Dict[str, Iterable[str]]]
         Optional parition-on attributes for datasets (dictionary mapping :term:`Dataset ID` -> columns).
         See :ref:`Dimensionality and Partitioning Details` for details.
+    df_serializer: Optional[ParquetSerializer]
+        Optional Dataframe to Parquet serializer
 
     Returns
     -------
@@ -270,7 +290,7 @@ def extend_cube(data, cube, store, metadata=None, overwrite=False, partition_on=
             partition_on=list(partition_on[ktk_cube_dataset_id]),
             metadata_storage_format=KTK_CUBE_METADATA_STORAGE_FORMAT,
             metadata_version=KTK_CUBE_METADATA_VERSION,
-            df_serializer=KTK_CUBE_DF_SERIALIZER,
+            df_serializer=df_serializer or KTK_CUBE_DF_SERIALIZER,
             overwrite=overwrite,
         )
 
@@ -551,7 +571,7 @@ def remove_partitions(
     return existing_datasets
 
 
-def append_to_cube(data, cube, store, metadata=None):
+def append_to_cube(data, cube, store, metadata=None, df_serializer=None):
     """
     Append data to existing cube.
 
@@ -579,6 +599,8 @@ def append_to_cube(data, cube, store, metadata=None):
     metadata: Optional[Dict[str, Dict[str, Any]]]
         Metadata for every dataset, optional. For every dataset, only given keys are updated/replaced. Deletion of
         metadata keys is not possible.
+    df_serializer: Optional[ParquetSerializer]
+        Optional Dataframe to Parquet serializer
 
     Returns
     -------
@@ -618,7 +640,7 @@ def append_to_cube(data, cube, store, metadata=None):
             dataset_uuid=cube.ktk_dataset_uuid(ktk_cube_dataset_id),
             df_list=part,
             partition_on=list(partition_on[ktk_cube_dataset_id]),
-            df_serializer=KTK_CUBE_DF_SERIALIZER,
+            df_serializer=df_serializer or KTK_CUBE_DF_SERIALIZER,
             metadata=prepare_ktk_metadata(cube, ktk_cube_dataset_id, metadata),
         )
 

--- a/kartothek/io/testing/append_cube.py
+++ b/kartothek/io/testing/append_cube.py
@@ -10,16 +10,21 @@ from kartothek.core.cube.constants import (
 from kartothek.core.cube.cube import Cube
 from kartothek.core.dataset import DatasetMetadata
 from kartothek.io.eager_cube import build_cube
+from kartothek.io.testing.utils import assert_num_row_groups
+from kartothek.serialization._parquet import ParquetSerializer
 
 __all__ = (
     "existing_cube",
     "test_append_partitions",
     "test_append_partitions_no_ts",
+    "test_compression_is_compatible_on_append_cube",
     "test_fails_incompatible_dtypes",
     "test_fails_missing_column",
     "test_fails_unknown_dataset",
     "test_indices",
     "test_metadata",
+    "test_rowgroups_are_applied_when_df_serializer_is_passed_to_append_cube",
+    "test_single_rowgroup_when_df_serializer_is_not_passed_to_append_cube",
 )
 
 
@@ -96,6 +101,118 @@ def test_append_partitions(driver, function_store, existing_cube):
     assert partitions_source_1.issubset(partitions_source_2)
 
     assert partitions_enrich_2 == partitions_enrich_1
+
+
+@pytest.mark.parametrize("chunk_size_build", [None, 1, 2, 3])
+@pytest.mark.parametrize("chunk_size_append", [None, 1, 2, 3])
+def test_rowgroups_are_applied_when_df_serializer_is_passed_to_append_cube(
+    driver, function_store, chunk_size_build, chunk_size_append
+):
+    """
+    Test that the dataset is split into row groups depending on the chunk size
+
+    Partitions build with ``chunk_size=None`` should keep a single row group after the append. Partitions that are newly created with
+    ``chunk_size>0`` should be split into row groups accordingly.
+    """
+
+    # Build cube
+    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]}, columns=["x", "p"],)
+    cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
+    build_cube(
+        data=df,
+        cube=cube,
+        store=function_store,
+        df_serializer=ParquetSerializer(chunk_size=chunk_size_build),
+    )
+
+    # Append to cube
+    df_append = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [2, 3, 3, 3]}, columns=["x", "p"],
+    )
+    result = driver(
+        data={"seed": df_append},
+        cube=cube,
+        store=function_store,
+        df_serializer=ParquetSerializer(chunk_size=chunk_size_append),
+    )
+    dataset = result["seed"].load_all_indices(function_store())
+
+    part_num_rows = {0: 2, 1: 2, 2: 1, 3: 3}
+    part_chunk_size = {
+        0: chunk_size_build,
+        1: chunk_size_build,
+        2: chunk_size_append,
+        3: chunk_size_append,
+    }
+
+    assert len(dataset.partitions) == 4
+    assert_num_row_groups(function_store(), dataset, part_num_rows, part_chunk_size)
+
+
+def test_single_rowgroup_when_df_serializer_is_not_passed_to_append_cube(
+    driver, function_store
+):
+    """
+    Test that the dataset has a single row group as default path
+    """
+
+    # Build cube
+    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]}, columns=["x", "p"],)
+    cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
+    build_cube(
+        data=df, cube=cube, store=function_store,
+    )
+
+    # Append to cube
+    df_append = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [2, 3, 3, 3]}, columns=["x", "p"],
+    )
+    result = driver(data={"seed": df_append}, cube=cube, store=function_store,)
+    dataset = result["seed"].load_all_indices(function_store())
+
+    part_num_rows = {0: 2, 1: 2, 2: 1, 3: 3}
+    part_chunk_size = {0: None, 1: None, 2: None, 3: None}
+
+    assert len(dataset.partitions) == 4
+    assert_num_row_groups(function_store(), dataset, part_num_rows, part_chunk_size)
+
+
+# Per ARROW-9424, writing files with LZ4 compression has been disabled
+@pytest.mark.parametrize(
+    "compression_build", ["NONE", "SNAPPY", "GZIP", "BROTLI", "ZSTD"]
+)
+@pytest.mark.parametrize(
+    "compression_append", ["NONE", "SNAPPY", "GZIP", "BROTLI", "ZSTD"]
+)
+def test_compression_is_compatible_on_append_cube(
+    driver, function_store, compression_build, compression_append
+):
+    """
+    Test that partitons written with different compression algorithms are compatible
+    """
+    # Build cube
+    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]}, columns=["x", "p"],)
+    cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
+    build_cube(
+        data=df,
+        cube=cube,
+        store=function_store,
+        df_serializer=ParquetSerializer(compression=compression_build),
+    )
+
+    # Append to cube
+    df_append = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [2, 3, 3, 3]}, columns=["x", "p"],
+    )
+    result = driver(
+        data={"seed": df_append},
+        cube=cube,
+        store=function_store,
+        df_serializer=ParquetSerializer(compression=compression_append),
+    )
+    dataset = result["seed"].load_all_indices(function_store())
+
+    assert len(dataset.partitions) == 4
 
 
 def test_append_partitions_no_ts(driver, function_store):

--- a/kartothek/io/testing/build_cube.py
+++ b/kartothek/io/testing/build_cube.py
@@ -273,8 +273,7 @@ def test_parquet(driver, function_store):
         pdt.assert_frame_equal(df_actual.reset_index(drop=True), df_expected)
 
 
-@pytest.mark.filterwarnings("ignore::UnicodeWarning")
-@pytest.mark.parametrize("chunk_size", [None, 1, 2, 3])
+@pytest.mark.parametrize("chunk_size", [None, 2])
 def test_rowgroups_are_applied_when_df_serializer_is_passed_to_build_cube(
     driver, function_store, chunk_size
 ):
@@ -299,7 +298,6 @@ def test_rowgroups_are_applied_when_df_serializer_is_passed_to_build_cube(
     assert_num_row_groups(function_store(), dataset, part_num_rows, part_chunk_size)
 
 
-@pytest.mark.filterwarnings("ignore::UnicodeWarning")
 def test_single_rowgroup_when_df_serializer_is_not_passed_to_build_cube(
     driver, function_store
 ):

--- a/kartothek/io/testing/extend_cube.py
+++ b/kartothek/io/testing/extend_cube.py
@@ -5,11 +5,14 @@ from kartothek.core.cube.cube import Cube
 from kartothek.core.dataset import DatasetMetadata
 from kartothek.core.index import ExplicitSecondaryIndex, PartitionIndex
 from kartothek.io.eager_cube import build_cube
+from kartothek.io.testing.utils import assert_num_row_groups
 from kartothek.io_components.cube.write import MultiTableCommitAborted
 from kartothek.io_components.metapartition import SINGLE_TABLE
+from kartothek.serialization._parquet import ParquetSerializer
 
 __all__ = (
     "existing_cube",
+    "test_compression_is_compatible_on_extend_cube",
     "test_fail_all_empty",
     "test_fail_no_store_factory",
     "test_fail_not_a_df",
@@ -25,7 +28,9 @@ __all__ = (
     "test_fails_seed_dataset",
     "test_overwrite_move_columns",
     "test_overwrite_single",
+    "test_rowgroups_are_applied_when_df_serializer_is_passed_to_extend_cube",
     "test_simple",
+    "test_single_rowgroup_when_df_serializer_is_not_passed_to_extend_cube",
 )
 
 
@@ -77,6 +82,87 @@ def test_simple(driver, function_store, existing_cube):
     assert isinstance(ds.indices["i3"], ExplicitSecondaryIndex)
 
     assert set(ds.table_meta) == {SINGLE_TABLE}
+
+
+@pytest.mark.parametrize("chunk_size", [None, 1, 2, 3])
+def test_rowgroups_are_applied_when_df_serializer_is_passed_to_extend_cube(
+    driver, function_store, existing_cube, chunk_size
+):
+    """
+    Test that the dataset is split into row groups depending on the chunk size
+    """
+    df_extra = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]}, columns=["x", "p"],
+    )
+    result = driver(
+        data={"extra": df_extra},
+        cube=existing_cube,
+        store=function_store,
+        df_serializer=ParquetSerializer(chunk_size=chunk_size),
+    )
+    dataset = result["extra"].load_all_indices(function_store())
+
+    part_num_rows = {0: 1, 1: 3}
+    part_chunk_size = {0: chunk_size, 1: chunk_size}
+
+    assert len(dataset.partitions) == 2
+    assert_num_row_groups(function_store(), dataset, part_num_rows, part_chunk_size)
+
+
+def test_single_rowgroup_when_df_serializer_is_not_passed_to_extend_cube(
+    driver, function_store, existing_cube
+):
+    """
+    Test that the dataset has a single row group as default path
+    """
+    df_extra = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]}, columns=["x", "p"],
+    )
+    result = driver(data={"extra": df_extra}, cube=existing_cube, store=function_store,)
+    dataset = result["extra"].load_all_indices(function_store())
+
+    part_num_rows = {0: 1, 1: 3}
+    part_chunk_size = {0: None, 1: None}
+
+    assert len(dataset.partitions) == 2
+    assert_num_row_groups(function_store(), dataset, part_num_rows, part_chunk_size)
+
+
+# Per ARROW-9424, writing files with LZ4 compression has been disabled
+@pytest.mark.parametrize(
+    "compression_build", ["NONE", "SNAPPY", "GZIP", "BROTLI", "ZSTD"]
+)
+@pytest.mark.parametrize(
+    "compression_extend", ["NONE", "SNAPPY", "GZIP", "BROTLI", "ZSTD"]
+)
+def test_compression_is_compatible_on_extend_cube(
+    driver, function_store, compression_build, compression_extend
+):
+    """
+    Test that partitons written with different compression algorithms are compatible
+    """
+    # Build cube
+    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]}, columns=["x", "p"],)
+    cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
+    build_cube(
+        data=df,
+        cube=cube,
+        store=function_store,
+        df_serializer=ParquetSerializer(compression=compression_build),
+    )
+
+    df_extra = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]}, columns=["x", "p"],
+    )
+    result = driver(
+        data={"extra": df_extra},
+        cube=cube,
+        store=function_store,
+        df_serializer=ParquetSerializer(compression=compression_extend),
+    )
+    dataset = result["extra"].load_all_indices(function_store())
+
+    assert len(dataset.partitions) == 2
 
 
 def test_fails_incompatible_dtypes(driver, function_store, existing_cube):

--- a/kartothek/io/testing/utils.py
+++ b/kartothek/io/testing/utils.py
@@ -1,7 +1,9 @@
+import math
 import string
 
 import numpy as np
 import pandas as pd
+from pyarrow.parquet import ParquetFile
 
 from kartothek.io.eager import store_dataframes_as_dataset
 from kartothek.io_components.metapartition import SINGLE_TABLE
@@ -35,3 +37,21 @@ def create_dataset(dataset_uuid, store_factory, metadata_version):
         dataset_uuid=dataset_uuid,
         metadata_version=metadata_version,
     )
+
+
+def assert_num_row_groups(store, dataset, part_num_rows, part_chunk_size):
+    """
+    Assert that the row groups of each partition match the expectation based on the
+    number of rows and the chunk size
+    """
+    # Iterate over the partitions of each index value
+    for index, partitions in dataset.indices["p"].index_dct.items():
+        for part_key in partitions:
+            key = dataset.partitions[part_key].files["table"]
+            parquet_file = ParquetFile(store.open(key))
+            if part_chunk_size[index] is None:
+                assert parquet_file.num_row_groups == 1
+            else:
+                assert parquet_file.num_row_groups == math.ceil(
+                    part_num_rows[index] / part_chunk_size[index]
+                )

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -72,8 +72,6 @@ class ParquetSerializer(DataFrameSerializer):
     def __init__(
         self, compression: str = "SNAPPY", chunk_size: Optional[int] = None
     ) -> None:
-        if compression not in ["NONE", "SNAPPY", "GZIP", "BROTLI", "LZ4", "ZSTD"]:
-            raise ValueError(f"Unknown compression '{compression}'")
         self.compression = compression
 
         if chunk_size is not None:

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -69,8 +69,22 @@ class ParquetSerializer(DataFrameSerializer):
     _PARQUET_VERSION = "2.0"
     type_stable = True
 
-    def __init__(self, compression="SNAPPY", chunk_size=None):
+    def __init__(
+        self, compression: str = "SNAPPY", chunk_size: Optional[int] = None
+    ) -> None:
+        if compression not in ["NONE", "SNAPPY", "GZIP", "BROTLI", "LZ4", "ZSTD"]:
+            raise ValueError(f"Unknown compression '{compression}'")
         self.compression = compression
+
+        if chunk_size is not None:
+            if not isinstance(chunk_size, int):
+                raise TypeError(
+                    "Cannot initialize ParquetSerializer because chunk size is not integer type"
+                )
+            if chunk_size < 1:
+                raise ValueError(
+                    "Cannot initialize ParquetSerializer because chunk size < 1"
+                )
         self.chunk_size = chunk_size
 
     def __eq__(self, other):

--- a/tests/serialization/test_parquet.py
+++ b/tests/serialization/test_parquet.py
@@ -50,14 +50,6 @@ def chunk_size(request, mocker):
     return chunk_size
 
 
-@pytest.mark.parametrize("compression", ["gzip", "RAAAR"])
-def test_parquet_serializer_raises_on_invalid_compression(compression):
-    with pytest.raises(
-        ValueError, match=f"Unknown compression '{compression}'",
-    ):
-        ParquetSerializer(compression=compression)
-
-
 @pytest.mark.parametrize("chunk_size", ["1", 1.0])
 def test_parquet_serializer_raises_on_invalid_chunk_size_type(chunk_size):
     with pytest.raises(

--- a/tests/serialization/test_parquet.py
+++ b/tests/serialization/test_parquet.py
@@ -50,10 +50,35 @@ def chunk_size(request, mocker):
     return chunk_size
 
 
+@pytest.mark.parametrize("compression", ["gzip", "RAAAR"])
+def test_parquet_serializer_raises_on_invalid_compression(compression):
+    with pytest.raises(
+        ValueError, match=f"Unknown compression '{compression}'",
+    ):
+        ParquetSerializer(compression=compression)
+
+
+@pytest.mark.parametrize("chunk_size", ["1", 1.0])
+def test_parquet_serializer_raises_on_invalid_chunk_size_type(chunk_size):
+    with pytest.raises(
+        TypeError,
+        match="Cannot initialize ParquetSerializer because chunk size is not integer type",
+    ):
+        ParquetSerializer(chunk_size=chunk_size)
+
+
+@pytest.mark.parametrize("chunk_size", [-5, 0])
+def test_parquet_serializer_raises_when_chunk_size_smaller_one(chunk_size):
+    with pytest.raises(
+        ValueError, match="Cannot initialize ParquetSerializer because chunk size < 1"
+    ):
+        ParquetSerializer(chunk_size=chunk_size)
+
+
 @pytest.mark.parametrize("use_categorical", [True, False])
 def test_rowgroup_writing(store, use_categorical, chunk_size):
-    df = pd.DataFrame({"string": ["abc", "affe", "banane", "buchstabe"]})
-    serialiser = ParquetSerializer(chunk_size=2)
+    df = pd.DataFrame({"string": ["abc", "affe", "banane", "buchstabe"] * 5})
+    serialiser = ParquetSerializer(chunk_size=chunk_size)
     # Arrow 0.9.0 has a bug in writing categorical columns to more than a single
     # RowGroup: "ArrowIOError: Column 2 had 2 while previous column had 4".
     # We have special handling for that in pandas-serialiser that should be
@@ -65,7 +90,10 @@ def test_rowgroup_writing(store, use_categorical, chunk_size):
     key = serialiser.store(store, "prefix", df_write)
 
     parquet_file = ParquetFile(store.open(key))
-    assert parquet_file.num_row_groups == 2
+    if chunk_size is None:
+        assert parquet_file.num_row_groups == 1
+    else:
+        assert parquet_file.num_row_groups == 20 / chunk_size
 
 
 _INT_TYPES = ["int8", "int16", "int32", "int64"]


### PR DESCRIPTION
This allows to specify the compression algorithm and a chunk size to
generate row groups.

The Parquet serializer parameter is added the following cube operations:
  * `build_cube`
  * `append_cube`
  * `extend_cube`
  * `update_cube`

Specifying different Parquet serializers is back- and forwards compatible.
Row groups are kept for partitions that are not touched during cube operations.
If partitions are replaced or newly created, they are rewritten by the
specified Parquet serializer.

# Description:

Briefly describe the change of behavior


- [ ] Closes #xxxx
- [ ] Changelog entry
