### PR TITLE
Caching and asv

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,3 +5,7 @@ coverage:
     project:
       default:
         threshold: 0.1
+
+ignore:
+  - kartothek/io/testing/*
+  - kartothek/core/_deprecation.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 [run]
 branch = True
 source = kartothek
-# omit = bad_file.py
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
       # Tests
       - name: Pytest
-        run: pytest --cov kartothek --cov-report xml
+        run: pytest --cov-report xml
 
       - name: Running benchmarks
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,15 @@ jobs:
       - name: Pytest
         run: pytest --cov kartothek --cov-report xml
 
+      - name: Running benchmarks
+        run: |
+          asv --config ./asv_bench/asv.conf.json machine --machine github --os unknown --arch unknown --cpu unknown --ram unknown
+          asv --config ./asv_bench/asv.conf.json dev | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+          if grep "failed" benchmarks.log > /dev/null ; then
+              exit 1
+          fi
+        if: env.IS_MASTER_BUILD == 'true'
+
       # Builds
       - name: Build Wheel
         run: python setup.py sdist bdist_wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
         run: echo $IS_MASTER_BUILD
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Cache conda
+        uses: actions/cache@v2
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-${{ matrix.python }}-${{ matrix.pyarrow }}-${{ hashFiles('conda-requirements.txt', 'conda-test-requirements.txt')}}
+
       - name: Conda Bootstrap
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/conda-test-requirements.txt
+++ b/conda-test-requirements.txt
@@ -16,3 +16,6 @@ pandoc
 
 # CLI
 ipython
+
+# ASV // Benchmark
+asv

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -17,3 +17,6 @@ flake8-mutable
 
 # CLI
 ipython
+
+# ASV // Benchmark
+asv


### PR DESCRIPTION
# Description:

This re-enables the asv benchmark tests by parsing output, sets up some caching and fixes the drop in coverage reports which lately fail our PRs for no reasons

the asv and caching is motivated by the pandas ci workflow, see https://github.com/pandas-dev/pandas/blob/9a678df32112fdac7fa082954dd4b44f82d9301c/.github/workflows/ci.yml#L31-L35 and https://github.com/pandas-dev/pandas/blob/9a678df32112fdac7fa082954dd4b44f82d9301c/.github/workflows/ci.yml#L78-L88


- [x] Closes #394
- [x] Closes #377
