### PR TITLE
Add retries to restore dataframe

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Version 3.19.0 (2021-02-XY)
   state after the update
 * Expose compression type and row group chunk size in Cube interface via optional
   parameter of type :class:`~kartothek.serialization.ParquetSerializer`.
-* Add retries to  :func:`~kartothek.serialization.parquet.ParquetSerializer.restore_dataframe`
+* Add retries to  :func:`~kartothek.serialization._parquet.ParquetSerializer.restore_dataframe`
+  IOErrors on long running ktk + dask tasks have been observed. Until the root cause is fixed,
+  the serialization is retried to gain more stability.
 
 Version 3.18.0 (2021-01-25)
 ===========================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Version 3.19.0 (2021-02-XY)
   state after the update
 * Expose compression type and row group chunk size in Cube interface via optional
   parameter of type :class:`~kartothek.serialization.ParquetSerializer`.
+* Add retries to  :func:`~kartothek.serialization.parquet.ParquetSerializer.restore_dataframe`
 
 Version 3.18.0 (2021-01-25)
 ===========================

--- a/kartothek/serialization/_io_buffer.py
+++ b/kartothek/serialization/_io_buffer.py
@@ -10,6 +10,14 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
+class BufferReadError(IOError):
+    """
+    Internal kartothek error while attempting to read from buffer
+    """
+
+    pass
+
+
 class BlockBuffer(io.BufferedIOBase):
     """
     Block-based buffer.
@@ -111,7 +119,7 @@ class BlockBuffer(io.BufferedIOBase):
                 f"Expected raw read to return {size} bytes, but instead got {len(data)}"
             )
             _logger.error(err)
-            raise IOError(err)
+            raise BufferReadError(err)
 
         # fill blocks
         for i in range(n):
@@ -135,7 +143,7 @@ class BlockBuffer(io.BufferedIOBase):
         if size < 0:
             msg = f"Expected size >= 0, but got start={start}, size={size}"
             _logger.error(msg)
-            raise AssertionError(msg)
+            raise BufferReadError(msg)
 
         block = start // self._blocksize
         offset = start % self._blocksize

--- a/kartothek/serialization/_io_buffer.py
+++ b/kartothek/serialization/_io_buffer.py
@@ -111,7 +111,7 @@ class BlockBuffer(io.BufferedIOBase):
                 f"Expected raw read to return {size} bytes, but instead got {len(data)}"
             )
             _logger.error(err)
-            raise AssertionError(err)
+            raise IOError(err)
 
         # fill blocks
         for i in range(n):

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -6,6 +6,8 @@ This module contains functionality for persisting/serialising DataFrames.
 
 
 import datetime
+import logging
+import time
 from typing import Iterable, Optional
 
 import numpy as np
@@ -33,8 +35,12 @@ try:
 except ImportError:
     HAVE_BOTO = False
 
+_logger = logging.getLogger(__name__)
+
 
 EPOCH_ORDINAL = datetime.date(1970, 1, 1).toordinal()
+MAX_NB_RETRIES = 6  # longest retry backoff = BACKOFF_TIME * 2**(MAX_NB_RETRIES - 2)
+BACKOFF_TIME = 0.01  # 10 ms
 
 
 def _empty_table_from_schema(parquet_file):
@@ -63,6 +69,14 @@ def _reset_dictionary_columns(table, exclude=None):
 
     table = table.cast(schema)
     return table
+
+
+class ParquetReadError(IOError):
+    """
+    Internal kartothek error while attempting to read Parquet file
+    """
+
+    pass
 
 
 class ParquetSerializer(DataFrameSerializer):
@@ -107,85 +121,39 @@ class ParquetSerializer(DataFrameSerializer):
         categories: Optional[Iterable[str]] = None,
         predicates: Optional[PredicatesType] = None,
         date_as_object: bool = False,
-    ):
-        check_predicates(predicates)
-        # If we want to do columnar access we can benefit from partial reads
-        # otherwise full read en block is the better option.
-        if (not predicate_pushdown_to_io) or (columns is None and predicates is None):
-            with pa.BufferReader(store.get(key)) as reader:
-                table = pq.read_pandas(reader, columns=columns)
-        else:
-            if HAVE_BOTO and isinstance(store, BotoStore):
-                # Parquet and seeks on S3 currently leak connections thus
-                # we omit column projection to the store.
-                reader = pa.BufferReader(store.get(key))
-            else:
-                reader = store.open(key)
-                # Buffer at least 4 MB in requests. This is chosen because the default block size of the Azure
-                # storage client is 4MB.
-                reader = BlockBuffer(reader, 4 * 1024 * 1024)
+    ) -> pd.DataFrame:
+        for nb_retry in range(MAX_NB_RETRIES):
             try:
-                parquet_file = ParquetFile(reader)
-                if predicates and parquet_file.metadata.num_rows > 0:
-                    # We need to calculate different predicates for predicate
-                    # pushdown and the later DataFrame filtering. This is required
-                    # e.g. in the case where we have an `in` predicate as this has
-                    # different normalized values.
-                    columns_to_io = _columns_for_pushdown(columns, predicates)
-                    predicates_for_pushdown = _normalize_predicates(
-                        parquet_file, predicates, True
-                    )
-                    predicates = _normalize_predicates(parquet_file, predicates, False)
-                    tables = _read_row_groups_into_tables(
-                        parquet_file, columns_to_io, predicates_for_pushdown
-                    )
-
-                    if len(tables) == 0:
-                        table = _empty_table_from_schema(parquet_file)
-                    else:
-                        table = pa.concat_tables(tables)
-                else:
-                    # ARROW-5139 Column projection with empty columns returns a table w/out index
-                    if columns == []:
-                        # Create an arrow table with expected index length.
-                        df = (
-                            parquet_file.schema.to_arrow_schema()
-                            .empty_table()
-                            .to_pandas(date_as_object=date_as_object)
-                        )
-                        index = pd.Int64Index(
-                            pd.RangeIndex(start=0, stop=parquet_file.metadata.num_rows)
-                        )
-                        df = pd.DataFrame(df, index=index)
-                        # convert back to table to keep downstream code untouched by this patch
-                        table = pa.Table.from_pandas(df)
-                    else:
-                        table = pq.read_pandas(reader, columns=columns)
-            finally:
-                reader.close()
-
-        if columns is not None:
-            missing_columns = set(columns) - set(table.schema.names)
-            if missing_columns:
-                raise ValueError(
-                    "Columns cannot be found in stored dataframe: {missing}".format(
-                        missing=", ".join(sorted(missing_columns))
-                    )
+                return _restore_dataframe(
+                    store=store,
+                    key=key,
+                    filter_query=filter_query,
+                    columns=columns,
+                    predicate_pushdown_to_io=predicate_pushdown_to_io,
+                    categories=categories,
+                    predicates=predicates,
+                    date_as_object=date_as_object,
                 )
+            except (AssertionError, OSError):
+                _logger.warning(
+                    msg=(
+                        f"Failed to restore dataframe, attempt {nb_retry} of {MAX_NB_RETRIES} with parameters "
+                        f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
+                        f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
+                        f"predicates: {predicates}, date_as_object: {date_as_object}."
+                    ),
+                    exc_info=True,
+                )
+                # we don't sleep when we're done with the last attempt
+                if nb_retry < (MAX_NB_RETRIES - 1):
+                    time.sleep(BACKOFF_TIME * 2 ** nb_retry)
 
-        table = _reset_dictionary_columns(table, exclude=categories)
-        df = table.to_pandas(categories=categories, date_as_object=date_as_object)
-        df.columns = df.columns.map(ensure_unicode_string_type)
-        if predicates:
-            df = filter_df_from_predicates(
-                df, predicates, strict_date_types=date_as_object
-            )
-        else:
-            df = filter_df(df, filter_query)
-        if columns is not None:
-            return df.reindex(columns=columns, copy=False)
-        else:
-            return df
+        raise ParquetReadError(
+            "Failed to restore dataframe after {MAX_NB_RETRIES} attempts. Parameters: "
+            f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
+            f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
+            f"predicates: {predicates}, date_as_object: {date_as_object}."
+        )
 
     def store(self, store, key_prefix, df):
         key = "{}.parquet".format(key_prefix)
@@ -205,6 +173,94 @@ class ParquetSerializer(DataFrameSerializer):
         )
         store.put(key, buf.getvalue().to_pybytes())
         return key
+
+
+def _restore_dataframe(
+    store: KeyValueStore,
+    key: str,
+    filter_query: Optional[str] = None,
+    columns: Optional[Iterable[str]] = None,
+    predicate_pushdown_to_io: bool = True,
+    categories: Optional[Iterable[str]] = None,
+    predicates: Optional[PredicatesType] = None,
+    date_as_object: bool = False,
+) -> pd.DataFrame:
+    check_predicates(predicates)
+    # If we want to do columnar access we can benefit from partial reads
+    # otherwise full read en block is the better option.
+    if (not predicate_pushdown_to_io) or (columns is None and predicates is None):
+        with pa.BufferReader(store.get(key)) as reader:
+            table = pq.read_pandas(reader, columns=columns)
+    else:
+        if HAVE_BOTO and isinstance(store, BotoStore):
+            # Parquet and seeks on S3 currently leak connections thus
+            # we omit column projection to the store.
+            reader = pa.BufferReader(store.get(key))
+        else:
+            reader = store.open(key)
+            # Buffer at least 4 MB in requests. This is chosen because the default block size of the Azure
+            # storage client is 4MB.
+            reader = BlockBuffer(reader, 4 * 1024 * 1024)
+        try:
+            parquet_file = ParquetFile(reader)
+            if predicates and parquet_file.metadata.num_rows > 0:
+                # We need to calculate different predicates for predicate
+                # pushdown and the later DataFrame filtering. This is required
+                # e.g. in the case where we have an `in` predicate as this has
+                # different normalized values.
+                columns_to_io = _columns_for_pushdown(columns, predicates)
+                predicates_for_pushdown = _normalize_predicates(
+                    parquet_file, predicates, True
+                )
+                predicates = _normalize_predicates(parquet_file, predicates, False)
+                tables = _read_row_groups_into_tables(
+                    parquet_file, columns_to_io, predicates_for_pushdown
+                )
+
+                if len(tables) == 0:
+                    table = _empty_table_from_schema(parquet_file)
+                else:
+                    table = pa.concat_tables(tables)
+            else:
+                # ARROW-5139 Column projection with empty columns returns a table w/out index
+                if columns == []:
+                    # Create an arrow table with expected index length.
+                    df = (
+                        parquet_file.schema.to_arrow_schema()
+                        .empty_table()
+                        .to_pandas(date_as_object=date_as_object)
+                    )
+                    index = pd.Int64Index(
+                        pd.RangeIndex(start=0, stop=parquet_file.metadata.num_rows)
+                    )
+                    df = pd.DataFrame(df, index=index)
+                    # convert back to table to keep downstream code untouched by this patch
+                    table = pa.Table.from_pandas(df)
+                else:
+                    table = pq.read_pandas(reader, columns=columns)
+        finally:
+            reader.close()
+
+    if columns is not None:
+        missing_columns = set(columns) - set(table.schema.names)
+        if missing_columns:
+            raise ValueError(
+                "Columns cannot be found in stored dataframe: {missing}".format(
+                    missing=", ".join(sorted(missing_columns))
+                )
+            )
+
+    table = _reset_dictionary_columns(table, exclude=categories)
+    df = table.to_pandas(categories=categories, date_as_object=date_as_object)
+    df.columns = df.columns.map(ensure_unicode_string_type)
+    if predicates:
+        df = filter_df_from_predicates(df, predicates, strict_date_types=date_as_object)
+    else:
+        df = filter_df(df, filter_query)
+    if columns is not None:
+        return df.reindex(columns=columns, copy=False)
+    else:
+        return df
 
 
 def _columns_for_pushdown(columns, predicates):

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -213,9 +213,10 @@ class ParquetSerializer(DataFrameSerializer):
         predicates: Optional[PredicatesType] = None,
         date_as_object: bool = False,
     ) -> pd.DataFrame:
-        # XXX: We have been seeing weired `IOError` while reading Parquet files from Azure Blob Store,
-        # thus, we implement retries at this point. This code should not live forever, it should be removed
-        # once the underlying cause has been resolved
+        # https://github.com/JDASoftwareGroup/kartothek/issues/407  We have been seeing weird `IOError`s while reading
+        # Parquet files from Azure Blob Store. These errors have caused long running computations to fail.
+        # The workaround is to retry the serialization here and gain more stability for long running tasks.
+        # This code should not live forever, it should be removed once the underlying cause has been resolved.
         for nb_retry in range(MAX_NB_RETRIES):
             try:
                 return cls._restore_dataframe(

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -225,7 +225,8 @@ class ParquetSerializer(DataFrameSerializer):
                     predicates=predicates,
                     date_as_object=date_as_object,
                 )
-            except (AssertionError, OSError):
+            except (AssertionError, OSError) as err:
+                raised_error = err
                 _logger.warning(
                     msg=(
                         f"Failed to restore dataframe, attempt {nb_retry + 1} of {MAX_NB_RETRIES} with parameters "
@@ -244,7 +245,7 @@ class ParquetSerializer(DataFrameSerializer):
             f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
             f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
             f"date_as_object: {date_as_object}, predicates: {predicates}."
-        )
+        ) from raised_error
 
     def store(self, store, key_prefix, df):
         key = "{}.parquet".format(key_prefix)

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -152,7 +152,7 @@ class ParquetSerializer(DataFrameSerializer):
             "Failed to restore dataframe after {MAX_NB_RETRIES} attempts. Parameters: "
             f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
             f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
-            f"predicates: {predicates}, date_as_object: {date_as_object}."
+            f"date_as_object: {date_as_object}, predicates: {predicates}."
         )
 
     def store(self, store, key_prefix, df):

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -137,7 +137,7 @@ class ParquetSerializer(DataFrameSerializer):
             except (AssertionError, OSError):
                 _logger.warning(
                     msg=(
-                        f"Failed to restore dataframe, attempt {nb_retry} of {MAX_NB_RETRIES} with parameters "
+                        f"Failed to restore dataframe, attempt {nb_retry + 1} of {MAX_NB_RETRIES} with parameters "
                         f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
                         f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
                         f"predicates: {predicates}, date_as_object: {date_as_object}."

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -149,7 +149,7 @@ class ParquetSerializer(DataFrameSerializer):
                     time.sleep(BACKOFF_TIME * 2 ** nb_retry)
 
         raise ParquetReadError(
-            "Failed to restore dataframe after {MAX_NB_RETRIES} attempts. Parameters: "
+            f"Failed to restore dataframe after {MAX_NB_RETRIES} attempts. Parameters: "
             f"key: {key}, filter_query: {filter_query}, columns: {columns}, "
             f"predicate_pushdown_to_io: {predicate_pushdown_to_io}, categories: {categories}, "
             f"date_as_object: {date_as_object}, predicates: {predicates}."

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -112,7 +112,98 @@ class ParquetSerializer(DataFrameSerializer):
         )
 
     @staticmethod
+    def _restore_dataframe(
+        store: KeyValueStore,
+        key: str,
+        filter_query: Optional[str] = None,
+        columns: Optional[Iterable[str]] = None,
+        predicate_pushdown_to_io: bool = True,
+        categories: Optional[Iterable[str]] = None,
+        predicates: Optional[PredicatesType] = None,
+        date_as_object: bool = False,
+    ) -> pd.DataFrame:
+        check_predicates(predicates)
+        # If we want to do columnar access we can benefit from partial reads
+        # otherwise full read en block is the better option.
+        if (not predicate_pushdown_to_io) or (columns is None and predicates is None):
+            with pa.BufferReader(store.get(key)) as reader:
+                table = pq.read_pandas(reader, columns=columns)
+        else:
+            if HAVE_BOTO and isinstance(store, BotoStore):
+                # Parquet and seeks on S3 currently leak connections thus
+                # we omit column projection to the store.
+                reader = pa.BufferReader(store.get(key))
+            else:
+                reader = store.open(key)
+                # Buffer at least 4 MB in requests. This is chosen because the default block size of the Azure
+                # storage client is 4MB.
+                reader = BlockBuffer(reader, 4 * 1024 * 1024)
+            try:
+                parquet_file = ParquetFile(reader)
+                if predicates and parquet_file.metadata.num_rows > 0:
+                    # We need to calculate different predicates for predicate
+                    # pushdown and the later DataFrame filtering. This is required
+                    # e.g. in the case where we have an `in` predicate as this has
+                    # different normalized values.
+                    columns_to_io = _columns_for_pushdown(columns, predicates)
+                    predicates_for_pushdown = _normalize_predicates(
+                        parquet_file, predicates, True
+                    )
+                    predicates = _normalize_predicates(parquet_file, predicates, False)
+                    tables = _read_row_groups_into_tables(
+                        parquet_file, columns_to_io, predicates_for_pushdown
+                    )
+
+                    if len(tables) == 0:
+                        table = _empty_table_from_schema(parquet_file)
+                    else:
+                        table = pa.concat_tables(tables)
+                else:
+                    # ARROW-5139 Column projection with empty columns returns a table w/out index
+                    if columns == []:
+                        # Create an arrow table with expected index length.
+                        df = (
+                            parquet_file.schema.to_arrow_schema()
+                            .empty_table()
+                            .to_pandas(date_as_object=date_as_object)
+                        )
+                        index = pd.Int64Index(
+                            pd.RangeIndex(start=0, stop=parquet_file.metadata.num_rows)
+                        )
+                        df = pd.DataFrame(df, index=index)
+                        # convert back to table to keep downstream code untouched by this patch
+                        table = pa.Table.from_pandas(df)
+                    else:
+                        table = pq.read_pandas(reader, columns=columns)
+            finally:
+                reader.close()
+
+        if columns is not None:
+            missing_columns = set(columns) - set(table.schema.names)
+            if missing_columns:
+                raise ValueError(
+                    "Columns cannot be found in stored dataframe: {missing}".format(
+                        missing=", ".join(sorted(missing_columns))
+                    )
+                )
+
+        table = _reset_dictionary_columns(table, exclude=categories)
+        df = table.to_pandas(categories=categories, date_as_object=date_as_object)
+        df.columns = df.columns.map(ensure_unicode_string_type)
+        if predicates:
+            df = filter_df_from_predicates(
+                df, predicates, strict_date_types=date_as_object
+            )
+        else:
+            df = filter_df(df, filter_query)
+        if columns is not None:
+            return df.reindex(columns=columns, copy=False)
+        else:
+            return df
+
+    @classmethod
     def restore_dataframe(
+        cls,
         store: KeyValueStore,
         key: str,
         filter_query: Optional[str] = None,
@@ -124,7 +215,7 @@ class ParquetSerializer(DataFrameSerializer):
     ) -> pd.DataFrame:
         for nb_retry in range(MAX_NB_RETRIES):
             try:
-                return _restore_dataframe(
+                return cls._restore_dataframe(
                     store=store,
                     key=key,
                     filter_query=filter_query,
@@ -173,94 +264,6 @@ class ParquetSerializer(DataFrameSerializer):
         )
         store.put(key, buf.getvalue().to_pybytes())
         return key
-
-
-def _restore_dataframe(
-    store: KeyValueStore,
-    key: str,
-    filter_query: Optional[str] = None,
-    columns: Optional[Iterable[str]] = None,
-    predicate_pushdown_to_io: bool = True,
-    categories: Optional[Iterable[str]] = None,
-    predicates: Optional[PredicatesType] = None,
-    date_as_object: bool = False,
-) -> pd.DataFrame:
-    check_predicates(predicates)
-    # If we want to do columnar access we can benefit from partial reads
-    # otherwise full read en block is the better option.
-    if (not predicate_pushdown_to_io) or (columns is None and predicates is None):
-        with pa.BufferReader(store.get(key)) as reader:
-            table = pq.read_pandas(reader, columns=columns)
-    else:
-        if HAVE_BOTO and isinstance(store, BotoStore):
-            # Parquet and seeks on S3 currently leak connections thus
-            # we omit column projection to the store.
-            reader = pa.BufferReader(store.get(key))
-        else:
-            reader = store.open(key)
-            # Buffer at least 4 MB in requests. This is chosen because the default block size of the Azure
-            # storage client is 4MB.
-            reader = BlockBuffer(reader, 4 * 1024 * 1024)
-        try:
-            parquet_file = ParquetFile(reader)
-            if predicates and parquet_file.metadata.num_rows > 0:
-                # We need to calculate different predicates for predicate
-                # pushdown and the later DataFrame filtering. This is required
-                # e.g. in the case where we have an `in` predicate as this has
-                # different normalized values.
-                columns_to_io = _columns_for_pushdown(columns, predicates)
-                predicates_for_pushdown = _normalize_predicates(
-                    parquet_file, predicates, True
-                )
-                predicates = _normalize_predicates(parquet_file, predicates, False)
-                tables = _read_row_groups_into_tables(
-                    parquet_file, columns_to_io, predicates_for_pushdown
-                )
-
-                if len(tables) == 0:
-                    table = _empty_table_from_schema(parquet_file)
-                else:
-                    table = pa.concat_tables(tables)
-            else:
-                # ARROW-5139 Column projection with empty columns returns a table w/out index
-                if columns == []:
-                    # Create an arrow table with expected index length.
-                    df = (
-                        parquet_file.schema.to_arrow_schema()
-                        .empty_table()
-                        .to_pandas(date_as_object=date_as_object)
-                    )
-                    index = pd.Int64Index(
-                        pd.RangeIndex(start=0, stop=parquet_file.metadata.num_rows)
-                    )
-                    df = pd.DataFrame(df, index=index)
-                    # convert back to table to keep downstream code untouched by this patch
-                    table = pa.Table.from_pandas(df)
-                else:
-                    table = pq.read_pandas(reader, columns=columns)
-        finally:
-            reader.close()
-
-    if columns is not None:
-        missing_columns = set(columns) - set(table.schema.names)
-        if missing_columns:
-            raise ValueError(
-                "Columns cannot be found in stored dataframe: {missing}".format(
-                    missing=", ".join(sorted(missing_columns))
-                )
-            )
-
-    table = _reset_dictionary_columns(table, exclude=categories)
-    df = table.to_pandas(categories=categories, date_as_object=date_as_object)
-    df.columns = df.columns.map(ensure_unicode_string_type)
-    if predicates:
-        df = filter_df_from_predicates(df, predicates, strict_date_types=date_as_object)
-    else:
-        df = filter_df(df, filter_query)
-    if columns is not None:
-        return df.reindex(columns=columns, copy=False)
-    else:
-        return df
 
 
 def _columns_for_pushdown(columns, predicates):


### PR DESCRIPTION
# Description:

Same as in https://github.com/JDASoftwareGroup/kartothek/pull/401
I don't have write access to lr4d's fork, so I can't push on his branch.

Baseline: Add retries for restoring dataframes. We have seen IOErrors on long running ktk + dask tasks with no clear idea what the root cause is. Therefore retry the serialization to gain more stability, until the root cause is fixed.