### PR TITLE
Drop missings from fake categories in align categories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Version 3.19.1 (2021-02-XX)
 ===========================
 
 * Allow ``pyarrow==3`` as a dependency.
+* Fix a bug in :func:`~kartothek.io_components.utils.align_categories` for dataframes
+  with missings and of non-categorical dtype.
 
 Version 3.19.0 (2021-02-12)
 ===========================

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -344,7 +344,7 @@ def align_categories(dfs, categoricals):
         for ix, df in enumerate(dfs):
             ser = df[column]
             if not pd.api.types.is_categorical_dtype(ser):
-                cats = ser.unique()
+                cats = ser.dropna().unique()
                 LOGGER.info(
                     "Encountered non-categorical type where categorical was expected\n"
                     "Found at index position {ix} for column {col}\n"

--- a/tests/io_components/test_utils.py
+++ b/tests/io_components/test_utils.py
@@ -1,6 +1,7 @@
 from functools import partial
 from typing import Callable
 
+import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pyarrow as pa
@@ -200,6 +201,20 @@ def test_align_categories():
             name=col_name,
         )
         pdt.assert_series_equal(out_dfs[2][col_name], expected_3)
+
+
+def test_align_categories_with_missings():
+    df_0 = pd.DataFrame({"letters": ["a", "a", "b", np.nan]})
+    df_1 = pd.DataFrame({"letters": ["a", "a"]})
+    out = align_categories([df_0, df_1], ["letters"])
+    expected_0 = pd.DataFrame(
+        {"letters": pd.Categorical(["a", "a", "b", np.nan], categories=["a", "b"])}
+    )
+    expected_1 = pd.DataFrame(
+        {"letters": pd.Categorical(["a", "a"], categories=["a", "b"])}
+    )
+    pdt.assert_frame_equal(out[0], expected_0)
+    pdt.assert_frame_equal(out[1], expected_1)
 
 
 def test_sort_cateogrical():


### PR DESCRIPTION
The following bug popped up for us today:

```
In [1]: import numpy as np
   ...: import pandas as pd
   ...: 
   ...: from kartothek.io_components.utils import align_categories
   ...: 
   ...: df_1 = pd.DataFrame({"letters": ["a", "a", "b", np.nan]})
   ...: df_2 = pd.DataFrame({"letters": ["a", "a", "b"]})
   ...: 
   ...: align_categories([df_1, df_2], ["letters"])
   ...: 
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-1-869d9adb16e6> in <module>
      7 df_2 = pd.DataFrame({"letters": ["a", "a", "b"]})
      8 
----> 9 align_categories([df_1, df_2], ["letters"])

~/code/kartothek/kartothek/io_components/utils.py in align_categories(dfs, categoricals)
    362         # use the categories of the largest DF as a baseline to avoid having
    363         # to rewrite its codes. Append the remainder and sort it for reproducibility
--> 364         categories = list(largest_df_categories) + sorted(
    365             set(categories) - set(largest_df_categories)
    366         )

TypeError: '<' not supported between instances of 'str' and 'float'
```

This is due to 
https://github.com/JDASoftwareGroup/kartothek/blob/4008de4436dde947faa3979f3ccf035f99c955c0/kartothek/io_components/utils.py#L347
not dropping missings (which are never categories). This `sort` then raises:
https://github.com/JDASoftwareGroup/kartothek/blob/4008de4436dde947faa3979f3ccf035f99c955c0/kartothek/io_components/utils.py#L364-L366

This PR is a proposed quick-fix.