### PR TITLE
fix typo: 'KTK_CUBE_UUID_SEPERATOR' -> 'KTK_CUBE_UUID_SEPARATOR'

### DIFF
--- a/kartothek/api/discover.py
+++ b/kartothek/api/discover.py
@@ -10,7 +10,7 @@ from kartothek.core.cube.constants import (
     KTK_CUBE_METADATA_KEY_IS_SEED,
     KTK_CUBE_METADATA_PARTITION_COLUMNS,
     KTK_CUBE_METADATA_SUPPRESS_INDEX_ON,
-    KTK_CUBE_UUID_SEPERATOR,
+    KTK_CUBE_UUID_SEPARATOR,
 )
 from kartothek.core.cube.cube import Cube
 from kartothek.core.dataset import DatasetMetadata
@@ -79,7 +79,7 @@ def discover_ktk_cube_dataset_ids(uuid_prefix: str, store: StoreInput) -> Set[st
         The ktk_cube dataset ids
 
     """
-    prefix = uuid_prefix + KTK_CUBE_UUID_SEPERATOR
+    prefix = uuid_prefix + KTK_CUBE_UUID_SEPARATOR
     names = _discover_dataset_meta_files(prefix, store)
     return set([name[len(prefix) :] for name in names])
 
@@ -115,7 +115,7 @@ def discover_datasets_unchecked(
     filter_ktk_cube_dataset_ids = converter_str_set_optional(
         filter_ktk_cube_dataset_ids
     )
-    prefix = uuid_prefix + KTK_CUBE_UUID_SEPERATOR
+    prefix = uuid_prefix + KTK_CUBE_UUID_SEPARATOR
 
     names = _discover_dataset_meta_files(prefix, store)
 

--- a/kartothek/core/cube/constants.py
+++ b/kartothek/core/cube/constants.py
@@ -46,3 +46,5 @@ KTK_CUBE_METADATA_SUPPRESS_INDEX_ON = "ktk_cube_suppress_index_on"
 
 #: Character sequence used to seperate cube and dataset UUID
 KTK_CUBE_UUID_SEPARATOR = "++"
+# Alias for compat reasons
+KTK_CUBE_UUID_SEPERATOR = KTK_CUBE_UUID_SEPARATOR

--- a/kartothek/core/cube/constants.py
+++ b/kartothek/core/cube/constants.py
@@ -9,7 +9,7 @@ __all__ = (
     "KTK_CUBE_METADATA_KEY_IS_SEED",
     "KTK_CUBE_METADATA_STORAGE_FORMAT",
     "KTK_CUBE_METADATA_VERSION",
-    "KTK_CUBE_UUID_SEPERATOR",
+    "KTK_CUBE_UUID_SEPARATOR",
 )
 
 
@@ -45,4 +45,4 @@ KTK_CUBE_METADATA_PARTITION_COLUMNS = "ktk_cube_partition_columns"
 KTK_CUBE_METADATA_SUPPRESS_INDEX_ON = "ktk_cube_suppress_index_on"
 
 #: Character sequence used to seperate cube and dataset UUID
-KTK_CUBE_UUID_SEPERATOR = "++"
+KTK_CUBE_UUID_SEPARATOR = "++"

--- a/kartothek/core/cube/cube.py
+++ b/kartothek/core/cube/cube.py
@@ -2,7 +2,7 @@ import typing
 
 import attr
 
-from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPERATOR
+from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPARATOR
 from kartothek.core.dataset import _validate_uuid
 from kartothek.utils.converters import (
     converter_str,
@@ -102,10 +102,10 @@ def _validator_uuid_freestanding(name, value):
                 name=name, value=value
             )
         )
-    if value.find(KTK_CUBE_UUID_SEPERATOR) != -1:
+    if value.find(KTK_CUBE_UUID_SEPARATOR) != -1:
         raise ValueError(
             '{name} ("{value}") must not contain UUID separator {sep}'.format(
-                name=name, value=value, sep=KTK_CUBE_UUID_SEPERATOR
+                name=name, value=value, sep=KTK_CUBE_UUID_SEPARATOR
             )
         )
 
@@ -201,7 +201,7 @@ class Cube:
         _validator_uuid_freestanding("ktk_cube_dataset_id", ktk_cube_dataset_id)
         return "{uuid_prefix}{sep}{ktk_cube_dataset_id}".format(
             uuid_prefix=self.uuid_prefix,
-            sep=KTK_CUBE_UUID_SEPERATOR,
+            sep=KTK_CUBE_UUID_SEPARATOR,
             ktk_cube_dataset_id=ktk_cube_dataset_id,
         )
 

--- a/kartothek/io/dask/common_cube.py
+++ b/kartothek/io/dask/common_cube.py
@@ -61,7 +61,7 @@ def ensure_valid_cube_indices(
 ) -> Cube:
     """
     Parse all existing datasets and infer the required set of indices. We do not
-    allow indices to be removed or added in update steps at the momenent and
+    allow indices to be removed or added in update steps at the moment and
     need to make sure that existing ones are updated properly.
     The returned `Cube` instance will be a copy of the input with
     `index_columns` and `suppress_index_on` fields adjusted to reflect the

--- a/kartothek/io/testing/cleanup_cube.py
+++ b/kartothek/io/testing/cleanup_cube.py
@@ -2,7 +2,7 @@
 import pandas as pd
 import pytest
 
-from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPERATOR
+from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPARATOR
 from kartothek.core.cube.cube import Cube
 from kartothek.io.eager_cube import build_cube, copy_cube
 
@@ -185,7 +185,7 @@ def test_additional_files(driver, function_store):
     key_in_ds = cube.ktk_dataset_uuid(cube.seed_dataset) + "/foo"
     key_with_ds_prefix = cube.ktk_dataset_uuid(cube.seed_dataset) + ".foo"
     key_with_cube_prefix = cube.uuid_prefix + ".foo"
-    key_with_cube_prefix_separator = cube.uuid_prefix + KTK_CUBE_UUID_SEPERATOR + ".foo"
+    key_with_cube_prefix_separator = cube.uuid_prefix + KTK_CUBE_UUID_SEPARATOR + ".foo"
 
     function_store().put(key_in_ds, b"")
     function_store().put(key_with_ds_prefix, b"")

--- a/kartothek/io_components/cube/cleanup.py
+++ b/kartothek/io_components/cube/cleanup.py
@@ -1,6 +1,6 @@
 from functools import reduce
 
-from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPERATOR
+from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPARATOR
 from kartothek.utils.ktk_adapters import get_dataset_keys
 
 __all__ = ("get_keys_to_clean",)
@@ -27,7 +27,7 @@ def get_keys_to_clean(cube_uuid_prefix, datasets, store):
     )
 
     keys_present = {
-        k for k in store.iter_keys(cube_uuid_prefix + KTK_CUBE_UUID_SEPERATOR)
+        k for k in store.iter_keys(cube_uuid_prefix + KTK_CUBE_UUID_SEPARATOR)
     }
 
     return keys_present - keys_should

--- a/kartothek/io_components/cube/write.py
+++ b/kartothek/io_components/cube/write.py
@@ -130,6 +130,7 @@ def prepare_ktk_metadata(cube, ktk_cube_dataset_id, metadata):
     return ds_metadata
 
 
+# XXX: This is not consistent with plain kartothek datasets (indices are accepted on nullable columns there)
 def assert_dimesion_index_cols_notnull(
     df: pd.DataFrame, ktk_cube_dataset_id: str, cube: Cube, partition_on: Sequence[str]
 ) -> pd.DataFrame:

--- a/tests/core/cube/test_constants.py
+++ b/tests/core/cube/test_constants.py
@@ -1,6 +1,6 @@
-from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPERATOR
+from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPARATOR
 from kartothek.core.dataset import _validate_uuid
 
 
 def test_uuid_seperator_valid():
-    assert _validate_uuid(KTK_CUBE_UUID_SEPERATOR)
+    assert _validate_uuid(KTK_CUBE_UUID_SEPARATOR)


### PR DESCRIPTION
# Description:

Fix two typos, add a comment about ktk/ktk.cube inconsistency

- [ ] Closes #xxxx
- [ ] Changelog entry
