### PR TITLE
Fix read_dataset_as_dataframes(_iterator) to correctly return categoricals for misaligned categories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version 3.19.2 (2021-xx-xx)
+===========================
+
+* :func:`~kartothek.io.eager.read_dataset_as_dataframes` and
+  :func:`~kartothek.io.iter.read_dataset_as_dataframes__iterator` now correctly return
+  categoricals as requested for misaligned categories.
+
+
 Version 3.19.1 (2021-02-24)
 ===========================
 

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -51,6 +51,7 @@ from kartothek.core.uuid import gen_uuid
 from kartothek.io_components.utils import (
     InferredIndices,
     _ensure_valid_indices,
+    align_categories,
     combine_metadata,
 )
 from kartothek.serialization import (
@@ -1561,6 +1562,12 @@ class MetaPartition(Iterable):
             if len(data[table]) == 1:
                 new_data[table] = data[table][0]
             else:
+                categoricals = [
+                    col
+                    for col, dtype in data[table][0].items()
+                    if pd.api.types.is_categorical_dtype(dtype)
+                ]
+                data[table] = align_categories(data[table], categoricals)
                 new_data[table] = pd.concat(data[table])
 
             new_schema[table] = validate_compatible(schema[table])

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -330,11 +330,15 @@ def align_categories(dfs, categoricals):
         A list of dataframes for which the categoricals should be aligned
     categoricals: List[str]
         Columns holding categoricals which should be aligned
+
     Returns
     -------
     List[pd.DataFrame]
         A list with aligned dataframes
     """
+    if len(categoricals) == 0:
+        return dfs
+
     col_dtype = {}
 
     for column in categoricals:

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1453,6 +1453,26 @@ def test_concat_metapartition_different_partitioning(df_all_types):
         MetaPartition.concat_metapartitions([mp1, mp2])
 
 
+def test_concat_metapartition_categoricals(df_all_types):
+    mp1 = MetaPartition(
+        label="first",
+        data={"table": pd.DataFrame({"a": [0, 0], "b": ["a", "a"]}, dtype="category")},
+        metadata_version=4,
+        partition_keys=["a"],
+    )
+    mp2 = MetaPartition(
+        label="second",
+        data={"table": pd.DataFrame({"a": [1, 1], "b": ["a", "b"]}, dtype="category")},
+        metadata_version=4,
+        partition_keys=["a"],
+    )
+
+    new_mp = MetaPartition.concat_metapartitions([mp1, mp2])
+
+    assert new_mp.tables == ["table"]
+    assert pd.api.types.is_categorical_dtype(new_mp.data["table"]["b"].dtype)
+
+
 # We can't partition on null columns (gh-262)
 @pytest.mark.parametrize(
     "col", sorted(set(get_dataframe_not_nested().columns) - {"null"})


### PR DESCRIPTION
Closes #420 

I did not find a cleaner way to get the list of categoricals. Another option would be to do this within `align_categoricals` is `categoricals=None`.

I am not sure whether the
```python
    if len(categoricals) == 0:
        return dfs
```
is required to prevent additional copies in absence of categoricals.