### PR TITLE
[DRAFT] support renaming of datasets while copying a cube

### DIFF
--- a/kartothek/io/eager_cube.py
+++ b/kartothek/io/eager_cube.py
@@ -419,7 +419,15 @@ def delete_cube(cube, store, datasets=None):
         store.delete(k)
 
 
-def copy_cube(cube, src_store, tgt_store, overwrite=False, datasets=None):
+def copy_cube(
+    cube,
+    src_store,
+    tgt_store,
+    overwrite=False,
+    datasets=None,
+    renamed_cube=None,
+    datasets_to_rename=None,
+):
     """
     Copy cube from one store to another.
 
@@ -436,6 +444,12 @@ def copy_cube(cube, src_store, tgt_store, overwrite=False, datasets=None):
     datasets: Union[None, Iterable[str], Dict[str, kartothek.core.dataset.DatasetMetadata]]
         Datasets to copy, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, a list
         of Ktk_cube dataset ID or ``None`` (in which case entire cube will be copied).
+    renamed_cube: Optional[str]
+        If specified, the entire cube will be renamed while copying
+    datasets_to_rename: Optional[Dict[str, str]]
+        Optional dict of {old dataset name:  new dataset name} entries. If specified,
+        the corresponding datasets will be renamed accordingly. Unknown keys will cause
+        an error.
     """
     if callable(src_store):
         src_store = src_store()
@@ -451,8 +465,11 @@ def copy_cube(cube, src_store, tgt_store, overwrite=False, datasets=None):
         tgt_store=tgt_store,
         overwrite=overwrite,
         datasets=datasets,
+        datasets_to_rename=datasets_to_rename,
     )
-    copy_keys(keys, src_store, tgt_store)
+    copy_keys(
+        keys, src_store, tgt_store, datasets_to_rename=datasets_to_rename, src_cube=cube
+    )
 
 
 def collect_stats(cube, store, datasets=None):

--- a/kartothek/io/testing/copy_cube.py
+++ b/kartothek/io/testing/copy_cube.py
@@ -4,7 +4,7 @@ import pytest
 
 from kartothek.api.discover import discover_datasets_unchecked
 from kartothek.core.cube.cube import Cube
-from kartothek.io.eager_cube import build_cube
+from kartothek.io.eager_cube import build_cube, query_cube
 from kartothek.utils.ktk_adapters import get_dataset_keys
 
 __all__ = (
@@ -33,6 +33,7 @@ __all__ = (
     "test_partial_copy_dataset_list",
     "test_read_only_source",
     "test_simple",
+    "test_simple_with_rename",
 )
 
 
@@ -86,6 +87,45 @@ def assert_same_keys(store1, store2, keys):
 def test_simple(driver, function_store, function_store2, cube, simple_cube_1):
     driver(cube=cube, src_store=function_store, tgt_store=function_store2)
     assert_same_keys(function_store, function_store2, simple_cube_1)
+
+
+def test_simple_with_rename(
+    driver, function_store, function_store2, cube, simple_cube_1, df_seed, df_enrich
+):
+    # TODO first attempt: only implemented for driver copy_cube
+    # TODO any way to use pytest.mark.skipif with a fixture variable?
+    if "copy_cube" not in str(driver):
+        return
+    ds_name_old = "enrich"
+    ds_name_new = "augmented"
+    driver(
+        cube=cube,
+        src_store=function_store,
+        tgt_store=function_store2,
+        datasets_to_rename={ds_name_old: ds_name_new},
+    )
+
+    tgt_keys = function_store2().keys()
+    for src_key in sorted(simple_cube_1):
+        tgt_key = src_key.replace(ds_name_old, ds_name_new)
+        assert tgt_key in tgt_keys
+        b1 = function_store().get(src_key)
+        b2 = function_store2().get(tgt_key)
+        if tgt_key.endswith("by-dataset-metadata.json"):
+            b1_mod = (
+                b1.decode("utf-8").replace(ds_name_old, ds_name_new).encode("utf-8")
+            )
+            assert b1_mod == b2
+        else:
+            assert b1 == b2
+
+    tgt_cube = Cube(
+        dimension_columns=["x"], partition_columns=["p"], uuid_prefix="cube"
+    )
+    tgt_cube_res = query_cube(cube=tgt_cube, store=function_store2)[0]
+    assert tgt_cube_res is not None
+    assert tgt_cube_res[["x", "p", "v1"]].equals(df_seed)
+    assert tgt_cube_res[["x", "p", "v2"]].equals(df_enrich)
 
 
 def test_overwrite_fail(

--- a/kartothek/io_components/cube/copy.py
+++ b/kartothek/io_components/cube/copy.py
@@ -3,12 +3,25 @@ from __future__ import absolute_import
 from copy import copy
 
 from kartothek.api.discover import check_datasets, discover_datasets_unchecked
+from kartothek.core.dataset import DatasetMetadataBuilder
 from kartothek.utils.ktk_adapters import get_dataset_keys
 
 __all__ = ("get_copy_keys",)
 
 
-def get_copy_keys(cube, src_store, tgt_store, overwrite, datasets=None):
+def _assert_datasets_contained_in(cube, ds_needles, ds_haystack):
+    unknown_datasets = set(ds_needles) - set(ds_haystack)
+    if unknown_datasets:
+        raise RuntimeError(
+            "{cube}, datasets {datasets} do not exist in source store".format(
+                cube=cube, datasets=unknown_datasets
+            )
+        )
+
+
+def get_copy_keys(
+    cube, src_store, tgt_store, overwrite, datasets=None, datasets_to_rename=None
+):
     """
     Get and check keys that should be copied from one store to another.
 
@@ -25,6 +38,10 @@ def get_copy_keys(cube, src_store, tgt_store, overwrite, datasets=None):
     datasets: Union[None, Iterable[str], Dict[str, kartothek.core.dataset.DatasetMetadata]]
         Datasets to copy, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, an
         iterable of Ktk_cube dataset ID or ``None`` (in which case entire cube will be copied).
+    datasets_to_rename: Optional[Dict[str, str]]
+        Optional dict of {old dataset name:  new dataset name} entries. If specified,
+        the corresponding datasets will be renamed accordingly. Unknown keys will cause
+        an error.
 
     Returns
     -------
@@ -35,46 +52,63 @@ def get_copy_keys(cube, src_store, tgt_store, overwrite, datasets=None):
     ------
     RuntimeError: In case the copy would not pass successfully or if there is no cube in ``src_store``.
     """
+
+    # if datasets is a dict, i.e. the result of discover_datasets(): use it.
+    # otherwise, call discover_datasets_unchecked() to create such a dict
     if not isinstance(datasets, dict):
-        new_datasets = discover_datasets_unchecked(
+        datasets_to_copy = discover_datasets_unchecked(
             uuid_prefix=cube.uuid_prefix,
             store=src_store,
             filter_ktk_cube_dataset_ids=datasets,
         )
     else:
-        new_datasets = datasets
+        datasets_to_copy = datasets
 
     if datasets is None:
-        if not new_datasets:
+        if not datasets_to_copy:
             raise RuntimeError("{} not found in source store".format(cube))
     else:
-        unknown_datasets = set(datasets) - set(new_datasets)
-        if unknown_datasets:
-            raise RuntimeError(
-                "{cube}, datasets {datasets} do not exist in source store".format(
-                    cube=cube, datasets=unknown_datasets
-                )
-            )
+        # check if datasets parameter contains unknown, i.e. non-existing, datasets.
+        # this may only happen if datasets is a list of dataset names.
+        _assert_datasets_contained_in(cube, datasets, datasets_to_copy)
+
+    if datasets_to_rename:
+        # if datasets shall be renamed: check if the list of datasets to rename is a
+        # subset of the datasets to copy
+        _assert_datasets_contained_in(cube, datasets_to_rename, datasets_to_copy)
+    else:
+        datasets_to_rename = {}
 
     existing_datasets = discover_datasets_unchecked(cube.uuid_prefix, tgt_store)
 
     if not overwrite:
-        for ktk_cube_dataset_id in sorted(new_datasets.keys()):
-            if ktk_cube_dataset_id in existing_datasets:
+        # If no target data shall be overwritten, check if the selected datasets do
+        # already exist in the target store. Note that the dataset name may change.
+        for ktk_cube_dataset_id in sorted(datasets_to_copy.keys()):
+            ktk_target_dataset_id = datasets_to_rename.get(
+                ktk_cube_dataset_id, ktk_cube_dataset_id
+            )
+            if ktk_target_dataset_id in existing_datasets:
                 raise RuntimeError(
                     'Dataset "{uuid}" exists in target store but overwrite was set to False'.format(
-                        uuid=new_datasets[ktk_cube_dataset_id].uuid
+                        uuid=existing_datasets[ktk_target_dataset_id].uuid
                     )
                 )
 
     all_datasets = copy(existing_datasets)
-    all_datasets.update(new_datasets)
+    for ds, ds_meta in datasets_to_copy.items():
+        renamed_ds = datasets_to_rename.get(ds, ds)
+        all_datasets[renamed_ds] = (
+            DatasetMetadataBuilder.from_dataset(ds_meta)
+            .modify_dataset_name(renamed_ds)
+            .to_dataset()
+        )
 
     check_datasets(all_datasets, cube)
 
     keys = set()
-    for ktk_cube_dataset_id in sorted(new_datasets.keys()):
-        ds = new_datasets[ktk_cube_dataset_id]
+    for ktk_cube_dataset_id in sorted(datasets_to_copy.keys()):
+        ds = datasets_to_copy[ktk_cube_dataset_id]
         keys |= get_dataset_keys(ds)
 
     return keys


### PR DESCRIPTION
# Description:

Function copy_cube() has a new parameter: datasets_to_rename:

    datasets_to_rename: Optional[Dict[str, str]]
        Optional dict of {old dataset name:  new dataset name} entries. If specified,
        the corresponding datasets will be renamed accordingly. Unknown keys will cause
        an error.

Renaming will also affect the dataset metadata.
