### PR TITLE
Return dask scalar for store and update from ddf

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ This is a major release of kartothek with breaking API changes.
 * Remove `metadata`, `df_serializer`, `overwrite`, `metadata_merger` from :func:`kartothek.io.eager.write_single_partition`
 * :func:`~kartothek.io.eager.store_dataframes_as_dataset` now requires a list as an input
 * Default value for argument `date_as_object` is now universally set to ``True``. The behaviour for `False` will be deprecated and removed in the next major release
+* No longer allow to pass `delete_scope` as a delayed object to :func:`~kartothek.io.dask.dataframe.update_dataset_from_ddf`
+* :func:`~kartothek.io.dask.dataframe.update_dataset_from_ddf` and :func:`~kartothek.io.dask.dataframe.store_dataset_from_ddf` now return a `dd.core.Scalar` object. This enables all `dask.DataFrame` graph optimizations by default.
+* Remove argument `table_name` from :func:`~kartothek.io.dask.dataframe.collect_dataset_metadata`
+
 
 Version 3.20.0 (2021-03-15)
 ===========================

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -4,7 +4,7 @@ This module is a collection of helper functions
 import collections
 import inspect
 import logging
-from typing import Dict, Iterable, List, Optional, TypeVar, Union, overload
+from typing import Dict, Iterable, List, Optional, Union, overload
 
 import decorator
 import pandas as pd
@@ -165,7 +165,20 @@ _NORMALIZE_ARGS_LIST = [
 
 _NORMALIZE_ARGS = _NORMALIZE_ARGS_LIST + ["store", "dispatch_by"]
 
-T = TypeVar("T")
+
+@overload
+def normalize_arg(
+    arg_name: Literal[
+        "partition_on",
+        "delete_scope",
+        "secondary_indices",
+        "bucket_by",
+        "sort_partitions_by",
+        "dispatch_by",
+    ],
+    old_value: None,
+) -> None:
+    ...
 
 
 @overload
@@ -178,8 +191,8 @@ def normalize_arg(
         "sort_partitions_by",
         "dispatch_by",
     ],
-    old_value: Optional[Union[T, List[T]]],
-) -> List[T]:
+    old_value: Union[str, List[str]],
+) -> List[str]:
     ...
 
 

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -14,7 +14,6 @@ def test_collect_dataset_metadata(store_session_factory, dataset):
     df_stats = collect_dataset_metadata(
         store=store_session_factory,
         dataset_uuid="dataset_uuid",
-        table_name="table",
         predicates=None,
         frac=1,
     ).compute()
@@ -48,7 +47,6 @@ def test_collect_dataset_metadata_predicates(store_session_factory, dataset):
     df_stats = collect_dataset_metadata(
         store=store_session_factory,
         dataset_uuid="dataset_uuid",
-        table_name="table",
         predicates=predicates,
         frac=1,
     ).compute()
@@ -87,11 +85,7 @@ def test_collect_dataset_metadata_predicates_on_index(store_factory):
     predicates = [[("L", "==", "b")]]
 
     df_stats = collect_dataset_metadata(
-        store=store_factory,
-        dataset_uuid="dataset_uuid",
-        table_name="table",
-        predicates=predicates,
-        frac=1,
+        store=store_factory, dataset_uuid="dataset_uuid", predicates=predicates, frac=1,
     ).compute()
 
     assert "L=b" in df_stats["partition_label"].values[0]
@@ -135,11 +129,7 @@ def test_collect_dataset_metadata_predicates_row_group_size(store_factory):
     predicates = [[("L", "==", "a")]]
 
     df_stats = collect_dataset_metadata(
-        store=store_factory,
-        dataset_uuid="dataset_uuid",
-        table_name="table",
-        predicates=predicates,
-        frac=1,
+        store=store_factory, dataset_uuid="dataset_uuid", predicates=predicates, frac=1,
     ).compute()
 
     for part_label in df_stats["partition_label"]:
@@ -170,10 +160,7 @@ def test_collect_dataset_metadata_predicates_row_group_size(store_factory):
 
 def test_collect_dataset_metadata_frac_smoke(store_session_factory, dataset):
     df_stats = collect_dataset_metadata(
-        store=store_session_factory,
-        dataset_uuid="dataset_uuid",
-        table_name="table",
-        frac=0.8,
+        store=store_session_factory, dataset_uuid="dataset_uuid", frac=0.8,
     ).compute()
     columns = {
         "partition_label",
@@ -195,7 +182,7 @@ def test_collect_dataset_metadata_empty_dataset(store_factory):
         store=store_factory, dataset_uuid="dataset_uuid", dfs=[df], partition_on=["A"]
     )
     df_stats = collect_dataset_metadata(
-        store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
+        store=store_factory, dataset_uuid="dataset_uuid"
     ).compute()
     expected = pd.DataFrame(columns=_METADATA_SCHEMA.keys())
     expected = expected.astype(_METADATA_SCHEMA)
@@ -209,7 +196,7 @@ def test_collect_dataset_metadata_concat(store_factory):
         store=store_factory, dataset_uuid="dataset_uuid", dfs=[df], partition_on=["A"]
     )
     df_stats1 = collect_dataset_metadata(
-        store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
+        store=store_factory, dataset_uuid="dataset_uuid",
     ).compute()
 
     # Remove all partitions of the dataset
@@ -218,7 +205,7 @@ def test_collect_dataset_metadata_concat(store_factory):
     )
 
     df_stats2 = collect_dataset_metadata(
-        store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
+        store=store_factory, dataset_uuid="dataset_uuid",
     ).compute()
     pd.concat([df_stats1, df_stats2])
 
@@ -234,7 +221,7 @@ def test_collect_dataset_metadata_delete_dataset(store_factory):
     )
 
     df_stats = collect_dataset_metadata(
-        store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
+        store=store_factory, dataset_uuid="dataset_uuid",
     ).compute()
     expected = pd.DataFrame(columns=_METADATA_SCHEMA)
     expected = expected.astype(_METADATA_SCHEMA)
@@ -273,16 +260,10 @@ def test_collect_dataset_metadata_at_least_one_partition(store_factory):
 def test_collect_dataset_metadata_invalid_frac(store_session_factory, dataset):
     with pytest.raises(ValueError, match="Invalid value for parameter `frac`"):
         collect_dataset_metadata(
-            store=store_session_factory,
-            dataset_uuid="dataset_uuid",
-            table_name="table",
-            frac=1.1,
+            store=store_session_factory, dataset_uuid="dataset_uuid", frac=1.1,
         )
 
     with pytest.raises(ValueError, match="Invalid value for parameter `frac`"):
         collect_dataset_metadata(
-            store=store_session_factory,
-            dataset_uuid="dataset_uuid",
-            table_name="table",
-            frac=0.0,
+            store=store_session_factory, dataset_uuid="dataset_uuid", frac=0.0,
         )

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -44,22 +44,6 @@ def _return_none():
     return None
 
 
-def test_delayed_as_delete_scope(store_factory, df_all_types):
-    # Check that delayed objects are allowed as delete scope.
-    tasks = update_dataset_from_ddf(
-        dd.from_pandas(df_all_types, npartitions=1),
-        store_factory,
-        dataset_uuid="output_dataset_uuid",
-        table="core",
-        delete_scope=dask.delayed(_return_none)(),
-    )
-
-    s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)
-    tasks = pickle.loads(s)
-
-    tasks.compute()
-
-
 @pytest.mark.parametrize("shuffle", [True, False])
 def test_update_dataset_from_ddf_empty(store_factory, shuffle):
     with pytest.raises(ValueError, match="Cannot store empty datasets"):


### PR DESCRIPTION
# Description:

I considered this always as a breaking change since it alters the way dask optimizes the graph which might impact workflows significantly. However, this result should be rather universally better so this is a good change we can safely do with 4.0

This also allows to implement some tree reduction which should speed up the final commit by merging indices in stages instead of one big step in the end but this is not implemented int his PR

- [x] Closes #354
- [x] Closes #301
- [x] Changelog entry
