### PR TITLE
Fix bug when loading few columns of a dataset with many primary indices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Kartothek 4.0.1 (2021-04-xx)
+============================
+* Fix a bug in :meth:`~kartothek.io_components.metapartition.MetaPartition._reconstruct_index_columns` that would raise an ``IndexError`` when loading few columns of a dataset with many primary indices.
+
+
 Kartothek 4.0.0 (2021-03-17)
 ============================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 
 Kartothek 4.0.1 (2021-04-xx)
 ============================
+
 * Fix a bug in :meth:`~kartothek.io_components.metapartition.MetaPartition._reconstruct_index_columns` that would raise an ``IndexError`` when loading few columns of a dataset with many primary indices.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 Kartothek 4.0.1 (2021-04-xx)
 ============================
 
-* Fix a bug in :meth:`~kartothek.io_components.metapartition.MetaPartition._reconstruct_index_columns` that would raise an ``IndexError`` when loading few columns of a dataset with many primary indices.
+* Fix a bug in ``MetaPartition._reconstruct_index_columns`` that would raise an ``IndexError`` when loading few columns of a dataset with many primary indices.
 
 
 Kartothek 4.0.0 (2021-03-17)

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -766,7 +766,8 @@ class MetaPartition(Iterable):
             # indexer call is slow, so only do that if really necessary
             df = df.reindex(columns=cleaned_original_columns, copy=False)
 
-        for pos, (primary_key, value) in enumerate(key_indices):
+        pos = 0
+        for primary_key, value in key_indices:
             # If there are predicates, don't reconstruct the index if it wasn't requested
             if columns is not None and primary_key not in columns:
                 continue
@@ -800,6 +801,7 @@ class MetaPartition(Iterable):
                 if convert_to_date:
                     value = pd.Timestamp(value).to_pydatetime().date()
             df.insert(pos, primary_key, value)
+            pos += 1
 
         return df
 

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -27,7 +27,7 @@ def test_store_single_dataframe_as_partition(store, metadata_version):
     mp = MetaPartition(label="test_label", data=df, metadata_version=metadata_version)
 
     meta_partition = mp.store_dataframes(
-        store=store, df_serializer=ParquetSerializer(), dataset_uuid="dataset_uuid",
+        store=store, df_serializer=ParquetSerializer(), dataset_uuid="dataset_uuid"
     )
 
     assert meta_partition.data is None
@@ -58,7 +58,7 @@ def test_load_dataframe_logical_conjunction(store, metadata_version):
         logical_conjunction=[("P", ">", 4)],
     )
     meta_partition = mp.store_dataframes(
-        store=store, df_serializer=None, dataset_uuid="dataset_uuid",
+        store=store, df_serializer=None, dataset_uuid="dataset_uuid"
     )
     predicates = None
     loaded_mp = meta_partition.load_dataframes(store=store, predicates=predicates)
@@ -1331,3 +1331,17 @@ def test_get_parquet_metadata_row_group_size(store):
         }
     )
     pd.testing.assert_frame_equal(actual, expected)
+
+
+def test__reconstruct_index_columns():
+    df = pd.DataFrame({"x": [0], "a": [-1], "b": [-2], "c": [-3]})
+    mp = MetaPartition(label="test_label", data=df)
+    df_with_index_columns = mp._reconstruct_index_columns(
+        df=df[["x"]],
+        key_indices=[("a", 1), ("b", 2), ("c", 3)],
+        columns=["x", "c"],
+        categories=None,
+        date_as_object=False,
+    )
+    # Index columns first
+    pdt.assert_frame_equal(df_with_index_columns, pd.DataFrame({"c": [3], "x": [0]}))


### PR DESCRIPTION
# Description:

On master:
```
In [1]: import pandas as pd
   ...: import storefact
   ...: from functools import partial
   ...: from kartothek.io.eager import store_dataframes_as_dataset, read_table
   ...: 
   ...: path = "/tmp"
   ...: uuid = "dataset"
   ...: 
   ...: df = pd.DataFrame({"w": [-1, -2], "x": [1, 2], "y": ["a", "b"], "z": [0.0, 1.1]})
   ...: 
   ...: store = partial(storefact.get_store_from_url, f"hfs://{path}?create_if_missing=False")
   ...: dm = store_dataframes_as_dataset(
   ...:     dfs=[df],
   ...:     dataset_uuid=uuid,
   ...:     store=store,
   ...:     partition_on=["w", "x", "y"],
   ...:     overwrite=True,
   ...: )
   ...: 
   ...: df = read_table(dataset_uuid=uuid, store=store, columns=["y", "z"])
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-1-a5c31589801c> in <module>
     18 )
     19 
---> 20 df = read_table(dataset_uuid=uuid, store=store, columns=["y", "z"])

~/code/kartothek/kartothek/io/eager.py in read_table(dataset_uuid, store, columns, predicate_pushdown_to_io, categoricals, dates_as_object, predicates, factory)
    248         dataset_uuid=dataset_uuid, store=store, factory=factory,
    249     )
--> 250     partitions = read_dataset_as_dataframes(
    251         columns=columns,
    252         predicate_pushdown_to_io=predicate_pushdown_to_io,

~/code/kartothek/kartothek/io/eager.py in read_dataset_as_dataframes(dataset_uuid, store, columns, predicate_pushdown_to_io, categoricals, dates_as_object, predicates, factory, dispatch_by)
    135     )
    136 
--> 137     mps = read_dataset_as_metapartitions(
    138         columns=columns,
    139         predicate_pushdown_to_io=predicate_pushdown_to_io,

~/code/kartothek/kartothek/io/eager.py in read_dataset_as_metapartitions(dataset_uuid, store, columns, predicate_pushdown_to_io, categoricals, dates_as_object, predicates, factory, dispatch_by)
    202         dispatch_by=dispatch_by,
    203     )
--> 204     return list(ds_iter)
    205 
    206 

~/code/kartothek/kartothek/io/iter.py in read_dataset_as_metapartitions__iterator(dataset_uuid, store, columns, predicate_pushdown_to_io, categoricals, dates_as_object, predicates, factory, dispatch_by)
     87         else:
     88             mp = cast(MetaPartition, mp)
---> 89             mp = mp.load_dataframes(
     90                 store=store,
     91                 columns=columns,

~/code/kartothek/kartothek/io_components/metapartition.py in _impl(self, *method_args, **method_kwargs)
    148         else:
    149             for mp in self:
--> 150                 method_return = method(mp, *method_args, **method_kwargs)
    151                 if not isinstance(method_return, MetaPartition):
    152                     raise ValueError(

~/code/kartothek/kartothek/io_components/metapartition.py in load_dataframes(self, store, columns, predicate_pushdown_to_io, categoricals, dates_as_object, predicates)
    701         # Metadata version >=4 parse the index columns and add them back to the dataframe
    702 
--> 703         df = self._reconstruct_index_columns(
    704             df=df,
    705             key_indices=indices,

~/code/kartothek/kartothek/io_components/metapartition.py in _reconstruct_index_columns(self, df, key_indices, columns, categories, date_as_object)
    800                 if convert_to_date:
    801                     value = pd.Timestamp(value).to_pydatetime().date()
--> 802             df.insert(pos, primary_key, value)
    803 
    804         return df

~/anaconda3/envs/kartothek/lib/python3.9/site-packages/pandas/core/frame.py in insert(self, loc, column, value, allow_duplicates)
   3622         self._ensure_valid_index(value)
   3623         value = self._sanitize_column(column, value, broadcast=False)
-> 3624         self._mgr.insert(loc, column, value, allow_duplicates=allow_duplicates)
   3625 
   3626     def assign(self, **kwargs) -> "DataFrame":

~/anaconda3/envs/kartothek/lib/python3.9/site-packages/pandas/core/internals/managers.py in insert(self, loc, item, value, allow_duplicates)
   1204             self._blknos = np.append(self._blknos, len(self.blocks))
   1205         else:
-> 1206             self._blklocs = np.insert(self._blklocs, loc, 0)
   1207             self._blknos = np.insert(self._blknos, loc, len(self.blocks))
   1208 

<__array_function__ internals> in insert(*args, **kwargs)

~/anaconda3/envs/kartothek/lib/python3.9/site-packages/numpy/lib/function_base.py in insert(arr, obj, values, axis)
   4556         index = indices.item()
   4557         if index < -N or index > N:
-> 4558             raise IndexError(
   4559                 "index %i is out of bounds for axis %i with "
   4560                 "size %i" % (obj, axis, N))

IndexError: index 2 is out of bounds for axis 0 with size 1

In [2]: 
```

This PR fixes this.

- [x] Changelog entry
