### PR TITLE
Add eager copy for datasets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,18 +2,17 @@
 Changelog
 =========
 
-
 Kartothek 4.0.2 (2021-04-xx)
 ============================
 
 * Fix a bug in ``MetaPartition._reconstruct_index_columns`` that would raise an ``IndexError`` when loading few columns of a dataset with many primary indices.
-
+* Add :meth:`~kartothek.io.eager.copy_dataset` to copy and optionally rename datasets within one store or between stores (eager only)
+* Add renaming option to :meth:`~kartothek.io.eager_cube.copy_cube`
 
 Kartothek 4.0.1 (2021-04-13)
 ============================
 
 * Fixed dataset corruption after updates when table names other than "table" are used (#445).
-
 
 Kartothek 4.0.0 (2021-03-17)
 ============================

--- a/kartothek/core/dataset.py
+++ b/kartothek/core/dataset.py
@@ -938,13 +938,12 @@ class DatasetMetadataBuilder(CopyMixin):
         self.partitions = modified_partitions
 
         for i_key, i in self.indices.items():
-            if (hasattr(i, "index_storage_key")) and (
-                getattr(i, "index_storage_key") is not None
+            if (
+                isinstance(i, ExplicitSecondaryIndex)
+                and i.index_storage_key is not None
             ):
-                setattr(
-                    i,
-                    "index_storage_key",
-                    getattr(i, "index_storage_key").replace(self.uuid, target_uuid, 1),
+                i.index_storage_key = i.index_storage_key.replace(
+                    self.uuid, target_uuid, 1
                 )
         self.uuid = target_uuid
         return self

--- a/kartothek/core/dataset.py
+++ b/kartothek/core/dataset.py
@@ -907,15 +907,15 @@ class DatasetMetadataBuilder(CopyMixin):
         ds_builder.partitions = dataset.partitions
         return ds_builder
 
-    def modify_uuid(self, tgt_uuid):
+    def modify_uuid(self, tgt_uuid: str):
         """
         Modify the dataset uuid and depending metadata:
         - paths to partitioning files
         - path to index files
 
-        Parameters:
-            tgt_uuid: str
-                Modified dataset UUID.
+        :param tgt_uuid:
+            Modified dataset UUID.
+        :return modified builder object
         """
 
         # modify file names in partition metadata
@@ -930,9 +930,8 @@ class DatasetMetadataBuilder(CopyMixin):
 
         for i_key, i in self.indices.items():
             if hasattr(i, "index_storage_key"):
-                i.index_storage_key = i.index_storage_key.replace(
-                    self.uuid, tgt_uuid, 1
-                )
+                i_mod = getattr(i, "index_storage_key").replace(self.uuid, tgt_uuid, 1)
+                i.index_storage_key = i_mod  # type: ignore
         self.uuid = tgt_uuid
         return self
 

--- a/kartothek/core/dataset.py
+++ b/kartothek/core/dataset.py
@@ -930,8 +930,11 @@ class DatasetMetadataBuilder(CopyMixin):
 
         for i_key, i in self.indices.items():
             if hasattr(i, "index_storage_key"):
-                i_mod = getattr(i, "index_storage_key").replace(self.uuid, tgt_uuid, 1)
-                i.index_storage_key = i_mod  # type: ignore
+                setattr(
+                    i,
+                    "index_storage_key",
+                    getattr(i, "index_storage_key").replace(self.uuid, tgt_uuid, 1),
+                )
         self.uuid = tgt_uuid
         return self
 

--- a/kartothek/core/dataset.py
+++ b/kartothek/core/dataset.py
@@ -907,6 +907,28 @@ class DatasetMetadataBuilder(CopyMixin):
         ds_builder.partitions = dataset.partitions
         return ds_builder
 
+    def modify_dataset_name(self, new_ds_name):
+        """
+        Modify the dataset name and change dependent fields, i.e. UUID and partitioning
+        information.
+
+        TODO: This will atm only work for cube datasets with a UUID like cube++dataset.
+        Which UUIDs are possible for non-cube datasets?
+        """
+        rx_transform_path = re.compile(r"(\w*)\+\+(\w*)/(.*)")
+
+        cube_name, old_ds_name = self.uuid.split("++")
+        self.uuid = cube_name + "++" + new_ds_name
+        for p_key, p in self.partitions.items():
+            pdict = p.to_dict()
+            for table_name, file_name in pdict["files"].items():
+                match = rx_transform_path.match(file_name)
+                if match:
+                    f_cube, f_ds, f_path = match.groups()
+                    pdict["files"][table_name] = f"{f_cube}++{new_ds_name}/{f_path}"
+            self.partitions[p_key] = Partition.from_dict(p_key, pdict)
+        return self
+
     def add_partition(self, name, partition):
         """
         Add an (embedded) Partition.

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -744,36 +744,6 @@ def garbage_collect_dataset(dataset_uuid=None, store=None, factory=None):
     return delete_files(next(nested_files), store_factory=ds_factory.store_factory)
 
 
-def _transform_key(source_key: str, source_uuid: str, target_uuid: str) -> str:
-    """
-    Modify a key: replace the source dataset UUID with the target dataset UUID
-    Parameters:
-        source_key: str
-            Key to modify
-        source_uuid: str
-            Source dataset UUID
-        target_uuid: str
-            Target dataset UUID
-    """
-    return source_key.replace(source_uuid, target_uuid)
-
-
-def _transform_metadata(src_metadata: DatasetMetadata, tgt_ds: str) -> bytes:
-    """
-    Modify the metadata to reflect the changes of the copying process
-
-    :param src_metadata:
-        Metadata to modify
-    :param tgt_ds:
-        UUID of target dataset
-    """
-    return (
-        DatasetMetadataBuilder.from_dataset(src_metadata)
-        .modify_uuid(tgt_ds)
-        .to_json()[1]
-    )
-
-
 def copy_dataset(
     src_dataset_uuid: str,
     store: KeyValueStore,

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -60,6 +60,7 @@ __all__ = (
     "update_dataset_from_dataframes",
     "build_dataset_indices",
     "garbage_collect_dataset",
+    "copy_dataset",
 )
 
 
@@ -756,14 +757,14 @@ def copy_dataset(
 
     Parameters
     ----------
-    source_dataset_uuid: str
+    source_dataset_uuid:
         UUID of source dataset
-    store: KeyValueStore
+    store:
         Source store
-    target_dataset_uuid: Optional[str]
+    target_dataset_uuid:
         UUID of target dataset. May be the same as src_dataset_uuid, if store
         and tgt_store are different. If empty, src_dataset_uuid is used
-    target_store: Optional[KeyValueStore]
+    target_store:
         Target Store. May be the same as store, if src_dataset_uuid and
         target_dataset_uuid are different. If empty, value from parameter store is
         used

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -807,10 +807,7 @@ def copy_dataset(
         )
 
     ds_factory_source = _ensure_factory(
-        dataset_uuid=src_dataset_uuid,
-        store=store,
-        factory=None,
-        load_dataset_metadata=True,
+        dataset_uuid=src_dataset_uuid, store=store, factory=None,
     )
 
     # Create a dict of {source key: target key} entries

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -750,7 +750,7 @@ def copy_dataset(
     store: KeyValueStore,
     target_dataset_uuid: Optional[str] = None,
     target_store: Optional[KeyValueStore] = None,
-):
+) -> Dict[str, DatasetMetadata]:
     """
     Copies and optionally renames a dataset, either  from one store to another or
     within one store.
@@ -792,13 +792,15 @@ def copy_dataset(
 
     # Create a dict of metadata which has to be changed. This is only the
     # <uuid>.by-dataset-metadata.json file
+
     md_transformed = {
-        f"{source_dataset_uuid}{METADATA_BASE_SUFFIX}{METADATA_FORMAT_JSON}": DatasetMetadataBuilder.from_dataset(
+        f"{target_dataset_uuid}{METADATA_BASE_SUFFIX}{METADATA_FORMAT_JSON}": DatasetMetadataBuilder.from_dataset(
             ds_factory_source.dataset_metadata
         )
         .modify_uuid(target_dataset_uuid)
-        .to_json()[1]
+        .to_dataset()
     }
-
     # Copy the keys from one store to another
     copy_rename_keys(mapped_keys, store, target_store, md_transformed)
+
+    return md_transformed

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -47,7 +47,7 @@ from kartothek.io_components.utils import (
 from kartothek.io_components.write import raise_if_dataset_exists
 from kartothek.serialization import DataFrameSerializer
 from kartothek.utils.ktk_adapters import get_dataset_keys
-from kartothek.utils.store import copy_keys
+from kartothek.utils.store import copy_rename_keys
 
 __all__ = (
     "delete_dataset",
@@ -744,26 +744,28 @@ def garbage_collect_dataset(dataset_uuid=None, store=None, factory=None):
     return delete_files(next(nested_files), store_factory=ds_factory.store_factory)
 
 
-def _transform_key(source_key: str, source_ds: str, target_ds: str) -> str:
+def _transform_key(source_key: str, source_uuid: str, target_uuid: str) -> str:
     """
     Modify a key: replace the source dataset UUID with the target dataset UUID
     Parameters:
         source_key: str
             Key to modify
-        source_ds: str
+        source_uuid: str
             Source dataset UUID
-        target_ds: str
+        target_uuid: str
             Target dataset UUID
     """
-    return source_key.replace(source_ds, target_ds)
+    return source_key.replace(source_uuid, target_uuid)
 
 
-def _transform_metadata(src_metadata: DatasetMetadata, tgt_ds: str) -> DatasetMetadata:
+def _transform_metadata(src_metadata: DatasetMetadata, tgt_ds: str) -> bytes:
     """
     Modify the metadata to reflect the changes of the copying process
 
-    src_metadata: Metadata to modify
-    tgt_ds: UUID of target dataset
+    :param src_metadata:
+        Metadata to modify
+    :param tgt_ds:
+        UUID of target dataset
     """
     return (
         DatasetMetadataBuilder.from_dataset(src_metadata)
@@ -782,18 +784,17 @@ def copy_dataset(
     Copies and optionally renames a dataset, either  from one store to another or
     within one store.
 
-    Parameters:
-        src_dataset_uuid: str
-            UUID of source dataset
-        store: KeyValueStore
-            Source store
-        target_dataset_uuid: Optional[str]
-            UUID of target dataset. May be the same as src_dataset_uuid, if store
-            and tgt_store are different. If empty, src_dataset_uuid is used
-        tgt_store: Optional[KeyValueStore]
-            Target Store. May be the same as store, if src_dataset_uuid and
-            target_dataset_uuid are different. If empty, value from parameter store is
-            used
+    :param src_dataset_uuid:
+        UUID of source dataset
+    :param store:
+        Source store
+    :param target_dataset_uuid:
+        UUID of target dataset. May be the same as src_dataset_uuid, if store
+        and tgt_store are different. If empty, src_dataset_uuid is used
+    :param tgt_store:
+        Target Store. May be the same as store, if src_dataset_uuid and
+        target_dataset_uuid are different. If empty, value from parameter store is
+        used
     """
     if target_dataset_uuid is None:
         target_dataset_uuid = src_dataset_uuid
@@ -814,17 +815,20 @@ def copy_dataset(
 
     # Create a dict of {source key: target key} entries
     keys = get_dataset_keys(ds_factory_source.dataset_metadata)
-    mapped_keys = {}
-    for key in keys:
-        mapped_keys[key] = _transform_key(key, src_dataset_uuid, target_dataset_uuid)
+    mapped_keys = {
+        source_key: source_key.replace(src_dataset_uuid, target_dataset_uuid)
+        for source_key in keys
+    }
 
-    # Create a dict of {source key: transformed metadata} entries for all metadata
-    # which must be changed (only uuid.by-dataset-metadata.json files)
+    # Create a dict of metadata which has to be changed. This is only the
+    # <uuid>.by-dataset-metadata.json file
     md_transformed = {
-        f"{src_dataset_uuid}{METADATA_BASE_SUFFIX}{METADATA_FORMAT_JSON}": _transform_metadata(
-            ds_factory_source.dataset_metadata, target_dataset_uuid
+        f"{src_dataset_uuid}{METADATA_BASE_SUFFIX}{METADATA_FORMAT_JSON}": DatasetMetadataBuilder.from_dataset(
+            ds_factory_source.dataset_metadata
         )
+        .modify_uuid(target_dataset_uuid)
+        .to_json()[1]
     }
 
     # Copy the keys from one store to another
-    copy_keys(mapped_keys, store, tgt_store, md_transformed)
+    copy_rename_keys(mapped_keys, store, tgt_store, md_transformed)

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -15,6 +15,8 @@ from kartothek.core.factory import DatasetFactory, _ensure_factory
 from kartothek.core.naming import (
     DEFAULT_METADATA_STORAGE_FORMAT,
     DEFAULT_METADATA_VERSION,
+    METADATA_BASE_SUFFIX,
+    METADATA_FORMAT_JSON,
     PARQUET_FILE_SUFFIX,
     get_partition_file_prefix,
 )
@@ -44,6 +46,8 @@ from kartothek.io_components.utils import (
 )
 from kartothek.io_components.write import raise_if_dataset_exists
 from kartothek.serialization import DataFrameSerializer
+from kartothek.utils.ktk_adapters import get_dataset_keys
+from kartothek.utils.store import copy_keys
 
 __all__ = (
     "delete_dataset",
@@ -738,3 +742,89 @@ def garbage_collect_dataset(dataset_uuid=None, store=None, factory=None):
     # Given that `nested_files` is a generator with a single element, just
     # return the output of `delete_files` on that element.
     return delete_files(next(nested_files), store_factory=ds_factory.store_factory)
+
+
+def _transform_key(source_key: str, source_ds: str, target_ds: str) -> str:
+    """
+    Modify a key: replace the source dataset UUID with the target dataset UUID
+    Parameters:
+        source_key: str
+            Key to modify
+        source_ds: str
+            Source dataset UUID
+        target_ds: str
+            Target dataset UUID
+    """
+    return source_key.replace(source_ds, target_ds)
+
+
+def _transform_metadata(src_metadata: DatasetMetadata, tgt_ds: str) -> DatasetMetadata:
+    """
+    Modify the metadata to reflect the changes of the copying process
+
+    src_metadata: Metadata to modify
+    tgt_ds: UUID of target dataset
+    """
+    return (
+        DatasetMetadataBuilder.from_dataset(src_metadata)
+        .modify_uuid(tgt_ds)
+        .to_json()[1]
+    )
+
+
+def copy_dataset(
+    src_dataset_uuid: str,
+    store: KeyValueStore,
+    target_dataset_uuid: Optional[str] = None,
+    tgt_store: Optional[KeyValueStore] = None,
+):
+    """
+    Copies and optionally renames a dataset, either  from one store to another or
+    within one store.
+
+    Parameters:
+        src_dataset_uuid: str
+            UUID of source dataset
+        store: KeyValueStore
+            Source store
+        target_dataset_uuid: Optional[str]
+            UUID of target dataset. May be the same as src_dataset_uuid, if store
+            and tgt_store are different. If empty, src_dataset_uuid is used
+        tgt_store: Optional[KeyValueStore]
+            Target Store. May be the same as store, if src_dataset_uuid and
+            target_dataset_uuid are different. If empty, value from parameter store is
+            used
+    """
+    if target_dataset_uuid is None:
+        target_dataset_uuid = src_dataset_uuid
+    if tgt_store is None:
+        tgt_store = store
+
+    if (src_dataset_uuid == target_dataset_uuid) & (store == tgt_store):
+        raise ValueError(
+            "Cannot copy to a dataset with the same UUID within the same store!"
+        )
+
+    ds_factory_source = _ensure_factory(
+        dataset_uuid=src_dataset_uuid,
+        store=store,
+        factory=None,
+        load_dataset_metadata=True,
+    )
+
+    # Create a dict of {source key: target key} entries
+    keys = get_dataset_keys(ds_factory_source.dataset_metadata)
+    mapped_keys = {}
+    for key in keys:
+        mapped_keys[key] = _transform_key(key, src_dataset_uuid, target_dataset_uuid)
+
+    # Create a dict of {source key: transformed metadata} entries for all metadata
+    # which must be changed (only uuid.by-dataset-metadata.json files)
+    md_transformed = {
+        f"{src_dataset_uuid}{METADATA_BASE_SUFFIX}{METADATA_FORMAT_JSON}": _transform_metadata(
+            ds_factory_source.dataset_metadata, target_dataset_uuid
+        )
+    }
+
+    # Copy the keys from one store to another
+    copy_keys(mapped_keys, store, tgt_store, md_transformed)

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -745,52 +745,54 @@ def garbage_collect_dataset(dataset_uuid=None, store=None, factory=None):
 
 
 def copy_dataset(
-    src_dataset_uuid: str,
+    source_dataset_uuid: str,
     store: KeyValueStore,
     target_dataset_uuid: Optional[str] = None,
-    tgt_store: Optional[KeyValueStore] = None,
+    target_store: Optional[KeyValueStore] = None,
 ):
     """
     Copies and optionally renames a dataset, either  from one store to another or
     within one store.
 
-    :param src_dataset_uuid:
+    Parameters
+    ----------
+    source_dataset_uuid: str
         UUID of source dataset
-    :param store:
+    store: KeyValueStore
         Source store
-    :param target_dataset_uuid:
+    target_dataset_uuid: Optional[str]
         UUID of target dataset. May be the same as src_dataset_uuid, if store
         and tgt_store are different. If empty, src_dataset_uuid is used
-    :param tgt_store:
+    target_store: Optional[KeyValueStore]
         Target Store. May be the same as store, if src_dataset_uuid and
         target_dataset_uuid are different. If empty, value from parameter store is
         used
     """
     if target_dataset_uuid is None:
-        target_dataset_uuid = src_dataset_uuid
-    if tgt_store is None:
-        tgt_store = store
+        target_dataset_uuid = source_dataset_uuid
+    if target_store is None:
+        target_store = store
 
-    if (src_dataset_uuid == target_dataset_uuid) & (store == tgt_store):
+    if (source_dataset_uuid == target_dataset_uuid) & (store == target_store):
         raise ValueError(
             "Cannot copy to a dataset with the same UUID within the same store!"
         )
 
     ds_factory_source = _ensure_factory(
-        dataset_uuid=src_dataset_uuid, store=store, factory=None,
+        dataset_uuid=source_dataset_uuid, store=store, factory=None,
     )
 
     # Create a dict of {source key: target key} entries
     keys = get_dataset_keys(ds_factory_source.dataset_metadata)
     mapped_keys = {
-        source_key: source_key.replace(src_dataset_uuid, target_dataset_uuid)
+        source_key: source_key.replace(source_dataset_uuid, target_dataset_uuid)
         for source_key in keys
     }
 
     # Create a dict of metadata which has to be changed. This is only the
     # <uuid>.by-dataset-metadata.json file
     md_transformed = {
-        f"{src_dataset_uuid}{METADATA_BASE_SUFFIX}{METADATA_FORMAT_JSON}": DatasetMetadataBuilder.from_dataset(
+        f"{source_dataset_uuid}{METADATA_BASE_SUFFIX}{METADATA_FORMAT_JSON}": DatasetMetadataBuilder.from_dataset(
             ds_factory_source.dataset_metadata
         )
         .modify_uuid(target_dataset_uuid)
@@ -798,4 +800,4 @@ def copy_dataset(
     }
 
     # Copy the keys from one store to another
-    copy_rename_keys(mapped_keys, store, tgt_store, md_transformed)
+    copy_rename_keys(mapped_keys, store, target_store, md_transformed)

--- a/kartothek/io/eager_cube.py
+++ b/kartothek/io/eager_cube.py
@@ -517,9 +517,9 @@ def copy_cube(
     ----------
     cube: Cube
         Cube specification.
-    src_store: Union[KeyValueStore, Callable[[], KeyValueStore]]
+    src_store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
         Source KV store.
-    tgt_store: Union[KeyValueStore, Callable[[], KeyValueStore]]
+    tgt_store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
         Target KV store.
     overwrite: bool
         If possibly existing datasets in the target store should be overwritten.

--- a/kartothek/io/eager_cube.py
+++ b/kartothek/io/eager_cube.py
@@ -419,7 +419,15 @@ def delete_cube(cube, store, datasets=None):
         store.delete(k)
 
 
-def copy_cube(cube, src_store, tgt_store, overwrite=False, datasets=None):
+def copy_cube(
+    cube,
+    src_store,
+    tgt_store,
+    overwrite=False,
+    datasets=None,
+    renamed_cube=None,
+    datasets_to_rename=None,
+):
     """
     Copy cube from one store to another.
 
@@ -436,6 +444,12 @@ def copy_cube(cube, src_store, tgt_store, overwrite=False, datasets=None):
     datasets: Union[None, Iterable[str], Dict[str, kartothek.core.dataset.DatasetMetadata]]
         Datasets to copy, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, a list
         of Ktk_cube dataset ID or ``None`` (in which case entire cube will be copied).
+    renamed_cube: Optional[str]
+        If specified, the entire cube will be renamed while copying
+    datasets_to_rename: Optional[Dict[str, str]]
+        Optional dict of {old dataset name:  new dataset name} entries. If specified,
+        the corresponding datasets will be renamed accordingly. Unknown keys will cause
+        an error.
     """
     if callable(src_store):
         src_store = src_store()
@@ -451,8 +465,11 @@ def copy_cube(cube, src_store, tgt_store, overwrite=False, datasets=None):
         tgt_store=tgt_store,
         overwrite=overwrite,
         datasets=datasets,
+        datasets_to_rename=datasets_to_rename,
     )
-    copy_keys(keys, src_store, tgt_store)
+    copy_keys(
+        keys, src_store, tgt_store, datasets_to_rename=datasets_to_rename, src_cube=cube
+    )
 
 
 def collect_stats(cube, store, datasets=None):

--- a/kartothek/io/eager_cube.py
+++ b/kartothek/io/eager_cube.py
@@ -420,13 +420,7 @@ def delete_cube(cube, store, datasets=None):
 
 
 def copy_cube(
-    cube,
-    src_store,
-    tgt_store,
-    overwrite=False,
-    datasets=None,
-    renamed_cube=None,
-    datasets_to_rename=None,
+    cube, src_store, tgt_store, overwrite=False, datasets=None,
 ):
     """
     Copy cube from one store to another.
@@ -444,12 +438,6 @@ def copy_cube(
     datasets: Union[None, Iterable[str], Dict[str, kartothek.core.dataset.DatasetMetadata]]
         Datasets to copy, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, a list
         of Ktk_cube dataset ID or ``None`` (in which case entire cube will be copied).
-    renamed_cube: Optional[str]
-        If specified, the entire cube will be renamed while copying
-    datasets_to_rename: Optional[Dict[str, str]]
-        Optional dict of {old dataset name:  new dataset name} entries. If specified,
-        the corresponding datasets will be renamed accordingly. Unknown keys will cause
-        an error.
     """
     if callable(src_store):
         src_store = src_store()
@@ -465,11 +453,8 @@ def copy_cube(
         tgt_store=tgt_store,
         overwrite=overwrite,
         datasets=datasets,
-        datasets_to_rename=datasets_to_rename,
     )
-    copy_keys(
-        keys, src_store, tgt_store, datasets_to_rename=datasets_to_rename, src_cube=cube
-    )
+    copy_keys(keys, src_store, tgt_store)
 
 
 def collect_stats(cube, store, datasets=None):

--- a/kartothek/io/eager_cube.py
+++ b/kartothek/io/eager_cube.py
@@ -479,16 +479,17 @@ def _transform_metadata(
     all_datasets = discover_datasets_unchecked(
         uuid_prefix=cube_prefix, store=src_store,
     )
+    if renamed_datasets is None:
+        renamed_datasets = {}
+
     md_transformed = {}
     tgt_cube_prefix = renamed_cube or cube_prefix
+
     for ds, ds_meta in all_datasets.items():
         # build new cube uuid for each dataset: <new prefix>++<new dataset name>
-        if (renamed_datasets is not None) and (ds in renamed_datasets.keys()):
-            tgt_uuid = (
-                f"{tgt_cube_prefix}{KTK_CUBE_UUID_SEPARATOR}{renamed_datasets[ds]}"
-            )
-        else:
-            tgt_uuid = f"{tgt_cube_prefix}{KTK_CUBE_UUID_SEPARATOR}{ds}"
+        tgt_uuid = (
+            f"{tgt_cube_prefix}{KTK_CUBE_UUID_SEPARATOR}{renamed_datasets.get(ds, ds)}"
+        )
 
         # transform metadata for this dataset
         md_ds_transformed = (
@@ -496,7 +497,7 @@ def _transform_metadata(
             .modify_uuid(tgt_uuid)
             .to_json()[1]
         )
-        md_ds_key = f"{cube_prefix}{KTK_CUBE_UUID_SEPARATOR}{ds}{METADATA_BASE_SUFFIX}{METADATA_FORMAT_JSON}"
+        md_ds_key = f"{ds_meta.uuid}{METADATA_BASE_SUFFIX}{METADATA_FORMAT_JSON}"
         md_transformed[md_ds_key] = md_ds_transformed
     return md_transformed
 

--- a/kartothek/io/testing/copy_cube.py
+++ b/kartothek/io/testing/copy_cube.py
@@ -290,15 +290,19 @@ def test_copy_fail_overwrite_false(
     side_effect.counter = 0
 
     with mocker.patch("kartothek.io.eager_cube.copy_dataset", side_effect=side_effect):
-        driver(
-            cube=cube,
-            src_store=function_store,
-            tgt_store=function_store2,
-            renamed_cube_prefix="new_cube",
-            overwrite=False,
-        )
+        from kartothek.io_components.cube.write import MultiTableCommitAborted
 
-    assert len(function_store2().keys()) == 0
+        with pytest.raises(MultiTableCommitAborted):
+            driver(
+                cube=cube,
+                src_store=function_store,
+                tgt_store=function_store2,
+                renamed_cube_prefix="new_cube",
+                overwrite=False,
+            )
+    # rollback transaction means that only the metadata file is deleted
+    # therefore we still have remaining parquet files
+    assert len(function_store2().keys()) == 3
 
 
 def test_overwrite_fail(

--- a/kartothek/io/testing/copy_cube.py
+++ b/kartothek/io/testing/copy_cube.py
@@ -4,7 +4,7 @@ import pytest
 
 from kartothek.api.discover import discover_datasets_unchecked
 from kartothek.core.cube.cube import Cube
-from kartothek.io.eager_cube import build_cube
+from kartothek.io.eager_cube import build_cube, query_cube
 from kartothek.utils.ktk_adapters import get_dataset_keys
 
 __all__ = (
@@ -33,6 +33,7 @@ __all__ = (
     "test_partial_copy_dataset_list",
     "test_read_only_source",
     "test_simple",
+    "test_simple_with_rename",
 )
 
 
@@ -86,6 +87,45 @@ def assert_same_keys(store1, store2, keys):
 def test_simple(driver, function_store, function_store2, cube, simple_cube_1):
     driver(cube=cube, src_store=function_store, tgt_store=function_store2)
     assert_same_keys(function_store, function_store2, simple_cube_1)
+
+
+def test_simple_with_rename(
+    driver, function_store, function_store2, cube, simple_cube_1, df_seed, df_enrich
+):
+    # TODO first attempt: only implemented for driver copy_cube
+    # TODO any way to use pytest.mark.skipif with a fixture variable?
+    if "copy_cube" not in str(driver):
+        return
+    ds_name_old = "enrich"
+    ds_name_new = "augmented"
+    driver(
+        cube=cube,
+        src_store=function_store,
+        tgt_store=function_store2,
+        datasets_to_rename={ds_name_old: ds_name_new},
+    )
+
+    tgt_keys = function_store2().keys()
+    for src_key in sorted(simple_cube_1):
+        tgt_key = src_key.replace(ds_name_old, ds_name_new)
+        assert tgt_key in tgt_keys
+        b1 = function_store().get(src_key)
+        b2 = function_store2().get(tgt_key)
+        if tgt_key.endswith("by-dataset-metadata.json"):
+            b1_mod = (
+                b1.decode("utf-8").replace(ds_name_old, ds_name_new).encode("utf-8")
+            )
+            assert b1_mod == b2
+        else:
+            assert b1 == b2
+
+    tgt_cube = Cube(
+        dimension_columns=["x"], partition_columns=["p"], uuid_prefix="cube"
+    )
+    tgt_cube_res = query_cube(cube=tgt_cube, store=function_store2)[0]
+    assert tgt_cube_res is not None
+    assert tgt_cube_res[["x", "p", "v1"]].equals(df_seed)
+    assert tgt_cube_res[["x", "p", "v2"]].equals(df_enrich)
 
 
 def test_overwrite_fail(

--- a/kartothek/io/testing/copy_cube.py
+++ b/kartothek/io/testing/copy_cube.py
@@ -4,6 +4,7 @@ import pytest
 
 from kartothek.api.discover import discover_datasets_unchecked
 from kartothek.core.cube.cube import Cube
+from kartothek.io.eager import copy_dataset
 from kartothek.io.eager_cube import build_cube, query_cube
 from kartothek.utils.ktk_adapters import get_dataset_keys
 
@@ -33,8 +34,12 @@ __all__ = (
     "test_partial_copy_dataset_list",
     "test_read_only_source",
     "test_simple",
-    "test_simple_rename_dataset",
-    "test_simple_rename_cube",
+    "test_simple_copy_cube_rename_dataset",
+    "test_simple_copy_cube_rename_cube_prefix",
+    "test_simple_copy_cube_rename_cube_prefix_and_dataset",
+    "test_copy_fail_overwrite_true",
+    "test_copy_fail_overwrite_false",
+    "test_simple_rename_cube_same_stores",
 )
 
 
@@ -73,6 +78,16 @@ def simple_cube_2(df_seed, df_enrich, cube, function_store2):
     return set(function_store2().keys())
 
 
+def assert_target_cube_readable(tgt_cube_uuid, tgt_store, df_seed, df_enrich):
+    tgt_cube = Cube(
+        dimension_columns=["x"], partition_columns=["p"], uuid_prefix=tgt_cube_uuid
+    )
+    tgt_cube_res = query_cube(cube=tgt_cube, store=tgt_store)[0]
+    assert tgt_cube_res is not None
+    assert tgt_cube_res[["x", "p", "v1"]].equals(df_seed)
+    assert tgt_cube_res[["x", "p", "v2"]].equals(df_enrich)
+
+
 def assert_same_keys(store1, store2, keys):
     k1 = set(store1().keys())
     k2 = set(store2().keys())
@@ -90,7 +105,7 @@ def test_simple(driver, function_store, function_store2, cube, simple_cube_1):
     assert_same_keys(function_store, function_store2, simple_cube_1)
 
 
-def test_simple_rename_dataset(
+def test_simple_copy_cube_rename_dataset(
     driver, function_store, function_store2, cube, simple_cube_1, df_seed, df_enrich
 ):
     """
@@ -103,6 +118,7 @@ def test_simple_rename_dataset(
 
     ds_name_old = "enrich"
     ds_name_new = "augmented"
+
     driver(
         cube=cube,
         src_store=function_store,
@@ -114,30 +130,22 @@ def test_simple_rename_dataset(
     for src_key in sorted(simple_cube_1):
         tgt_key = src_key.replace(ds_name_old, ds_name_new)
         assert tgt_key in tgt_keys
-        b1 = function_store().get(src_key)
-        b2 = function_store2().get(tgt_key)
+        src_blob = function_store().get(src_key)
+        tgt_blob = function_store2().get(tgt_key)
         if tgt_key.endswith("by-dataset-metadata.json"):
-            b1_mod = (
-                b1.decode("utf-8").replace(ds_name_old, ds_name_new).encode("utf-8")
+            src_blob_mod = (
+                src_blob.decode("utf-8")
+                .replace(ds_name_old, ds_name_new)
+                .encode("utf-8")
             )
-            assert b1_mod == b2
+            assert src_blob_mod == tgt_blob
         else:
-            assert b1 == b2
+            assert src_blob == tgt_blob
 
     assert_target_cube_readable("cube", function_store2, df_seed, df_enrich)
 
 
-def assert_target_cube_readable(tgt_cube_uuid, tgt_store, df_seed, df_enrich):
-    tgt_cube = Cube(
-        dimension_columns=["x"], partition_columns=["p"], uuid_prefix=tgt_cube_uuid
-    )
-    tgt_cube_res = query_cube(cube=tgt_cube, store=tgt_store)[0]
-    assert tgt_cube_res is not None
-    assert tgt_cube_res[["x", "p", "v1"]].equals(df_seed)
-    assert tgt_cube_res[["x", "p", "v2"]].equals(df_enrich)
-
-
-def test_simple_rename_cube(
+def test_simple_copy_cube_rename_cube_prefix(
     driver, function_store, function_store2, cube, simple_cube_1, df_seed, df_enrich
 ):
     """
@@ -161,22 +169,23 @@ def test_simple_rename_cube(
     for src_key in sorted(simple_cube_1):
         tgt_key = src_key.replace(f"{old_cube_prefix}++", f"{new_cube_prefix}++")
         assert tgt_key in tgt_keys
-        b1 = function_store().get(src_key)
-        b2 = function_store2().get(tgt_key)
+
+        src_blob = function_store().get(src_key)
+        tgt_blob = function_store2().get(tgt_key)
         if tgt_key.endswith("by-dataset-metadata.json"):
-            b1_mod = (
-                b1.decode("utf-8")
+            src_blob_mod = (
+                src_blob.decode("utf-8")
                 .replace(f"{old_cube_prefix}++", f"{new_cube_prefix}++")
                 .encode("utf-8")
             )
-            assert b1_mod == b2
+            assert src_blob_mod == tgt_blob
         else:
-            assert b1 == b2
+            assert src_blob == tgt_blob
 
     assert_target_cube_readable(new_cube_prefix, function_store2, df_seed, df_enrich)
 
 
-def test_simple_rename_cube_dataset(
+def test_simple_copy_cube_rename_cube_prefix_and_dataset(
     driver, function_store, function_store2, cube, simple_cube_1, df_seed, df_enrich
 ):
     """
@@ -205,20 +214,91 @@ def test_simple_rename_cube_dataset(
             f"{old_cube_prefix}++", f"{new_cube_prefix}++"
         ).replace(f"++{ds_name_old}", f"++{ds_name_new}")
         assert tgt_key in tgt_keys
-        b1 = function_store().get(src_key)
-        b2 = function_store2().get(tgt_key)
+
+        src_blob = function_store().get(src_key)
+        tgt_blob = function_store2().get(tgt_key)
+
         if tgt_key.endswith("by-dataset-metadata.json"):
-            b1_mod = (
-                b1.decode("utf-8")
+            src_blob_mod = (
+                src_blob.decode("utf-8")
                 .replace(f"{old_cube_prefix}++", f"{new_cube_prefix}++")
                 .replace(f"++{ds_name_old}", f"++{ds_name_new}")
                 .encode("utf-8")
             )
-            assert b1_mod == b2
+            assert src_blob_mod == tgt_blob
         else:
-            assert b1 == b2
+            assert src_blob == tgt_blob
 
     assert_target_cube_readable(new_cube_prefix, function_store2, df_seed, df_enrich)
+
+
+def test_simple_rename_cube_same_stores(
+    driver, function_store, cube, simple_cube_1, df_seed, df_enrich
+):
+    new_cube_prefix = "my_target_cube"
+    ds_name_old = "enrich"
+    ds_name_new = "augmented"
+
+    # NB: only implemented for eager copying so far
+    if "copy_cube" not in str(driver):
+        pytest.skip()
+
+    with pytest.raises(ValueError):
+        driver(
+            cube=cube,
+            src_store=function_store,
+            tgt_store=function_store,
+            renamed_cube_prefix=new_cube_prefix,
+            renamed_datasets={ds_name_old: ds_name_new},
+        )
+
+
+def test_copy_fail_overwrite_true(
+    driver, mocker, cube, simple_cube_1, function_store, function_store2
+):
+    # NB: only implemented for eager copying so far
+    if "copy_cube" not in str(driver):
+        pytest.skip()
+    with pytest.raises(RuntimeError):
+        with mocker.patch(
+            "kartothek.io.eager_cube.copy_dataset",
+            side_effect=ValueError("Copying cube failed horribly."),
+        ):
+            driver(
+                cube=cube,
+                src_store=function_store,
+                tgt_store=function_store2,
+                renamed_cube_prefix="new_cube",
+                overwrite=True,
+            )
+
+
+def test_copy_fail_overwrite_false(
+    driver, mocker, cube, simple_cube_1, function_store, function_store2
+):
+    # NB: only implemented for eager copying so far
+    if "copy_cube" not in str(driver):
+        pytest.skip()
+
+    def side_effect(*args, **kwargs):
+        if side_effect.counter == 0:
+            side_effect.counter += 1
+            return copy_dataset(*args, **kwargs)
+        else:
+            raise ValueError("Something unexpected happened during cube copy.")
+
+    side_effect.counter = 0
+
+    with mocker.patch("kartothek.io.eager_cube.copy_dataset", side_effect=side_effect):
+        driver(
+            cube=cube,
+            src_store=function_store,
+            tgt_store=function_store2,
+            renamed_cube_prefix="new_cube",
+            overwrite=False,
+        )
+
+    assert len(function_store2().keys()) == 0
 
 
 def test_overwrite_fail(

--- a/kartothek/io_components/cube/copy.py
+++ b/kartothek/io_components/cube/copy.py
@@ -3,12 +3,25 @@ from __future__ import absolute_import
 from copy import copy
 
 from kartothek.api.discover import check_datasets, discover_datasets_unchecked
+from kartothek.core.dataset import DatasetMetadataBuilder
 from kartothek.utils.ktk_adapters import get_dataset_keys
 
 __all__ = ("get_copy_keys",)
 
 
-def get_copy_keys(cube, src_store, tgt_store, overwrite, datasets=None):
+def _assert_datasets_contained_in(cube, ds_needles, ds_haystack):
+    unknown_datasets = set(ds_needles) - set(ds_haystack)
+    if unknown_datasets:
+        raise RuntimeError(
+            "{cube}, datasets {datasets} do not exist in source store".format(
+                cube=cube, datasets=unknown_datasets
+            )
+        )
+
+
+def get_copy_keys(
+    cube, src_store, tgt_store, overwrite, datasets=None, datasets_to_rename=None
+):
     """
     Get and check keys that should be copied from one store to another.
 
@@ -25,6 +38,10 @@ def get_copy_keys(cube, src_store, tgt_store, overwrite, datasets=None):
     datasets: Union[None, Iterable[str], Dict[str, kartothek.core.dataset.DatasetMetadata]]
         Datasets to copy, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, an
         iterable of Ktk_cube dataset ID or ``None`` (in which case entire cube will be copied).
+    datasets_to_rename: Optional[Dict[str, str]]
+        Optional dict of {old dataset name:  new dataset name} entries. If specified,
+        the corresponding datasets will be renamed accordingly. Unknown keys will cause
+        an error.
 
     Returns
     -------
@@ -35,46 +52,63 @@ def get_copy_keys(cube, src_store, tgt_store, overwrite, datasets=None):
     ------
     RuntimeError: In case the copy would not pass successfully or if there is no cube in ``src_store``.
     """
+
+    # if datasets is a dict, i.e. the result of discover_datasets(): use it.
+    # otherwise, call discover_datasets_unchecked() to create such a dict
     if not isinstance(datasets, dict):
-        new_datasets = discover_datasets_unchecked(
+        datasets_to_copy = discover_datasets_unchecked(
             uuid_prefix=cube.uuid_prefix,
             store=src_store,
             filter_ktk_cube_dataset_ids=datasets,
         )
     else:
-        new_datasets = datasets
+        datasets_to_copy = datasets
 
     if datasets is None:
-        if not new_datasets:
+        if not datasets_to_copy:
             raise RuntimeError("{} not found in source store".format(cube))
     else:
-        unknown_datasets = set(datasets) - set(new_datasets)
-        if unknown_datasets:
-            raise RuntimeError(
-                "{cube}, datasets {datasets} do not exist in source store".format(
-                    cube=cube, datasets=unknown_datasets
-                )
-            )
+        # check if datasets parameter contains unknown, i.e. non-existing, datasets.
+        # this may only happen if datasets is a list of dataset names.
+        _assert_datasets_contained_in(cube, datasets, datasets_to_copy)
+
+    if datasets_to_rename:
+        # if datasets shall be renamed: check if the list of datasets to rename is a
+        # subset of the datasets to copy
+        _assert_datasets_contained_in(cube, datasets_to_rename, datasets_to_copy)
+    else:
+        datasets_to_rename = {}
 
     existing_datasets = discover_datasets_unchecked(cube.uuid_prefix, tgt_store)
 
     if not overwrite:
-        for ktk_cube_dataset_id in sorted(new_datasets.keys()):
-            if ktk_cube_dataset_id in existing_datasets:
+        # If no target data shall be overwritten, check if the selected datasets do
+        # already exist in the target store. Note that the dataset name may change.
+        for ktk_cube_dataset_id in sorted(datasets_to_copy.keys()):
+            ktk_target_dataset_id = datasets_to_rename.get(
+                ktk_cube_dataset_id, ktk_cube_dataset_id
+            )
+            if ktk_target_dataset_id in existing_datasets:
                 raise RuntimeError(
                     'Dataset "{uuid}" exists in target store but overwrite was set to False'.format(
-                        uuid=new_datasets[ktk_cube_dataset_id].uuid
+                        uuid=existing_datasets[ktk_target_dataset_id].uuid
                     )
                 )
 
     all_datasets = copy(existing_datasets)
-    all_datasets.update(new_datasets)
+    for ds, ds_meta in datasets_to_copy.items():
+        renamed_ds = datasets_to_rename.get(ds, ds)
+        all_datasets[renamed_ds] = (
+            DatasetMetadataBuilder.from_dataset(ds_meta)
+            .modify_dataset_name(renamed_ds)
+            .to_dataset()
+        )
 
     check_datasets(all_datasets, cube)
 
     keys = set()
-    for ktk_cube_dataset_id in sorted(new_datasets.keys()):
-        ds = new_datasets[ktk_cube_dataset_id]
+    for ktk_cube_dataset_id in sorted(datasets_to_copy.keys()):
+        ds = datasets_to_copy[ktk_cube_dataset_id]
         keys |= get_dataset_keys(ds)
 
     return keys

--- a/kartothek/io_components/cube/copy.py
+++ b/kartothek/io_components/cube/copy.py
@@ -3,25 +3,12 @@ from __future__ import absolute_import
 from copy import copy
 
 from kartothek.api.discover import check_datasets, discover_datasets_unchecked
-from kartothek.core.dataset import DatasetMetadataBuilder
 from kartothek.utils.ktk_adapters import get_dataset_keys
 
 __all__ = ("get_copy_keys",)
 
 
-def _assert_datasets_contained_in(cube, ds_needles, ds_haystack):
-    unknown_datasets = set(ds_needles) - set(ds_haystack)
-    if unknown_datasets:
-        raise RuntimeError(
-            "{cube}, datasets {datasets} do not exist in source store".format(
-                cube=cube, datasets=unknown_datasets
-            )
-        )
-
-
-def get_copy_keys(
-    cube, src_store, tgt_store, overwrite, datasets=None, datasets_to_rename=None
-):
+def get_copy_keys(cube, src_store, tgt_store, overwrite, datasets=None):
     """
     Get and check keys that should be copied from one store to another.
 
@@ -38,10 +25,6 @@ def get_copy_keys(
     datasets: Union[None, Iterable[str], Dict[str, kartothek.core.dataset.DatasetMetadata]]
         Datasets to copy, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, an
         iterable of Ktk_cube dataset ID or ``None`` (in which case entire cube will be copied).
-    datasets_to_rename: Optional[Dict[str, str]]
-        Optional dict of {old dataset name:  new dataset name} entries. If specified,
-        the corresponding datasets will be renamed accordingly. Unknown keys will cause
-        an error.
 
     Returns
     -------
@@ -52,63 +35,46 @@ def get_copy_keys(
     ------
     RuntimeError: In case the copy would not pass successfully or if there is no cube in ``src_store``.
     """
-
-    # if datasets is a dict, i.e. the result of discover_datasets(): use it.
-    # otherwise, call discover_datasets_unchecked() to create such a dict
     if not isinstance(datasets, dict):
-        datasets_to_copy = discover_datasets_unchecked(
+        new_datasets = discover_datasets_unchecked(
             uuid_prefix=cube.uuid_prefix,
             store=src_store,
             filter_ktk_cube_dataset_ids=datasets,
         )
     else:
-        datasets_to_copy = datasets
+        new_datasets = datasets
 
     if datasets is None:
-        if not datasets_to_copy:
+        if not new_datasets:
             raise RuntimeError("{} not found in source store".format(cube))
     else:
-        # check if datasets parameter contains unknown, i.e. non-existing, datasets.
-        # this may only happen if datasets is a list of dataset names.
-        _assert_datasets_contained_in(cube, datasets, datasets_to_copy)
-
-    if datasets_to_rename:
-        # if datasets shall be renamed: check if the list of datasets to rename is a
-        # subset of the datasets to copy
-        _assert_datasets_contained_in(cube, datasets_to_rename, datasets_to_copy)
-    else:
-        datasets_to_rename = {}
+        unknown_datasets = set(datasets) - set(new_datasets)
+        if unknown_datasets:
+            raise RuntimeError(
+                "{cube}, datasets {datasets} do not exist in source store".format(
+                    cube=cube, datasets=unknown_datasets
+                )
+            )
 
     existing_datasets = discover_datasets_unchecked(cube.uuid_prefix, tgt_store)
 
     if not overwrite:
-        # If no target data shall be overwritten, check if the selected datasets do
-        # already exist in the target store. Note that the dataset name may change.
-        for ktk_cube_dataset_id in sorted(datasets_to_copy.keys()):
-            ktk_target_dataset_id = datasets_to_rename.get(
-                ktk_cube_dataset_id, ktk_cube_dataset_id
-            )
-            if ktk_target_dataset_id in existing_datasets:
+        for ktk_cube_dataset_id in sorted(new_datasets.keys()):
+            if ktk_cube_dataset_id in existing_datasets:
                 raise RuntimeError(
                     'Dataset "{uuid}" exists in target store but overwrite was set to False'.format(
-                        uuid=existing_datasets[ktk_target_dataset_id].uuid
+                        uuid=new_datasets[ktk_cube_dataset_id].uuid
                     )
                 )
 
     all_datasets = copy(existing_datasets)
-    for ds, ds_meta in datasets_to_copy.items():
-        renamed_ds = datasets_to_rename.get(ds, ds)
-        all_datasets[renamed_ds] = (
-            DatasetMetadataBuilder.from_dataset(ds_meta)
-            .modify_dataset_name(renamed_ds)
-            .to_dataset()
-        )
+    all_datasets.update(new_datasets)
 
     check_datasets(all_datasets, cube)
 
     keys = set()
-    for ktk_cube_dataset_id in sorted(datasets_to_copy.keys()):
-        ds = datasets_to_copy[ktk_cube_dataset_id]
+    for ktk_cube_dataset_id in sorted(new_datasets.keys()):
+        ds = new_datasets[ktk_cube_dataset_id]
         keys |= get_dataset_keys(ds)
 
     return keys

--- a/kartothek/io_components/cube/copy.py
+++ b/kartothek/io_components/cube/copy.py
@@ -1,39 +1,46 @@
 from __future__ import absolute_import
 
 from copy import copy
+from typing import Callable, Dict, Iterable, Optional, Union
+
+from simplekv import KeyValueStore
 
 from kartothek.api.discover import check_datasets, discover_datasets_unchecked
+from kartothek.core.cube.cube import Cube
+from kartothek.core.dataset import DatasetMetadata
 from kartothek.utils.ktk_adapters import get_dataset_keys
 
 __all__ = ("get_copy_keys",)
 
 
-def get_copy_keys(cube, src_store, tgt_store, overwrite, datasets=None):
+def get_datasets_to_copy(
+    cube: Cube,
+    src_store: Union[Callable[[], KeyValueStore], KeyValueStore],
+    tgt_store: Union[Callable[[], KeyValueStore], KeyValueStore],
+    overwrite: bool,
+    datasets: Optional[Union[Iterable[str], Dict[str, DatasetMetadata]]] = None,
+):
     """
-    Get and check keys that should be copied from one store to another.
+    Determine all dataset names of a given cube that should be copied and apply addtional consistency checks.
+    Copying only a specific set of datasets is possible by providing a list of dataset names via the parameter `datasets`.
 
     Parameters
     ----------
-    cube: kartothek.core.cube.cube.Cube
+    cube:
         Cube specification.
-    src_store: Union[Callable[[], simplekv.KeyValueStore], simplekv.KeyValueStore]
+    src_store:
         Source KV store.
-    tgt_store: Union[Callable[[], simplekv.KeyValueStore], simplekv.KeyValueStore]
+    tgt_store:
         Target KV store.
-    overwrite: bool
+    overwrite:
         If possibly existing datasets in the target store should be overwritten.
-    datasets: Union[None, Iterable[str], Dict[str, kartothek.core.dataset.DatasetMetadata]]
+    datasets:
         Datasets to copy, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, an
         iterable of Ktk_cube dataset ID or ``None`` (in which case entire cube will be copied).
 
-    Returns
-    -------
-    keys: Set[str]
-        Set of keys to copy.
-
-    Raises
-    ------
-    RuntimeError: In case the copy would not pass successfully or if there is no cube in ``src_store``.
+    Return
+    -----
+    All datasets that should be copied.
     """
     if not isinstance(datasets, dict):
         new_datasets = discover_datasets_unchecked(
@@ -71,6 +78,49 @@ def get_copy_keys(cube, src_store, tgt_store, overwrite, datasets=None):
     all_datasets.update(new_datasets)
 
     check_datasets(all_datasets, cube)
+    return new_datasets
+
+
+def get_copy_keys(
+    cube: Cube,
+    src_store: Union[Callable[[], KeyValueStore], KeyValueStore],
+    tgt_store: Union[Callable[[], KeyValueStore], KeyValueStore],
+    overwrite: bool,
+    datasets: Optional[Union[Iterable[str], Dict[str, DatasetMetadata]]] = None,
+):
+    """
+    Get and check keys that should be copied from one store to another.
+
+    Parameters
+    ----------
+    cube:
+        Cube specification.
+    src_store:
+        Source KV store.
+    tgt_store:
+        Target KV store.
+    overwrite:
+        If possibly existing datasets in the target store should be overwritten.
+    datasets:
+        Datasets to copy, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, an
+        iterable of Ktk_cube dataset ID or ``None`` (in which case entire cube will be copied).
+
+    Returns
+    -------
+    keys: Set[str]
+        Set of keys to copy.
+
+    Raises
+    ------
+    RuntimeError: In case the copy would not pass successfully or if there is no cube in ``src_store``.
+    """
+    new_datasets = get_datasets_to_copy(
+        cube=cube,
+        src_store=src_store,
+        tgt_store=tgt_store,
+        overwrite=overwrite,
+        datasets=datasets,
+    )
 
     keys = set()
     for ktk_cube_dataset_id in sorted(new_datasets.keys()):

--- a/kartothek/utils/store.py
+++ b/kartothek/utils/store.py
@@ -90,7 +90,7 @@ def _copy_azure_bbs(key_mappings, src_store, tgt_store, mapped_metadata=None):
     cprops = {}
     for src_key, tgt_key in key_mappings.items():
         # skip modified metadata which was already copied manually
-        if mapped_metadata and (src_key in mapped_metadata):
+        if (mapped_metadata is not None) and (src_key in mapped_metadata):
             continue
 
         source_md5 = _azure_bbs_content_md5(
@@ -186,7 +186,7 @@ def _copy_azure_cc(key_mappings, src_store, tgt_store, mapped_metadata=None):
     copy_ids = {}
     for src_key, tgt_key in key_mappings.items():
         # skip modified metadata which was already copied manually
-        if mapped_metadata and (src_key in mapped_metadata):
+        if (mapped_metadata is not None) and (src_key in mapped_metadata):
             continue
         source_md5 = _azure_cc_content_md5(src_cc, src_key, accept_missing=False)
 
@@ -244,7 +244,7 @@ def _copy_naive(key_mappings, src_store, tgt_store, mapped_metadata=None):
         Mapping containing {key: modified metadata} values to be changed
     """
     for src_key, tgt_key in key_mappings.items():
-        if mapped_metadata & (src_key in mapped_metadata):
+        if (mapped_metadata is not None) and (src_key in mapped_metadata):
             item = mapped_metadata.get(src_key)
         else:
             item = src_store.get(src_key)

--- a/kartothek/utils/store.py
+++ b/kartothek/utils/store.py
@@ -218,9 +218,9 @@ def _copy_naive(
     key_mappings: Dict[str, str]
         Mapping of source key names to target key names. May be equal if a key will
         not be renamed.
-    src_store: KeyValueStore
+    src_store: simplekv.KeyValueStore
         Source KV store
-    tgt_store: KeyValueStore
+    tgt_store: simplekv.KeyValueStore
         Target KV store
     mapped_metadata: Dict[str, bytes]
         Mapping containing {key: modified metadata} values which will be written

--- a/kartothek/utils/store.py
+++ b/kartothek/utils/store.py
@@ -247,9 +247,9 @@ def copy_rename_keys(
     ----------
     key_mappings: Dict[str, str]
         Dict with {old key: new key} mappings to rename keys during copying
-    src_store: KeyValueStore
+    src_store: simplekv.KeyValueStore
         Source KV store.
-    tgt_store: KeyValueStore
+    tgt_store: simplekv.KeyValueStore
         Target KV store.
     mapped_metadata: Dict[str, bytes]
         Dict with {source key: modified data} entries; the objects corresponding to
@@ -275,9 +275,9 @@ def copy_keys(
     ----------
     keys: Iterable[str]
         Set of keys to copy without renaming;
-    src_store: Union[KeyValueStore, Callable[[], KeyValueStore]]
+    src_store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
         Source KV store.
-    tgt_store: Union[KeyValueStore, Callable[[], KeyValueStore]]
+    tgt_store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
         Target KV store.
     """
     if callable(src_store):

--- a/kartothek/utils/store.py
+++ b/kartothek/utils/store.py
@@ -243,13 +243,15 @@ def copy_rename_keys(
     """
     Copy keys between to stores or within one store, and rename them.
 
-    :param key_mappings:
+    Parameters
+    ----------
+    key_mappings: Dict[str, str]
         Dict with {old key: new key} mappings to rename keys during copying
-    :param src_store:
+    src_store: KeyValueStore
         Source KV store.
-    :param tgt_store:
+    tgt_store: KeyValueStore
         Target KV store.
-    :param mapped_metadata:
+    mapped_metadata: Dict[str, bytes]
         Dict with {source key: modified data} entries; the objects corresponding to
         the keys will not be copied. Instead, the modified data will directly be put
         to the target store.
@@ -269,11 +271,13 @@ def copy_keys(
     """
     Copy keys between two stores or within one store.
 
-    :param keys:
+    Parameters
+    ----------
+    keys: Iterable[str]
         Set of keys to copy without renaming;
-    :param src_store:
+    src_store: Union[KeyValueStore, Callable[[], KeyValueStore]]
         Source KV store.
-    :param tgt_store:
+    tgt_store: Union[KeyValueStore, Callable[[], KeyValueStore]]
         Target KV store.
     """
     if callable(src_store):

--- a/tests/core/test_builder.py
+++ b/tests/core/test_builder.py
@@ -69,6 +69,48 @@ def test_builder_to_dataset(metadata_version, frozen_time):
     assert result == expected_from_dict
 
 
+def test_builder_modify_uuid_embedded_index(metadata_version, frozen_time):
+    expected = {
+        "dataset_uuid": "uuid_new",
+        "dataset_metadata_version": metadata_version,
+        "partitions": {"part_2": {"files": {"core": "uuid_new/core/part_2.parquet"}}},
+        "metadata": {"key": "value", "creation_time": TIME_TO_FREEZE_ISO},
+        "indices": {"col1": {"a": ["part1"], "b": ["part2"]}},
+    }
+
+    builder = DatasetMetadataBuilder("uuid", metadata_version=metadata_version)
+    part_2 = Partition("part_2", {"core": "uuid/core/part_2.parquet"})
+    builder.add_partition("part_2", part_2)
+    builder.add_metadata("key", "value")
+    builder.add_embedded_index(
+        "col1", ExplicitSecondaryIndex("col1", {"a": ["part1"], "b": ["part2"]})
+    )
+    builder.modify_uuid("uuid_new")
+    result = builder.to_dataset()
+    expected_from_dict = DatasetMetadata.from_dict(expected)
+    assert result == expected_from_dict
+
+
+def test_builder_modify_uuid_external_index(metadata_version, frozen_time):
+    expected = {
+        "dataset_uuid": "uuid_new",
+        "dataset_metadata_version": metadata_version,
+        "partitions": {"part_2": {"files": {"core": "uuid_new/core/part_2.parquet"}}},
+        "metadata": {"key": "value", "creation_time": TIME_TO_FREEZE_ISO},
+        "indices": {"col1": "uuid_new.col1.by-dataset-index.parquet"},
+    }
+
+    builder = DatasetMetadataBuilder("uuid", metadata_version=metadata_version)
+    part_2 = Partition("part_2", {"core": "uuid/core/part_2.parquet"})
+    builder.add_partition("part_2", part_2)
+    builder.add_metadata("key", "value")
+    builder.add_external_index("col1")
+    builder.modify_uuid("uuid_new")
+    result = builder.to_dataset()
+    expected_from_dict = DatasetMetadata.from_dict(expected)
+    assert result == expected_from_dict
+
+
 def test_builder_full(metadata_version, frozen_time):
     expected = {
         "dataset_uuid": "uuid",

--- a/tests/io/eager/test_copy.py
+++ b/tests/io/eager/test_copy.py
@@ -110,3 +110,13 @@ def test_copy_eager_without_rename_different_store(dataset_to_copy, store, store
     )
     assert_target_keys(store, SRC_DS_UUID, store2, SRC_DS_UUID)
     assert_target_ktk_readable(store2, SRC_DS_UUID)
+
+
+def test_copy_same_source_and_target(dataset_to_copy, store):
+    with pytest.raises(ValueError):
+        copy_dataset(
+            src_dataset_uuid=SRC_DS_UUID,
+            target_dataset_uuid=SRC_DS_UUID,
+            store=store,
+            tgt_store=store,
+        )

--- a/tests/io/eager/test_copy.py
+++ b/tests/io/eager/test_copy.py
@@ -75,10 +75,10 @@ def test_copy_rename_eager_same_store(dataset_to_copy, store):
     Copies and renames DS within one store
     """
     copy_dataset(
-        src_dataset_uuid=SRC_DS_UUID,
+        source_dataset_uuid=SRC_DS_UUID,
         target_dataset_uuid=TGT_DS_UUID,
         store=store,
-        tgt_store=store,
+        target_store=store,
     )
     assert_target_keys(store, SRC_DS_UUID, store, TGT_DS_UUID)
     assert_target_ktk_readable(store, TGT_DS_UUID)
@@ -89,10 +89,10 @@ def test_copy_eager_with_rename_different_store(dataset_to_copy, store, store2):
     Copies and renames DS between stores
     """
     copy_dataset(
-        src_dataset_uuid=SRC_DS_UUID,
+        source_dataset_uuid=SRC_DS_UUID,
         target_dataset_uuid=TGT_DS_UUID,
         store=store,
-        tgt_store=store2,
+        target_store=store2,
     )
     assert_target_keys(store, SRC_DS_UUID, store2, TGT_DS_UUID)
     assert_target_ktk_readable(store2, TGT_DS_UUID)
@@ -103,10 +103,10 @@ def test_copy_eager_without_rename_different_store(dataset_to_copy, store, store
     Copies DS between stores while keeping the name
     """
     copy_dataset(
-        src_dataset_uuid=SRC_DS_UUID,
+        source_dataset_uuid=SRC_DS_UUID,
         target_dataset_uuid=SRC_DS_UUID,
         store=store,
-        tgt_store=store2,
+        target_store=store2,
     )
     assert_target_keys(store, SRC_DS_UUID, store2, SRC_DS_UUID)
     assert_target_ktk_readable(store2, SRC_DS_UUID)
@@ -115,8 +115,8 @@ def test_copy_eager_without_rename_different_store(dataset_to_copy, store, store
 def test_copy_same_source_and_target(dataset_to_copy, store):
     with pytest.raises(ValueError):
         copy_dataset(
-            src_dataset_uuid=SRC_DS_UUID,
+            source_dataset_uuid=SRC_DS_UUID,
             target_dataset_uuid=SRC_DS_UUID,
             store=store,
-            tgt_store=store,
+            target_store=store,
         )

--- a/tests/io/eager/test_copy.py
+++ b/tests/io/eager/test_copy.py
@@ -98,6 +98,28 @@ def test_copy_eager_with_rename_different_store(dataset_to_copy, store, store2):
     assert_target_ktk_readable(store2, TGT_DS_UUID)
 
 
+def test_copy_eager_no_target_uuid(dataset_to_copy, store, store2):
+    copy_dataset(
+        source_dataset_uuid=SRC_DS_UUID,
+        target_dataset_uuid=None,
+        store=store,
+        target_store=store2,
+    )
+    assert_target_keys(store, SRC_DS_UUID, store2, SRC_DS_UUID)
+    assert_target_ktk_readable(store2, SRC_DS_UUID)
+
+
+def test_copy_eager_no_target_store(dataset_to_copy, store, store2):
+    copy_dataset(
+        source_dataset_uuid=SRC_DS_UUID,
+        target_dataset_uuid=TGT_DS_UUID,
+        store=store,
+        target_store=None,
+    )
+    assert_target_keys(store, SRC_DS_UUID, store, TGT_DS_UUID)
+    assert_target_ktk_readable(store, TGT_DS_UUID)
+
+
 def test_copy_eager_without_rename_different_store(dataset_to_copy, store, store2):
     """
     Copies DS between stores while keeping the name

--- a/tests/io/eager/test_copy.py
+++ b/tests/io/eager/test_copy.py
@@ -1,0 +1,112 @@
+import pytest
+
+from kartothek.core.factory import DatasetFactory
+from kartothek.core.utils import lazy_store
+from kartothek.io.eager import copy_dataset, read_table, store_dataframes_as_dataset
+from kartothek.serialization.testing import get_dataframe_not_nested
+from kartothek.utils.ktk_adapters import get_dataset_keys
+
+SRC_DS_UUID = "test_copy_ds_with_index"
+TGT_DS_UUID = "copy_target"
+
+
+@pytest.fixture
+def dataset_to_copy(store):
+    df = get_dataframe_not_nested(10)
+    store_dataframes_as_dataset(
+        dfs=[df],
+        dataset_uuid=SRC_DS_UUID,
+        store=store,
+        partition_on=[df.columns[0]],
+        secondary_indices=[df.columns[1]],
+    )
+
+
+def assert_target_ktk_readable(tgt_store, tgt_ds):
+    """
+    Try to read the target dataset using high level KTK functionality
+    """
+    df_result = read_table(store=tgt_store, dataset_uuid=tgt_ds,)
+    assert df_result is not None
+    assert len(df_result) == 10
+    df_result = read_table(
+        store=tgt_store, dataset_uuid=tgt_ds, predicates=[[("bool", "==", True)]]
+    )
+    assert len(df_result) == 5
+    df_result = read_table(
+        store=tgt_store, dataset_uuid=tgt_ds, predicates=[[("bytes", "==", b"2")]]
+    )
+    assert len(df_result) == 1
+
+
+def assert_target_keys(src_store, src_uuid, tgt_store, tgt_uuid):
+    """
+    Check that the expected keys exist in the target data set, and the corresponding
+    values are equal to the source data set (or modified as expected)
+    """
+    df_source = DatasetFactory(
+        dataset_uuid=src_uuid, store_factory=lazy_store(src_store),
+    )
+    src_keys = get_dataset_keys(df_source.dataset_metadata)
+    df_target = DatasetFactory(
+        dataset_uuid=tgt_uuid, store_factory=lazy_store(tgt_store),
+    )
+    tgt_keys = get_dataset_keys(df_target.dataset_metadata)
+
+    for src_key in src_keys:
+        # check for each source key if the corresponding target key exists
+        tgt_key = src_key.replace(src_uuid, tgt_uuid)
+        assert tgt_key in tgt_keys
+
+        # check if the files for source and target key are equal (exception:
+        # metadata => here the target must contain the modified metadata)
+        b1 = src_store.get(src_key)
+        b2 = tgt_store.get(tgt_key)
+
+        if tgt_key.endswith("by-dataset-metadata.json"):
+            b1_mod = b1.decode("utf-8").replace(src_uuid, tgt_uuid).encode("utf-8")
+            assert b1_mod == b2
+        else:
+            assert b1 == b2
+
+
+def test_copy_rename_eager_same_store(dataset_to_copy, store):
+    """
+    Copies and renames DS within one store
+    """
+    copy_dataset(
+        src_dataset_uuid=SRC_DS_UUID,
+        target_dataset_uuid=TGT_DS_UUID,
+        store=store,
+        tgt_store=store,
+    )
+    assert_target_keys(store, SRC_DS_UUID, store, TGT_DS_UUID)
+    assert_target_ktk_readable(store, TGT_DS_UUID)
+
+
+def test_copy_eager_with_rename_different_store(dataset_to_copy, store, store2):
+    """
+    Copies and renames DS between stores
+    """
+    copy_dataset(
+        src_dataset_uuid=SRC_DS_UUID,
+        target_dataset_uuid=TGT_DS_UUID,
+        store=store,
+        tgt_store=store2,
+    )
+    assert_target_keys(store, SRC_DS_UUID, store2, TGT_DS_UUID)
+    assert_target_ktk_readable(store2, TGT_DS_UUID)
+
+
+def test_copy_eager_without_rename_different_store(dataset_to_copy, store, store2):
+    """
+    Copies DS between stores while keeping the name
+    """
+    copy_dataset(
+        src_dataset_uuid=SRC_DS_UUID,
+        target_dataset_uuid=SRC_DS_UUID,
+        store=store,
+        tgt_store=store2,
+    )
+    assert_target_keys(store, SRC_DS_UUID, store2, SRC_DS_UUID)
+    assert_target_ktk_readable(store2, SRC_DS_UUID)


### PR DESCRIPTION
# Description:

This PR contains work that has already been done [here](https://github.com/JDASoftwareGroup/kartothek/pull/443) plus minor things to get it into a mergeable state. Opening a new one because @MartinHaffner is on vacation and I unfortunately don't have access rights on his fork.

We implement the eager copying of ktk datasets and offer the option to rename copied ktk cubes.
