### PR TITLE
Fix dataset corruption after updates (#445)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Kartothek 4.0.1 (2021-04-XX)
+============================
+
+* Fixed dataset corruption after updates when table names other than "table" are used (#445).
+
+
 Kartothek 4.0.0 (2021-03-17)
 ============================
 

--- a/kartothek/io/dask/delayed.py
+++ b/kartothek/io/dask/delayed.py
@@ -264,6 +264,7 @@ def update_dataset_from_delayed(
     sort_partitions_by=None,
     secondary_indices=None,
     factory=None,
+    table_name=SINGLE_TABLE,
 ):
     """
     A dask.delayed graph to add and store a list of dictionaries containing
@@ -304,6 +305,7 @@ def update_dataset_from_delayed(
         df_serializer=df_serializer,
         dataset_uuid=dataset_uuid,
         sort_partitions_by=sort_partitions_by,
+        dataset_table_name=table_name,
     )
 
     return dask.delayed(update_dataset_from_partitions)(

--- a/kartothek/io/testing/update.py
+++ b/kartothek/io/testing/update.py
@@ -656,7 +656,7 @@ def test_update_of_dataset_with_non_default_table_name(
         [df_update],
         store=store_factory,
         dataset_uuid=dataset_uuid,
-        table="non-default-name",
+        table_name="non-default-name",
         partition_on=["date"],
     )
     dm = DatasetMetadata.load_from_store(dataset_uuid, store_factory())

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -471,6 +471,7 @@ class MetaPartition(Iterable):
             schema=schema,
             partition_keys=metapartition.partition_keys or None,
             logical_conjunction=metapartition.logical_conjunction or None,
+            table_name=metapartition.table_name,
         )
 
         # Add metapartition information to the new object
@@ -1109,6 +1110,7 @@ class MetaPartition(Iterable):
                     f"{label}"
                 ),
                 partition_keys=partition_on,
+                table_name=self.table_name,
             )
             new_mp = new_mp.add_metapartition(tmp_mp, schema_validation=False)
         if self.indices:

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -32,6 +32,12 @@ def _update_dataset(partitions, *args, **kwargs):
     else:
         partitions = None
 
+    # Replace `table_name` with `table` keyword argument to enable shared test code
+    # via `bound_update_dataset` fixture
+    if "table_name" in kwargs:
+        kwargs["table"] = kwargs["table_name"]
+        del kwargs["table_name"]
+
     ddf = update_dataset_from_ddf(partitions, *args, **kwargs)
 
     s = pickle.dumps(ddf, pickle.HIGHEST_PROTOCOL)

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1331,3 +1331,13 @@ def test_get_parquet_metadata_row_group_size(store):
         }
     )
     pd.testing.assert_frame_equal(actual, expected)
+
+
+def test_partition_on_keeps_table_name():
+    mp = MetaPartition(
+        label="label_1",
+        data=pd.DataFrame({"P": [1, 2, 1, 2], "L": [1, 1, 2, 2]}),
+        table_name="non-default-name",
+    )
+    repartitioned_mp = mp.partition_on(["P"])
+    assert repartitioned_mp.table_name == "non-default-name"


### PR DESCRIPTION
When updating a dataset with a table name other than 'table', an additional table named
'table' is erroneously created. This corrupts the dataset. The issue was introduced after
deprecating the table name feature in the 4.0.0 release. The root cause is not passing the
table name as an argument within `partition_on` and `add_metapartition`, which leads to the
default table name "table" being used.

# Description:

Briefly describe the change of behavior


- [ ] Closes #xxxx
- [ ] Changelog entry
