### PR TITLE
Fix mistakes in documentation

### DIFF
--- a/docs/spec/indexing.rst
+++ b/docs/spec/indexing.rst
@@ -15,7 +15,7 @@ All currently supported kartothek index types are inverted indices and are mappi
 
     index_dct = {1: ["table/12345"], 2: ["table/12345", "table/6789"]}
 
-Where, in this example, the value ``42`` is found in exactly one partition which is labeled ``table/partitionA=42/12345``.
+Where, in this example, the value ``1`` is found in exactly one partition which is labeled ``table/12345``.
 
 Users typically do not interact with indices directly since querying a dataset will automatically load and interact with the indices. For some applications it is still quite useful to interact with them directly.
 
@@ -87,7 +87,7 @@ For data with high cardinality this kind of index is not well suited since it wo
 Secondary indices
 -----------------
 
-Secondary indices are the most powerful type of indices which allow us to reference files without having to encode any kind of values in the keys. They can be created by supplying the `secondary_indices` keyword argument as shown above. The user interaction works similarly to the
+Secondary indices are the most powerful type of indices which allow us to reference files without having to encode any kind of values in the keys. They can be created by supplying the `secondary_indices` keyword argument as shown above.
 
 
 Persistence


### PR DESCRIPTION
# Description:

I fixed some mistakes in the documentation:

- In the "Principle in-memory representation" section, the documentation refered to a partition `A=42`, which wasn't introduced before.
- In the "Secondary indices" section, the last sentence wasn't complete. I checked the git log and the file was created like that (https://github.com/JDASoftwareGroup/kartothek/commit/28939c7a56802409f8fbc5f2880796269d8fc84a#diff-5c15d229441c71aed6d9d3f371ab1c6498955d4faa0aa7304e399c1cc7009a2f). Maybe @fjetter still knows what he wanted to write? It's probably something about that the interaction is similar to primary indices. But I didn't want to guess, soI removed it for now.
