### PR TITLE
contribution / Add predicates to conditions converter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,11 @@ Changelog
 =========
 
 
-Version 5.0.1 (2021-06-xx)
+Version 5.1.0 (2021-06-xx)
 ==========================
 * Add :meth:`~kartothek.io.eager.copy_dataset` to copy and optionally rename datasets within one store or between stores (eager only)
 * Add renaming option to :meth:`~kartothek.io.eager_cube.copy_cube`
+* Add predicates to cube condition converter to :meth:`~kartothek.utils.predicate_converter`
 
 
 Version 5.0.0 (2021-06-23)

--- a/kartothek/utils/converters.py
+++ b/kartothek/utils/converters.py
@@ -7,6 +7,7 @@ from typing import Iterable, Optional, Tuple, Union
 
 import pandas as pd
 import pyarrow as pa
+from kartothek.core.cube.conditions import Condition
 
 __all__ = (
     "converter_str",
@@ -193,3 +194,64 @@ def get_str_to_python_converter(pa_type):
         return pd.Timestamp
     else:
         raise ValueError("Cannot handle type {pa_type}".format(pa_type=pa_type))
+
+
+def write_predicate_as_cube_condition(predicate):
+    """
+    Rewrites a single io.dask.dataset 'read_dataset_as_ddf' predicate condition as cube condition
+
+    Parameters
+    ----------
+    predicate_list: list
+        list containing single predicate definition
+
+    Returns
+    -------
+    condition: cube condition object
+        cube condition containing the predicate definition
+    """
+    parameter_format_dict = {}
+    if type(predicate[2]) == int:
+        condition_string = '{} {} {}'.format(predicate[0], predicate[1], str(predicate[2]))
+        parameter_format_dict[predicate[0]] = pa.int16()
+    if type(predicate[2]) == str:
+        condition_string = '{} {} {}'.format(predicate[0], predicate[1], predicate[2])
+        parameter_format_dict[predicate[0]] = pa.str()
+    if type(predicate[2]) == pd._libs.tslibs.timestamps.Timestamp:
+        condition_string = '{} {} {}'.format(predicate[0], predicate[1], predicate[2].strftime('%Y-%m-%d'))
+        parameter_format_dict[predicate[0]] = pa.timestamp('s')
+    if type(predicate[2]) == bool:
+        condition_string = '{} {} {}'.format(predicate[0], predicate[1], str(predicate[2]))
+        parameter_format_dict[predicate[0]] = pa.bool_()
+    if type(predicate[2]) == float:
+        condition_string = '{} {} {}'.format(predicate[0], predicate[1], str(predicate[2]))
+        parameter_format_dict[predicate[0]] = pa.float64()
+
+    if condition_string is not None:
+        condition = Condition.from_string(condition_string, parameter_format_dict)
+    else:
+        raise TypeError(
+            "Please enter only enter predicates for parameter values of the following type:"
+            " str, int, float, bool or pandas timestamp, "
+        )
+    return condition
+
+
+def convert_predicates_to_cube_conditions(predicates):
+    """
+    Converts a io.dask.dataset 'read_dataset_as_ddf' predicate to a cube condition
+
+    Parameters
+    ----------
+    predicates: list
+        list containing a list of single predicates
+
+    Returns
+    -------
+    condition: cube condition object
+        cube condition containing the combined predicate definitions
+    """
+    condition = ()
+    for predicate in predicates[0]:
+        condition = condition + (write_predicate_as_cube_condition(predicate),)
+    return condition

--- a/kartothek/utils/converters.py
+++ b/kartothek/utils/converters.py
@@ -7,7 +7,6 @@ from typing import Iterable, Optional, Tuple, Union
 
 import pandas as pd
 import pyarrow as pa
-from kartothek.core.cube.conditions import Condition
 
 __all__ = (
     "converter_str",
@@ -194,64 +193,3 @@ def get_str_to_python_converter(pa_type):
         return pd.Timestamp
     else:
         raise ValueError("Cannot handle type {pa_type}".format(pa_type=pa_type))
-
-
-def write_predicate_as_cube_condition(predicate):
-    """
-    Rewrites a single io.dask.dataset 'read_dataset_as_ddf' predicate condition as cube condition
-
-    Parameters
-    ----------
-    predicate_list: list
-        list containing single predicate definition
-
-    Returns
-    -------
-    condition: cube condition object
-        cube condition containing the predicate definition
-    """
-    parameter_format_dict = {}
-    if type(predicate[2]) == int:
-        condition_string = '{} {} {}'.format(predicate[0], predicate[1], str(predicate[2]))
-        parameter_format_dict[predicate[0]] = pa.int16()
-    if type(predicate[2]) == str:
-        condition_string = '{} {} {}'.format(predicate[0], predicate[1], predicate[2])
-        parameter_format_dict[predicate[0]] = pa.str()
-    if type(predicate[2]) == pd._libs.tslibs.timestamps.Timestamp:
-        condition_string = '{} {} {}'.format(predicate[0], predicate[1], predicate[2].strftime('%Y-%m-%d'))
-        parameter_format_dict[predicate[0]] = pa.timestamp('s')
-    if type(predicate[2]) == bool:
-        condition_string = '{} {} {}'.format(predicate[0], predicate[1], str(predicate[2]))
-        parameter_format_dict[predicate[0]] = pa.bool_()
-    if type(predicate[2]) == float:
-        condition_string = '{} {} {}'.format(predicate[0], predicate[1], str(predicate[2]))
-        parameter_format_dict[predicate[0]] = pa.float64()
-
-    if condition_string is not None:
-        condition = Condition.from_string(condition_string, parameter_format_dict)
-    else:
-        raise TypeError(
-            "Please enter only enter predicates for parameter values of the following type:"
-            " str, int, float, bool or pandas timestamp, "
-        )
-    return condition
-
-
-def convert_predicates_to_cube_conditions(predicates):
-    """
-    Converts a io.dask.dataset 'read_dataset_as_ddf' predicate to a cube condition
-
-    Parameters
-    ----------
-    predicates: list
-        list containing a list of single predicates
-
-    Returns
-    -------
-    condition: cube condition object
-        cube condition containing the combined predicate definitions
-    """
-    condition = ()
-    for predicate in predicates[0]:
-        condition = condition + (write_predicate_as_cube_condition(predicate),)
-    return condition

--- a/kartothek/utils/predicate_converter.py
+++ b/kartothek/utils/predicate_converter.py
@@ -61,7 +61,7 @@ def write_predicate_as_cube_condition(predicate: Tuple[str, str, Any]) -> Condit
 
 
 def convert_predicates_to_cube_conditions(
-    predicates: List[List],
+    predicates: List[List[Tuple[str, str, Any]]],
 ) -> Sequence[Condition]:
     """
     Converts a io.dask.dataset 'read_dataset_as_ddf' predicate to a cube condition

--- a/kartothek/utils/predicate_converter.py
+++ b/kartothek/utils/predicate_converter.py
@@ -1,0 +1,80 @@
+"""
+Helper module to convert kartothek dataset load predicates into cube conditions.
+"""
+
+from __future__ import absolute_import
+
+import pandas as pd
+import pyarrow as pa
+
+from kartothek.core.cube.conditions import Condition
+
+
+def write_predicate_as_cube_condition(predicate):
+    """
+    Rewrites a single io.dask.dataset 'read_dataset_as_ddf' predicate condition as cube condition
+
+    Parameters
+    ----------
+    predicate: list
+        list containing single predicate definition
+
+    Returns
+    -------
+    condition: cube condition object
+        cube condition containing the predicate definition
+    """
+    condition_string = None
+    parameter_format_dict = {}
+    if type(predicate[2]) == int:
+        condition_string = "{} {} {}".format(
+            predicate[0], predicate[1], str(predicate[2])
+        )
+        parameter_format_dict[predicate[0]] = pa.int16()
+    if type(predicate[2]) == str:
+        condition_string = "{} {} {}".format(predicate[0], predicate[1], predicate[2])
+        parameter_format_dict[predicate[0]] = pa.string()
+    if type(predicate[2]) == pd._libs.tslibs.timestamps.Timestamp:
+        condition_string = "{} {} {}".format(
+            predicate[0], predicate[1], predicate[2].strftime("%Y-%m-%d")
+        )
+        parameter_format_dict[predicate[0]] = pa.timestamp("s")
+    if type(predicate[2]) == bool:
+        condition_string = "{} {} {}".format(
+            predicate[0], predicate[1], str(predicate[2])
+        )
+        parameter_format_dict[predicate[0]] = pa.bool_()
+    if type(predicate[2]) == float:
+        condition_string = "{} {} {}".format(
+            predicate[0], predicate[1], str(predicate[2])
+        )
+        parameter_format_dict[predicate[0]] = pa.float64()
+
+    if condition_string is not None:
+        condition = Condition.from_string(condition_string, parameter_format_dict)
+    else:
+        raise TypeError(
+            "Please only enter predicates for parameter values of the following type:"
+            " str, int, float, bool or pandas timestamp, "
+        )
+    return condition
+
+
+def convert_predicates_to_cube_conditions(predicates):
+    """
+    Converts a io.dask.dataset 'read_dataset_as_ddf' predicate to a cube condition
+
+    Parameters
+    ----------
+    predicates: list
+        list containing a list of single predicates
+
+    Returns
+    -------
+    condition: cube condition object
+        cube condition containing the combined predicate definitions
+    """
+    condition = ()
+    for predicate in predicates[0]:
+        condition = condition + (write_predicate_as_cube_condition(predicate),)
+    return condition

--- a/kartothek/utils/predicate_converter.py
+++ b/kartothek/utils/predicate_converter.py
@@ -2,7 +2,7 @@
 Helper module to convert kartothek dataset load predicates into cube conditions.
 """
 
-from typing import Any, List, Tuple
+from typing import Any, List, Sequence, Tuple
 
 import pandas as pd
 import pyarrow as pa
@@ -10,7 +10,7 @@ import pyarrow as pa
 from kartothek.core.cube.conditions import Condition
 
 
-def write_predicate_as_cube_condition(predicate: Tuple[str, str, Any]) -> Any:
+def write_predicate_as_cube_condition(predicate: Tuple[str, str, Any]) -> Condition:
     """
     Rewrites a single io.dask.dataset 'read_dataset_as_ddf' predicate condition as cube condition
 
@@ -60,7 +60,9 @@ def write_predicate_as_cube_condition(predicate: Tuple[str, str, Any]) -> Any:
     return condition
 
 
-def convert_predicates_to_cube_conditions(predicates: List[List],) -> Any:
+def convert_predicates_to_cube_conditions(
+    predicates: List[List],
+) -> Sequence[Condition]:
     """
     Converts a io.dask.dataset 'read_dataset_as_ddf' predicate to a cube condition
 

--- a/kartothek/utils/predicate_converter.py
+++ b/kartothek/utils/predicate_converter.py
@@ -24,7 +24,7 @@ def write_predicate_as_cube_condition(predicate: Tuple[str, str, Any]) -> Condit
 
     Returns
     -------
-    condition: cube condition object
+    condition: Condition
         cube condition containing the predicate definition
     """
     condition_string = None

--- a/kartothek/utils/predicate_converter.py
+++ b/kartothek/utils/predicate_converter.py
@@ -74,7 +74,7 @@ def convert_predicates_to_cube_conditions(
 
     Returns
     -------
-    condition: cube condition object
+    condition: Condition
         cube condition containing the combined predicate definitions
     """
     condition: Any = ()

--- a/kartothek/utils/predicate_converter.py
+++ b/kartothek/utils/predicate_converter.py
@@ -12,7 +12,10 @@ from kartothek.core.cube.conditions import Condition
 
 def write_predicate_as_cube_condition(predicate: Tuple[str, str, Any]) -> Condition:
     """
-    Rewrites a single io.dask.dataset 'read_dataset_as_ddf' predicate condition as cube condition
+    Rewrites a single io.dask.dataset 'read_dataset_as_ddf' predicate condition as cube condition.
+
+    Remark: This function is restricted by "Condition.from_string" which does not allow for IsInCondition
+    and InIntervalCondition and will throw an error if conditions of those types are passed.
 
     Parameters
     ----------
@@ -26,28 +29,26 @@ def write_predicate_as_cube_condition(predicate: Tuple[str, str, Any]) -> Condit
     """
     condition_string = None
     parameter_format_dict = {}
+
+    if len(predicate) != 3:
+        raise ValueError("Please use predicates consisting of exactly 3 entries")
+
     if type(predicate[2]) == int:
-        condition_string = "{} {} {}".format(
-            predicate[0], predicate[1], str(predicate[2])
-        )
+        condition_string = f"{predicate[0]} {predicate[1]} {str(predicate[2])}"
         parameter_format_dict[predicate[0]] = pa.int64()
     if type(predicate[2]) == str:
-        condition_string = "{} {} {}".format(predicate[0], predicate[1], predicate[2])
+        condition_string = f"{predicate[0]} {predicate[1]} {predicate[2]}"
         parameter_format_dict[predicate[0]] = pa.string()
     if type(predicate[2]) == pd._libs.tslibs.timestamps.Timestamp:
-        condition_string = "{} {} {}".format(
-            predicate[0], predicate[1], predicate[2].strftime("%Y-%m-%d")
+        condition_string = (
+            f"{predicate[0]} {predicate[1]} {predicate[2].strftime('%Y-%m-%d')}"
         )
         parameter_format_dict[predicate[0]] = pa.timestamp("s")
     if type(predicate[2]) == bool:
-        condition_string = "{} {} {}".format(
-            predicate[0], predicate[1], str(predicate[2])
-        )
+        condition_string = f"{predicate[0]} {predicate[1]} {str(predicate[2])}"
         parameter_format_dict[predicate[0]] = pa.bool_()
     if type(predicate[2]) == float:
-        condition_string = "{} {} {}".format(
-            predicate[0], predicate[1], str(predicate[2])
-        )
+        condition_string = f"{predicate[0]} {predicate[1]} {str(predicate[2])}"
         parameter_format_dict[predicate[0]] = pa.float64()
 
     if condition_string is not None:
@@ -77,6 +78,11 @@ def convert_predicates_to_cube_conditions(
         cube condition containing the combined predicate definitions
     """
     condition: Any = ()
+    if len(predicates) > 1:
+        raise ValueError(
+            "Cube conditions cannot handle 'or' operators, therefore, "
+            "please pass a predicate list with one element."
+        )
     for predicate in predicates[0]:
         condition = condition + (write_predicate_as_cube_condition(predicate),)
     return condition

--- a/kartothek/utils/predicate_converter.py
+++ b/kartothek/utils/predicate_converter.py
@@ -2,13 +2,15 @@
 Helper module to convert kartothek dataset load predicates into cube conditions.
 """
 
+from typing import Any, List, Tuple
+
 import pandas as pd
 import pyarrow as pa
 
 from kartothek.core.cube.conditions import Condition
 
 
-def write_predicate_as_cube_condition(predicate):
+def write_predicate_as_cube_condition(predicate: Tuple[str, str, Any]) -> Any:
     """
     Rewrites a single io.dask.dataset 'read_dataset_as_ddf' predicate condition as cube condition
 
@@ -58,7 +60,7 @@ def write_predicate_as_cube_condition(predicate):
     return condition
 
 
-def convert_predicates_to_cube_conditions(predicates):
+def convert_predicates_to_cube_conditions(predicates: List[List],) -> Any:
     """
     Converts a io.dask.dataset 'read_dataset_as_ddf' predicate to a cube condition
 
@@ -72,7 +74,7 @@ def convert_predicates_to_cube_conditions(predicates):
     condition: cube condition object
         cube condition containing the combined predicate definitions
     """
-    condition = ()
+    condition: Any = ()
     for predicate in predicates[0]:
         condition = condition + (write_predicate_as_cube_condition(predicate),)
     return condition

--- a/kartothek/utils/predicate_converter.py
+++ b/kartothek/utils/predicate_converter.py
@@ -2,8 +2,6 @@
 Helper module to convert kartothek dataset load predicates into cube conditions.
 """
 
-from __future__ import absolute_import
-
 import pandas as pd
 import pyarrow as pa
 

--- a/kartothek/utils/predicate_converter.py
+++ b/kartothek/utils/predicate_converter.py
@@ -28,7 +28,7 @@ def write_predicate_as_cube_condition(predicate):
         condition_string = "{} {} {}".format(
             predicate[0], predicate[1], str(predicate[2])
         )
-        parameter_format_dict[predicate[0]] = pa.int16()
+        parameter_format_dict[predicate[0]] = pa.int64()
     if type(predicate[2]) == str:
         condition_string = "{} {} {}".format(predicate[0], predicate[1], predicate[2])
         parameter_format_dict[predicate[0]] = pa.string()

--- a/tests/utils/test_predicate_converter.py
+++ b/tests/utils/test_predicate_converter.py
@@ -8,25 +8,27 @@ from kartothek.utils.predicate_converter import (
 )
 
 
-def test_write_predicate_as_cube_condition():
-    assert write_predicate_as_cube_condition(["column", "==", 1]) == (C("column") == 1)
-    assert write_predicate_as_cube_condition(["column", "==", 1.1]) == (
-        C("column") == 1.1
-    )
-    assert write_predicate_as_cube_condition(["column", "==", "1"]) == (
-        C("column") == "1"
-    )
-    assert write_predicate_as_cube_condition(
-        ["date", "==", pd.to_datetime("2020-01-01")]
-    ) == (C("date") == pd.Timestamp("2020-01-01 00:00:00"))
-    assert write_predicate_as_cube_condition(["column", "==", True]) == (
-        C("column") == True  # noqa: E712
-    )
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        (["column", "==", 1], (C("column") == 1)),
+        (["column", "==", 1.1], C("column") == 1.1),
+        (["column", "==", "1"], C("column") == "1"),
+        (
+            ["date", "==", pd.to_datetime("2020-01-01")],
+            (C("date") == pd.Timestamp("2020-01-01 00:00:00")),
+        ),
+        (["column", "==", True], C("column") == True),  # noqa: E712)
+        (["column", "<=", 1], (C("column") <= 1)),
+        (["column", ">=", 1], (C("column") >= 1)),
+        (["column", "!=", 1], (C("column") != 1)),
+    ],
+)
+def test_write_predicate_as_cube_condition(test_input, expected):
+    assert write_predicate_as_cube_condition(test_input) == expected
 
-    assert write_predicate_as_cube_condition(["column", "<=", 1]) == (C("column") <= 1)
-    assert write_predicate_as_cube_condition(["column", ">=", 1]) == (C("column") >= 1)
-    assert write_predicate_as_cube_condition(["column", "!=", 1]) == (C("column") != 1)
 
+def test_raises_type_error_write_predicate_as_cube_condition():
     with pytest.raises(
         TypeError,
         match="Please only enter predicates for parameter values of the "
@@ -36,6 +38,8 @@ def test_write_predicate_as_cube_condition():
             ("date", "==", pd.to_datetime("2020-01-01").date())
         )
 
+
+def test_raises_value_error_write_predicate_as_cube_condition():
     with pytest.raises(
         ValueError, match="Please use predicates consisting of exactly 3 entries"
     ):
@@ -47,14 +51,21 @@ def test_write_predicate_as_cube_condition():
         write_predicate_as_cube_condition(("date", "==", "date", "=="))
 
 
-def test_convert_predicates_to_cube_conditions():
-    assert convert_predicates_to_cube_conditions([[("column", "==", 1)]]) == (
-        C("column") == 1,
-    )
-    assert convert_predicates_to_cube_conditions(
-        [[("column", "==", 1), ("column2", "==", "1")]]
-    ) == (C("column") == 1, C("column2") == "1")
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        ([[("column", "==", 1)]], (C("column") == 1,)),
+        (
+            [[("column", "==", 1), ("column2", "==", "1")]],
+            (C("column") == 1, C("column2") == "1"),
+        ),
+    ],
+)
+def test_convert_predicates_to_cube_conditions(test_input, expected):
+    assert convert_predicates_to_cube_conditions(test_input) == expected
 
+
+def test_raises_value_error_convert_predicates_to_cube_conditions():
     with pytest.raises(
         ValueError,
         match="Cube conditions cannot handle 'or' operators, therefore, "

--- a/tests/utils/test_predicate_converter.py
+++ b/tests/utils/test_predicate_converter.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import pytest
+
+from kartothek.core.cube.conditions import C
+from kartothek.utils.predicate_converter import (
+    convert_predicates_to_cube_conditions,
+    write_predicate_as_cube_condition,
+)
+
+
+def test_write_predicate_as_cube_condition():
+    assert write_predicate_as_cube_condition(["column", "==", 1]) == (C("column") == 1)
+    assert write_predicate_as_cube_condition(["column", "==", 1.1]) == (
+        C("column") == 1.1
+    )
+    assert write_predicate_as_cube_condition(["column", "==", "1"]) == (
+        C("column") == "1"
+    )
+    assert write_predicate_as_cube_condition(
+        ["date", "==", pd.to_datetime("2020-01-01")]
+    ) == (C("date") == pd.Timestamp("2020-01-01 00:00:00"))
+    assert write_predicate_as_cube_condition(["column", "==", True]) == (
+        C("column") == True  # noqa: E712
+    )
+
+    assert write_predicate_as_cube_condition(["column", "<=", 1]) == (C("column") <= 1)
+    assert write_predicate_as_cube_condition(["column", ">=", 1]) == (C("column") >= 1)
+    assert write_predicate_as_cube_condition(["column", "!=", 1]) == (C("column") != 1)
+
+    with pytest.raises(
+        TypeError,
+        match="Please only enter predicates for parameter values of the "
+        "following type: str, int, float, bool or pandas timestamp, ",
+    ):
+        write_predicate_as_cube_condition(
+            ["date", "==", pd.to_datetime("2020-01-01").date()]
+        )
+
+
+def test_convert_predicates_to_cube_conditions():
+    assert convert_predicates_to_cube_conditions([[("column", "==", 1)]]) == (
+        C("column") == 1,
+    )
+    assert convert_predicates_to_cube_conditions(
+        [[("column", "==", 1), ("column2", "==", "1")]]
+    ) == (C("column") == 1, C("column2") == "1")

--- a/tests/utils/test_predicate_converter.py
+++ b/tests/utils/test_predicate_converter.py
@@ -33,8 +33,18 @@ def test_write_predicate_as_cube_condition():
         "following type: str, int, float, bool or pandas timestamp, ",
     ):
         write_predicate_as_cube_condition(
-            ["date", "==", pd.to_datetime("2020-01-01").date()]
+            ("date", "==", pd.to_datetime("2020-01-01").date())
         )
+
+    with pytest.raises(
+        ValueError, match="Please use predicates consisting of exactly 3 entries"
+    ):
+        write_predicate_as_cube_condition(("date", "=="))
+
+    with pytest.raises(
+        ValueError, match="Please use predicates consisting of exactly 3 entries"
+    ):
+        write_predicate_as_cube_condition(("date", "==", "date", "=="))
 
 
 def test_convert_predicates_to_cube_conditions():
@@ -44,3 +54,12 @@ def test_convert_predicates_to_cube_conditions():
     assert convert_predicates_to_cube_conditions(
         [[("column", "==", 1), ("column2", "==", "1")]]
     ) == (C("column") == 1, C("column2") == "1")
+
+    with pytest.raises(
+        ValueError,
+        match="Cube conditions cannot handle 'or' operators, therefore, "
+        "please pass a predicate list with one element.",
+    ):
+        convert_predicates_to_cube_conditions(
+            [[("column", "==", 1)], [("column2", "==", 2)]]
+        )


### PR DESCRIPTION
# Description:

Adding a helper module in utils to convert a kartothek read dataset predicate to a query cube predicate.
This functionalities makes integrations from querying datasets to querying cubes easier, and also will be handy for libraries loading both data from datasets and cubes.

- [ ] Closes #xxxx
- [ ] Changelog entry
