### PR TITLE
5.x: rollback to the 3.20.0 state (#471)

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
+    - uses: pre-commit/action@v2.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
         run: python setup.py sdist bdist_wheel
 
       - name: Codecov
-        uses: codecov/codecov-action@v1.5.0
+        uses: codecov/codecov-action@v1.2.2
         with:
           # NOTE: `token` is not required, because the kartothek repo is public
           file: ./coverage.xml

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,22 @@
 Changelog
 =========
 
+Version 5.0.0 (2021-05-xx)
+==========================
+
+This release rolls all the changes introduced with 4.x back to 3.20.0.
+
+As the incompatibility between 4.0 and 5.0 will be an issue for some customers, we encourage you to use the very stable
+kartothek 3.20.0 and not version 4.x.
+
+Please refer the Issue #471 for further information.
+
 
 Kartothek 4.0.3 (2021-06-10)
 ============================
+
 * Pin dask to not use 2021.5.1 and 2020.6.0 (#475)
+
 
 Kartothek 4.0.2 (2021-06-07)
 ============================

--- a/asv_bench/benchmarks/index.py
+++ b/asv_bench/benchmarks/index.py
@@ -131,7 +131,9 @@ class BuildIndex(AsvBenchmarkConfig):
                 unique_vals = ["{:010d}".format(n) for n in range(cardinality)]
                 array = [unique_vals[x % len(unique_vals)] for x in range(num_values)]
             self.df = pd.DataFrame({self.column: array})
-            self.mp = MetaPartition(label=self.table, data=self.df, metadata_version=4)
+            self.mp = MetaPartition(
+                label=self.table, data={"core": self.df}, metadata_version=4
+            )
             self.mp_indices = self.mp.build_indices([self.column])
             self.merge_indices.append(self.mp_indices)
 

--- a/asv_bench/benchmarks/metapartition.py
+++ b/asv_bench/benchmarks/metapartition.py
@@ -33,7 +33,7 @@ class TimeMetaPartition(AsvBenchmarkConfig):
         self.mp = MetaPartition(
             label="primary_key={}/base_label".format(dtype[0]),
             metadata_version=4,
-            schema=self.schema,
+            table_meta={"table": self.schema},
         )
 
     def time_reconstruct_index(self, num_rows, dtype):
@@ -41,6 +41,7 @@ class TimeMetaPartition(AsvBenchmarkConfig):
         self.mp._reconstruct_index_columns(
             df=self.df,
             key_indices=[("primary_key", str(dtype[1]))],
+            table="table",
             columns=None,
             categories=None,
             date_as_object=False,
@@ -50,7 +51,8 @@ class TimeMetaPartition(AsvBenchmarkConfig):
         self.mp._reconstruct_index_columns(
             df=self.df,
             key_indices=[("primary_key", str(dtype[1]))],
+            table="table",
             columns=None,
-            categories="primary_key",
+            categories={"table": ["primary_key"]},
             date_as_object=False,
         )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -129,3 +129,8 @@ reftarget_replace = {
     "kartothek.serialization._generic": "kartothek.serialization",
     "kartothek.serialization._parquet": "kartothek.serialization",
 }
+
+# In particular the deprecation warning in DatasetMetadata.table_schema is
+# raising too many warning to handle sensibly using ipython directive pseudo
+# decorators. Remove this with 4.X again
+ipython_warning_is_error = False

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -36,7 +36,7 @@ Setup a store
 
     # Load your data
     # By default the single dataframe is stored in the 'core' table
-    df_from_store = read_table(store=store_url, dataset_uuid=dataset_uuid)
+    df_from_store = read_table(store=store_url, dataset_uuid=dataset_uuid, table="table")
     df_from_store
 
 
@@ -58,8 +58,14 @@ Write
 
     # We'll define two partitions which both have two tables
     input_list_of_partitions = [
-        pd.DataFrame({"A": range(10)}),
-        pd.DataFrame({"A": range(10, 20)}),
+        {
+            "label": "FirstPartition",
+            "data": [("FirstCategory", pd.DataFrame()), ("SecondCategory", pd.DataFrame())],
+        },
+        {
+            "label": "SecondPartition",
+            "data": [("FirstCategory", pd.DataFrame()), ("SecondCategory", pd.DataFrame())],
+        },
     ]
 
     # The pipeline will return a :class:`~kartothek.core.dataset.DatasetMetadata` object
@@ -90,10 +96,17 @@ Read
     # In case you were using the dataset created in the Write example
     for d1, d2 in zip(
         list_of_partitions,
-        [pd.DataFrame({"A": range(10)}), pd.DataFrame({"A": range(10, 20)}),],
+        [
+            # FirstPartition
+            {"FirstCategory": pd.DataFrame(), "SecondCategory": pd.DataFrame()},
+            # SecondPartition
+            {"FirstCategory": pd.DataFrame(), "SecondCategory": pd.DataFrame()},
+        ],
     ):
-        for k1, k2 in zip(d1, d2):
-            assert k1 == k2
+        for kv1, kv2 in zip(d1.items(), d2.items()):
+            k1, v1 = kv1
+            k2, v2 = kv2
+            assert k1 == k2 and all(v1 == v2)
 
 
 Iter
@@ -107,8 +120,14 @@ Write
     from kartothek.api.dataset import store_dataframes_as_dataset__iter
 
     input_list_of_partitions = [
-        pd.DataFrame({"A": range(10)}),
-        pd.DataFrame({"A": range(10, 20)}),
+        {
+            "label": "FirstPartition",
+            "data": [("FirstCategory", pd.DataFrame()), ("SecondCategory", pd.DataFrame())],
+        },
+        {
+            "label": "SecondPartition",
+            "data": [("FirstCategory", pd.DataFrame()), ("SecondCategory", pd.DataFrame())],
+        },
     ]
 
     # The pipeline will return a :class:`~kartothek.core.dataset.DatasetMetadata` object
@@ -141,10 +160,17 @@ Read
     # In case you were using the dataset created in the Write example
     for d1, d2 in zip(
         list_of_partitions,
-        [pd.DataFrame({"A": range(10)}), pd.DataFrame({"A": range(10, 20)}),],
+        [
+            # FirstPartition
+            {"FirstCategory": pd.DataFrame(), "SecondCategory": pd.DataFrame()},
+            # SecondPartition
+            {"FirstCategory": pd.DataFrame(), "SecondCategory": pd.DataFrame()},
+        ],
     ):
-        for k1, k2 in zip(d1, d2):
-            assert k1 == k2
+        for kv1, kv2 in zip(d1.items(), d2.items()):
+            k1, v1 = kv1
+            k2, v2 = kv2
+            assert k1 == k2 and all(v1 == v2)
 
 Dask
 ````
@@ -158,8 +184,14 @@ Write
     from kartothek.api.dataset import store_delayed_as_dataset
 
     input_list_of_partitions = [
-        pd.DataFrame({"A": range(10)}),
-        pd.DataFrame({"A": range(10, 20)}),
+        {
+            "label": "FirstPartition",
+            "data": [("FirstCategory", pd.DataFrame()), ("SecondCategory", pd.DataFrame())],
+        },
+        {
+            "label": "SecondPartition",
+            "data": [("FirstCategory", pd.DataFrame()), ("SecondCategory", pd.DataFrame())],
+        },
     ]
 
     # This will return a :class:`~dask.delayed`. The figure below

--- a/docs/guide/partitioning.rst
+++ b/docs/guide/partitioning.rst
@@ -100,7 +100,31 @@ Note that, since 2 dataframes have been provided as input to the function, there
 4 different files created, even though only 2 different combinations of values of E and
 F are found, ``E=test/F=foo`` and ``E=train/F=foo`` (However, these 4 physical partitions
 can be read as just the 2 logical partitions by using the argument
-``dispatch_by=["E", "F"]`` at reading time).
+``concat_partitions_on_primary_index=True`` at reading time).
+
+For datasets consisting of multiple tables, explicit partitioning on columns can only be
+performed if the column exists in both tables and is of the same data type: guaranteeing
+that their types are the same is part of schema validation in Kartothek.
+
+For example:
+
+.. ipython:: python
+    :okwarning:
+
+    df.dtypes
+    different_df = pd.DataFrame(
+        {"B": pd.to_datetime(["20130102", "20190101"]), "L": [1, 4], "Q": [True, False]}
+    )
+    different_df.dtypes
+
+    dm = store_dataframes_as_dataset(
+        store_url,
+        "multiple_partitioned_tables",
+        [{"data": {"table1": df, "table2": different_df}}],
+        partition_on="B",
+    )
+
+    sorted(dm.partitions.keys())
 
 
 As noted above, when data is appended to a dataset, Kartothek guarantees it has
@@ -108,6 +132,9 @@ the proper schema and partitioning.
 
 The order of columns provided in ``partition_on`` is important, as the partition
 structure would be different if the columns are in a different order.
+
+.. note:: Every partition must have data for every table. An empty dataframe in this
+          context is also considered as data.
 
 .. _partitioning_dask:
 
@@ -139,7 +166,7 @@ number of physical input partitions.
     ddf = dd.from_pandas(df, npartitions=10)
 
     dm = update_dataset_from_ddf(
-        ddf, dataset_uuid="no_shuffle", store=store_url, partition_on="A"
+        ddf, dataset_uuid="no_shuffle", store=store_url, partition_on="A", table="table"
     ).compute()
     sorted(dm.partitions.keys())
 
@@ -156,7 +183,12 @@ partitioning values of A to be fused into a single file.
     :okwarning:
 
     dm = update_dataset_from_ddf(
-        ddf, dataset_uuid="with_shuffle", store=store_url, partition_on="A", shuffle=True,
+        ddf,
+        dataset_uuid="with_shuffle",
+        store=store_url,
+        partition_on="A",
+        shuffle=True,
+        table="table",
     ).compute()
     sorted(dm.partitions.keys())
 
@@ -204,6 +236,7 @@ When investigating the index, we can also see that a query for a given value in 
         store=store_url,
         partition_on="A",
         shuffle=True,
+        table="table",
         bucket_by="B",
         num_buckets=4,
         secondary_indices="B",

--- a/docs/spec/indexing.rst
+++ b/docs/spec/indexing.rst
@@ -15,7 +15,7 @@ All currently supported kartothek index types are inverted indices and are mappi
 
     index_dct = {1: ["table/12345"], 2: ["table/12345", "table/6789"]}
 
-Where, in this example, the value ``1`` is found in exactly one partition which is labeled ``table/12345``.
+Where, in this example, the value ``42`` is found in exactly one partition which is labeled ``table/partitionA=42/12345``.
 
 Users typically do not interact with indices directly since querying a dataset will automatically load and interact with the indices. For some applications it is still quite useful to interact with them directly.
 
@@ -87,7 +87,7 @@ For data with high cardinality this kind of index is not well suited since it wo
 Secondary indices
 -----------------
 
-Secondary indices are the most powerful type of indices which allow us to reference files without having to encode any kind of values in the keys. They can be created by supplying the `secondary_indices` keyword argument as shown above.
+Secondary indices are the most powerful type of indices which allow us to reference files without having to encode any kind of values in the keys. They can be created by supplying the `secondary_indices` keyword argument as shown above. The user interaction works similarly to the
 
 
 Persistence

--- a/kartothek/api/consistency.py
+++ b/kartothek/api/consistency.py
@@ -314,14 +314,14 @@ def check_datasets(
     datasets = {name: ds.load_partition_indices() for name, ds in datasets.items()}
     _check_datasets(
         datasets=datasets,
-        f=lambda ds: {ds.table_name},
+        f=lambda ds: set(ds.table_meta.keys()),
         expected={SINGLE_TABLE},
         what="table",
     )
     _check_overlap(datasets, cube)
 
     # check column types
-    validate_shared_columns([ds.schema for ds in datasets.values()])
+    validate_shared_columns([ds.table_meta[SINGLE_TABLE] for ds in datasets.values()])
 
     _check_partition_columns(datasets, cube)
     _check_dimension_columns(datasets, cube)

--- a/kartothek/api/discover.py
+++ b/kartothek/api/discover.py
@@ -10,7 +10,7 @@ from kartothek.core.cube.constants import (
     KTK_CUBE_METADATA_KEY_IS_SEED,
     KTK_CUBE_METADATA_PARTITION_COLUMNS,
     KTK_CUBE_METADATA_SUPPRESS_INDEX_ON,
-    KTK_CUBE_UUID_SEPARATOR,
+    KTK_CUBE_UUID_SEPERATOR,
 )
 from kartothek.core.cube.cube import Cube
 from kartothek.core.dataset import DatasetMetadata
@@ -79,7 +79,7 @@ def discover_ktk_cube_dataset_ids(uuid_prefix: str, store: StoreInput) -> Set[st
         The ktk_cube dataset ids
 
     """
-    prefix = uuid_prefix + KTK_CUBE_UUID_SEPARATOR
+    prefix = uuid_prefix + KTK_CUBE_UUID_SEPERATOR
     names = _discover_dataset_meta_files(prefix, store)
     return set([name[len(prefix) :] for name in names])
 
@@ -115,7 +115,7 @@ def discover_datasets_unchecked(
     filter_ktk_cube_dataset_ids = converter_str_set_optional(
         filter_ktk_cube_dataset_ids
     )
-    prefix = uuid_prefix + KTK_CUBE_UUID_SEPARATOR
+    prefix = uuid_prefix + KTK_CUBE_UUID_SEPERATOR
 
     names = _discover_dataset_meta_files(prefix, store)
 

--- a/kartothek/cli/_info.py
+++ b/kartothek/cli/_info.py
@@ -4,6 +4,7 @@ import click
 
 from kartothek.cli._utils import to_bold as b
 from kartothek.cli._utils import to_header as h
+from kartothek.io_components.metapartition import SINGLE_TABLE
 from kartothek.utils.ktk_adapters import get_dataset_columns
 
 __all__ = ("info",)
@@ -18,7 +19,7 @@ def info(ctx):
     datasets = ctx.obj["datasets"]
 
     seed_ds = datasets[cube.seed_dataset]
-    seed_schema = seed_ds.schema
+    seed_schema = seed_ds.table_meta[SINGLE_TABLE]
 
     click.echo(h("Infos"))
     click.echo(b("UUID Prefix:") + "        {}".format(cube.uuid_prefix))
@@ -40,7 +41,7 @@ def _info_dataset(ktk_cube_dataset_id, ds, cube):
     click.echo(h("Dataset: {}".format(ktk_cube_dataset_id)))
 
     ds = ds.load_partition_indices()
-    schema = ds.schema
+    schema = ds.table_meta[SINGLE_TABLE]
     all_cols = get_dataset_columns(ds)
     payload_cols = sorted(
         all_cols - (set(cube.dimension_columns) | set(cube.partition_columns))
@@ -82,7 +83,7 @@ def _collist_string_index(cube, datasets):
     for col in sorted(cube.index_columns):
         for ktk_cube_dataset_id in sorted(datasets.keys()):
             ds = datasets[ktk_cube_dataset_id]
-            schema = ds.schema
+            schema = ds.table_meta[SINGLE_TABLE]
             if col in schema.names:
                 lines.append("  - {c}: {t}".format(c=col, t=schema.field(col).type))
                 break

--- a/kartothek/cli/_query.py
+++ b/kartothek/cli/_query.py
@@ -10,6 +10,7 @@ from prompt_toolkit.validation import ValidationError, Validator
 
 from kartothek.core.cube.conditions import Conjunction
 from kartothek.io.dask.bag_cube import query_cube_bag
+from kartothek.io_components.metapartition import SINGLE_TABLE
 from kartothek.utils.ktk_adapters import get_dataset_columns
 
 __all__ = ("query",)
@@ -41,7 +42,7 @@ def query(ctx):
         cols = get_dataset_columns(ds)
         all_columns |= cols
         for col in cols:
-            all_types[col] = ds.schema.field(col).type
+            all_types[col] = ds.table_meta[SINGLE_TABLE].field(col).type
 
     ipython = _get_ipython()
 

--- a/kartothek/core/common_metadata.py
+++ b/kartothek/core/common_metadata.py
@@ -16,7 +16,6 @@ from simplekv import KeyValueStore
 
 from kartothek.core import naming
 from kartothek.core._compat import load_json
-from kartothek.core.naming import SINGLE_TABLE
 from kartothek.core.utils import ensure_string_type
 
 _logger = logging.getLogger()
@@ -337,7 +336,7 @@ def _get_common_metadata_key(dataset_uuid, table):
 
 
 def read_schema_metadata(
-    dataset_uuid: str, store: KeyValueStore, table: str = SINGLE_TABLE
+    dataset_uuid: str, store: KeyValueStore, table: str
 ) -> SchemaWrapper:
     """
     Read schema and metadata from store.
@@ -361,10 +360,7 @@ def read_schema_metadata(
 
 
 def store_schema_metadata(
-    schema: SchemaWrapper,
-    dataset_uuid: str,
-    store: KeyValueStore,
-    table: str = SINGLE_TABLE,
+    schema: SchemaWrapper, dataset_uuid: str, store: KeyValueStore, table: str
 ) -> str:
     """
     Store schema and metadata to store.
@@ -450,7 +446,7 @@ def _determine_schemas_to_compare(
     reference = None
     null_cols_in_reference = set()
 
-    for schema in set(schemas):
+    for schema in schemas:
         if not isinstance(schema, SchemaWrapper):
             schema = SchemaWrapper(schema, "__unknown__")
 

--- a/kartothek/core/cube/constants.py
+++ b/kartothek/core/cube/constants.py
@@ -9,7 +9,7 @@ __all__ = (
     "KTK_CUBE_METADATA_KEY_IS_SEED",
     "KTK_CUBE_METADATA_STORAGE_FORMAT",
     "KTK_CUBE_METADATA_VERSION",
-    "KTK_CUBE_UUID_SEPARATOR",
+    "KTK_CUBE_UUID_SEPERATOR",
 )
 
 
@@ -45,6 +45,4 @@ KTK_CUBE_METADATA_PARTITION_COLUMNS = "ktk_cube_partition_columns"
 KTK_CUBE_METADATA_SUPPRESS_INDEX_ON = "ktk_cube_suppress_index_on"
 
 #: Character sequence used to seperate cube and dataset UUID
-KTK_CUBE_UUID_SEPARATOR = "++"
-# Alias for compat reasons
-KTK_CUBE_UUID_SEPERATOR = KTK_CUBE_UUID_SEPARATOR
+KTK_CUBE_UUID_SEPERATOR = "++"

--- a/kartothek/core/cube/cube.py
+++ b/kartothek/core/cube/cube.py
@@ -2,7 +2,7 @@ import typing
 
 import attr
 
-from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPARATOR
+from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPERATOR
 from kartothek.core.dataset import _validate_uuid
 from kartothek.utils.converters import (
     converter_str,
@@ -102,10 +102,10 @@ def _validator_uuid_freestanding(name, value):
                 name=name, value=value
             )
         )
-    if value.find(KTK_CUBE_UUID_SEPARATOR) != -1:
+    if value.find(KTK_CUBE_UUID_SEPERATOR) != -1:
         raise ValueError(
             '{name} ("{value}") must not contain UUID separator {sep}'.format(
-                name=name, value=value, sep=KTK_CUBE_UUID_SEPARATOR
+                name=name, value=value, sep=KTK_CUBE_UUID_SEPERATOR
             )
         )
 
@@ -201,7 +201,7 @@ class Cube:
         _validator_uuid_freestanding("ktk_cube_dataset_id", ktk_cube_dataset_id)
         return "{uuid_prefix}{sep}{ktk_cube_dataset_id}".format(
             uuid_prefix=self.uuid_prefix,
-            sep=KTK_CUBE_UUID_SEPARATOR,
+            sep=KTK_CUBE_UUID_SEPERATOR,
             ktk_cube_dataset_id=ktk_cube_dataset_id,
         )
 

--- a/kartothek/core/docs.py
+++ b/kartothek/core/docs.py
@@ -29,20 +29,18 @@ _PARAMETER_MAPPING = {
     "table": """
     table: Optional[str]
         The table to be loaded. If none is specified, the default 'table' is used.""",
-    "table_name": """
-    table_name:
-        The table name of the dataset to be loaded. This creates a namespace for
-        the partitioning like
-
-        `dataset_uuid/table_name/*`
-
-        This is to support legacy workflows. We recommend not to use this and use the default wherever possible.""",
-    "schema": """
-    schema: SchemaWrapper
-        The dataset table schema""",
+    "tables": """
+    tables : List[str]
+        A list of tables to be loaded. If None is given, all tables of
+        a partition are loaded""",
+    "table_meta": """
+    table_meta: Dict[str, SchemaWrapper]
+        The dataset table schemas""",
     "columns": """
-    columns
-        A subset of columns to be loaded.""",
+    columns : Optional[List[Dict[str]]]
+        A dictionary mapping tables to list of columns. Only the specified
+        columns are loaded for the corresponding table. If a specfied table or column is
+        not present in the dataset, a ValueError is raised.""",
     "dispatch_by": """
     dispatch_by: Optional[List[str]]
         List of index columns to group and partition the jobs by.
@@ -108,8 +106,14 @@ _PARAMETER_MAPPING = {
         For `kartothek.io.dask.update.update_dataset.*` a delayed object resolving to
         a list of dicts is also accepted.""",
     "categoricals": """
-    categoricals
-        Load the provided subset of columns as a :class:`pandas.Categorical`.""",
+    categoricals : Dict[str, List[str]]
+        A dictionary mapping tables to list of columns that should be
+        loaded as `category` dtype instead of the inferred one.""",
+    "label_filter": """
+    label_filter: Callable
+        A callable taking a partition label as a parameter and returns a boolean. The callable will be applied
+        to the list of partitions during dispatch and will filter out all partitions for which the callable
+        evaluates to False.""",
     "dates_as_object": """
     dates_as_object: bool
         Load pyarrow.date{32,64} columns as ``object`` columns in Pandas
@@ -162,12 +166,22 @@ _PARAMETER_MAPPING = {
     "df_generator": """
     df_generator: Iterable[Union[pandas.DataFrame, Dict[str, pandas.DataFrame]]]
         The dataframe(s) to be stored""",
+    "central_partition_metadata": """
+    central_partition_metadata: bool
+        This has no use and will be removed in future releases""",
     "default_metadata_version": """
     default_metadata_version: int
         Default metadata version. (Note: Metadata version greater than 3 are only supported)""",
+    "load_dynamic_metadata": """
+    load_dynamic_metadata: bool
+        The keyword `load_dynamic_metadata` is deprecated and will be removed in the next major release.""",
+    "concat_partitions_on_primary_index": """
+    concat_partitions_on_primary_index: bool
+        Concatenate partition based on their primary index values.""",
     "delayed_tasks": """
-    delayed_tasks
-        A list of delayed objects where each element returns a :class:`pandas.DataFrame`.""",
+    delayed_tasks: List[dask.delayed.Delayed]
+        Every delayed object represents a partition and should be accepted by
+        :func:`~kartothek.io_components.metapartition.parse_input_to_metapartition`""",
     "load_dataset_metadata": """
     load_dataset_metadata: bool
         Optional argument on whether to load the metadata or not""",

--- a/kartothek/core/naming.py
+++ b/kartothek/core/naming.py
@@ -4,9 +4,6 @@
 Global naming constants for datasets
 """
 
-
-# FIXME: move this constant somewhere else. Cannot import from its declaration due to cyclic imports
-SINGLE_TABLE = "table"
 DEFAULT_METADATA_VERSION = 4
 MIN_METADATA_VERSION = 4
 MAX_METADATA_VERSION = 4

--- a/kartothek/core/partition.py
+++ b/kartothek/core/partition.py
@@ -3,8 +3,6 @@ from typing import Any, Dict, Optional, Union
 PartitionDictType = Dict[str, Dict[str, str]]
 
 
-# TODO: purge this. This is just slowing us down by creating many python objects we don't actual
-# Changing the partition class needs to be done with are since it's to_dict is used for the storage metadata spec
 class Partition:
     def __init__(
         self, label: str, files: Optional[Dict[str, str]] = None, metadata: Dict = None

--- a/kartothek/core/urlencode.py
+++ b/kartothek/core/urlencode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from typing import List, Tuple, Union
+from typing import List, Tuple
 
 from urlquote import quote as urlquote_quote
 from urlquote import unquote as urlquote_unquote
@@ -22,9 +22,7 @@ def unquote(value):
     return urlquote_unquote(value).decode("utf-8")
 
 
-def decode_key(
-    key: str,
-) -> Union[Tuple[str, str, List, str], Tuple[str, None, List, None]]:
+def decode_key(key):
     """
     Split a given key into its kartothek components `{dataset_uuid}/{table}/{key_indices}/{filename}`
 

--- a/kartothek/io/dask/_shuffle.py
+++ b/kartothek/io/dask/_shuffle.py
@@ -9,6 +9,7 @@ import pandas as pd
 from kartothek.core.typing import StoreFactory
 from kartothek.io.dask.compression import pack_payload, unpack_payload_pandas
 from kartothek.io_components.metapartition import MetaPartition
+from kartothek.io_components.utils import InferredIndices
 from kartothek.io_components.write import write_partition
 from kartothek.serialization import DataFrameSerializer
 
@@ -35,7 +36,7 @@ def _hash_bucket(df: pd.DataFrame, subset: Optional[Sequence[str]], num_buckets:
 def shuffle_store_dask_partitions(
     ddf: dd.DataFrame,
     table: str,
-    secondary_indices: List[str],
+    secondary_indices: Optional[InferredIndices],
     metadata_version: int,
     partition_on: List[str],
     store_factory: StoreFactory,
@@ -131,11 +132,11 @@ def shuffle_store_dask_partitions(
 
 def _unpack_store_partition(
     df: pd.DataFrame,
-    secondary_indices: List[str],
+    secondary_indices: Optional[InferredIndices],
     sort_partitions_by: List[str],
     table: str,
     dataset_uuid: str,
-    partition_on: List[str],
+    partition_on: Optional[List[str]],
     store_factory: StoreFactory,
     df_serializer: DataFrameSerializer,
     metadata_version: int,

--- a/kartothek/io/dask/_utils.py
+++ b/kartothek/io/dask/_utils.py
@@ -15,11 +15,21 @@ except ImportError:
 CATEGORICAL_EFFICIENCY_WARN_LIMIT = 100000
 
 
+def _identity():
+    def _id(x):
+        return x
+
+    return _id
+
+
 def _get_data(mp, table=None):
     """
     Task to avoid serialization of lambdas
     """
-    return mp.data
+    if table:
+        return mp.data[table]
+    else:
+        return mp.data
 
 
 def _cast_categorical_to_index_cat(df, categories):
@@ -55,10 +65,14 @@ def _maybe_get_categoricals_from_index(dataset_metadata_factory, categoricals):
     """
     categoricals_from_index = {}
     if categoricals:
-        for column in categoricals:
-            if column in dataset_metadata_factory.indices:
-                cat_dtype = _construct_categorical(column, dataset_metadata_factory)
-                categoricals_from_index[column] = cat_dtype
+        for table, table_cat in categoricals.items():
+            if not table_cat:
+                continue
+            categoricals_from_index[table] = {}
+            for cat in table_cat:
+                if cat in dataset_metadata_factory.indices:
+                    cat_dtype = _construct_categorical(cat, dataset_metadata_factory)
+                    categoricals_from_index[table][cat] = cat_dtype
     return categoricals_from_index
 
 

--- a/kartothek/io/dask/bag.py
+++ b/kartothek/io/dask/bag.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+import warnings
+from collections import defaultdict
 from functools import partial
 from typing import Optional, Sequence
 
@@ -13,11 +16,11 @@ from kartothek.core.uuid import gen_uuid
 from kartothek.io.dask._utils import (
     _cast_categorical_to_index_cat,
     _get_data,
+    _identity,
     _maybe_get_categoricals_from_index,
 )
 from kartothek.io_components.index import update_indices_from_partitions
 from kartothek.io_components.metapartition import (
-    SINGLE_TABLE,
     MetaPartition,
     parse_input_to_metapartition,
 )
@@ -51,14 +54,19 @@ def _load_and_concat_metapartitions_inner(mps, *args, **kwargs):
 def read_dataset_as_metapartitions_bag(
     dataset_uuid=None,
     store=None,
+    tables=None,
     columns=None,
+    concat_partitions_on_primary_index=False,
     predicate_pushdown_to_io=True,
     categoricals=None,
-    dates_as_object: bool = True,
+    label_filter=None,
+    dates_as_object=False,
+    load_dataset_metadata=False,
     predicates=None,
     factory=None,
     dispatch_by=None,
     partition_size=None,
+    dispatch_metadata=True,
 ):
     """
     Retrieve dataset as `dask.bag.Bag` of `MetaPartition` objects.
@@ -72,19 +80,37 @@ def read_dataset_as_metapartitions_bag(
         A dask.bag object containing the metapartions.
     """
     ds_factory = _ensure_factory(
-        dataset_uuid=dataset_uuid, store=store, factory=factory,
+        dataset_uuid=dataset_uuid,
+        store=store,
+        factory=factory,
+        load_dataset_metadata=load_dataset_metadata,
     )
+
+    if len(ds_factory.tables) > 1:
+        warnings.warn(
+            "Trying to read a dataset with multiple internal tables. This functionality will be removed in the next "
+            "major release. If you require a multi tabled data format, we recommend to switch to the kartothek Cube "
+            "functionality. "
+            "https://kartothek.readthedocs.io/en/stable/guide/cube/kartothek_cubes.html",
+            DeprecationWarning,
+        )
 
     store = ds_factory.store_factory
     mps = dispatch_metapartitions_from_factory(
-        dataset_factory=ds_factory, predicates=predicates, dispatch_by=dispatch_by,
+        dataset_factory=ds_factory,
+        concat_partitions_on_primary_index=concat_partitions_on_primary_index,
+        label_filter=label_filter,
+        predicates=predicates,
+        dispatch_by=dispatch_by,
+        dispatch_metadata=dispatch_metadata,
     )
-    mp_bag = db.from_sequence(mps, partition_size=partition_size)
+    mps = db.from_sequence(mps, partition_size=partition_size)
 
-    if dispatch_by is not None:
-        mp_bag = mp_bag.map(
+    if concat_partitions_on_primary_index or dispatch_by is not None:
+        mps = mps.map(
             _load_and_concat_metapartitions_inner,
             store=store,
+            tables=tables,
             columns=columns,
             categoricals=categoricals,
             predicate_pushdown_to_io=predicate_pushdown_to_io,
@@ -92,9 +118,10 @@ def read_dataset_as_metapartitions_bag(
             predicates=predicates,
         )
     else:
-        mp_bag = mp_bag.map(
+        mps = mps.map(
             MetaPartition.load_dataframes,
             store=store,
+            tables=tables,
             columns=columns,
             categoricals=categoricals,
             predicate_pushdown_to_io=predicate_pushdown_to_io,
@@ -107,25 +134,28 @@ def read_dataset_as_metapartitions_bag(
     )
 
     if categoricals_from_index:
-
-        mp_bag = mp_bag.map(
-            MetaPartition.apply,
-            func=partial(
-                _cast_categorical_to_index_cat, categories=categoricals_from_index
-            ),
-            type_safe=True,
+        func_dict = defaultdict(_identity)
+        func_dict.update(
+            {
+                table: partial(_cast_categorical_to_index_cat, categories=cats)
+                for table, cats in categoricals_from_index.items()
+            }
         )
-    return mp_bag
+        mps = mps.map(MetaPartition.apply, func_dict, type_safe=True)
+    return mps
 
 
 @default_docs
 def read_dataset_as_dataframe_bag(
     dataset_uuid=None,
     store=None,
+    tables=None,
     columns=None,
+    concat_partitions_on_primary_index=False,
     predicate_pushdown_to_io=True,
     categoricals=None,
-    dates_as_object: bool = True,
+    label_filter=None,
+    dates_as_object=False,
     predicates=None,
     factory=None,
     dispatch_by=None,
@@ -146,13 +176,18 @@ def read_dataset_as_dataframe_bag(
         dataset_uuid=dataset_uuid,
         store=store,
         factory=factory,
+        tables=tables,
         columns=columns,
+        concat_partitions_on_primary_index=concat_partitions_on_primary_index,
         predicate_pushdown_to_io=predicate_pushdown_to_io,
         categoricals=categoricals,
+        label_filter=label_filter,
         dates_as_object=dates_as_object,
+        load_dataset_metadata=False,
         predicates=predicates,
         dispatch_by=dispatch_by,
         partition_size=partition_size,
+        dispatch_metadata=False,
     )
     return mps.map(_get_data)
 
@@ -171,7 +206,6 @@ def store_bag_as_dataset(
     partition_on=None,
     metadata_storage_format=naming.DEFAULT_METADATA_STORAGE_FORMAT,
     secondary_indices=None,
-    table_name: str = SINGLE_TABLE,
 ):
     """
     Transform and store a dask.bag of dictionaries containing
@@ -197,9 +231,7 @@ def store_bag_as_dataset(
     raise_if_indices_overlap(partition_on, secondary_indices)
 
     input_to_mps = partial(
-        parse_input_to_metapartition,
-        metadata_version=metadata_version,
-        table_name=table_name,
+        parse_input_to_metapartition, metadata_version=metadata_version
     )
     mps = bag.map(input_to_mps)
 
@@ -247,11 +279,17 @@ def build_dataset_indices__bag(
 
     """
     ds_factory = _ensure_factory(
-        dataset_uuid=dataset_uuid, store=store, factory=factory,
+        dataset_uuid=dataset_uuid,
+        store=store,
+        factory=factory,
+        load_dataset_metadata=False,
     )
 
-    assert ds_factory.schema is not None
-    cols_to_load = set(columns) & set(ds_factory.schema.names)
+    cols_to_load = {
+        table: set(columns) & set(meta.names)
+        for table, meta in ds_factory.table_meta.items()
+    }
+    cols_to_load = {table: cols for table, cols in cols_to_load.items() if cols}
 
     mps = dispatch_metapartitions_from_factory(ds_factory)
 
@@ -260,6 +298,7 @@ def build_dataset_indices__bag(
         .map(
             MetaPartition.load_dataframes,
             store=ds_factory.store_factory,
+            tables=list(cols_to_load.keys()),
             columns=cols_to_load,
         )
         .map(MetaPartition.build_indices, columns=columns)

--- a/kartothek/io/dask/common_cube.py
+++ b/kartothek/io/dask/common_cube.py
@@ -35,7 +35,6 @@ from kartothek.io_components.cube.write import (
     prepare_ktk_partition_on,
 )
 from kartothek.io_components.metapartition import (
-    SINGLE_TABLE,
     MetaPartition,
     parse_input_to_metapartition,
 )
@@ -61,7 +60,7 @@ def ensure_valid_cube_indices(
 ) -> Cube:
     """
     Parse all existing datasets and infer the required set of indices. We do not
-    allow indices to be removed or added in update steps at the moment and
+    allow indices to be removed or added in update steps at the momenent and
     need to make sure that existing ones are updated properly.
     The returned `Cube` instance will be a copy of the input with
     `index_columns` and `suppress_index_on` fields adjusted to reflect the
@@ -69,14 +68,14 @@ def ensure_valid_cube_indices(
     """
     dataset_indices = []
     for ds in existing_datasets.values():
-        assert ds.schema is not None
-        dataset_columns = set(ds.schema.names)
-        table_indices = cube.index_columns & dataset_columns
-        compatible_indices = _ensure_compatible_indices(ds, table_indices)
-        dataset_indices.append(set(compatible_indices))
+        for internal_table in ds.table_meta:
+            dataset_columns = set(ds.table_meta[internal_table].names)
+            table_indices = cube.index_columns & dataset_columns
+            compatible_indices = _ensure_compatible_indices(ds, table_indices)
+            if compatible_indices:
+                dataset_indices.append(set(compatible_indices))
     required_indices = cube.index_columns.union(*dataset_indices)
     suppress_index_on = cube.suppress_index_on.difference(*dataset_indices)
-
     # Need to remove dimension columns since they *are* technically indices but
     # the cube interface class declares them as not indexed just to add them
     # later on, assuming it is not blacklisted
@@ -645,7 +644,7 @@ def _multiplex_parse_input_to_metapartition(data):
     for k in sorted(data.keys()):
         v = data.pop(k)
         result[k] = parse_input_to_metapartition(
-            v, metadata_version=KTK_CUBE_METADATA_VERSION, table_name=SINGLE_TABLE
+            v, metadata_version=KTK_CUBE_METADATA_VERSION
         )
         del v
     return result

--- a/kartothek/io/testing/build_cube.py
+++ b/kartothek/io/testing/build_cube.py
@@ -11,10 +11,12 @@ from kartothek.core.cube.constants import (
     KTK_CUBE_METADATA_KEY_IS_SEED,
     KTK_CUBE_METADATA_PARTITION_COLUMNS,
     KTK_CUBE_METADATA_SUPPRESS_INDEX_ON,
+    KTK_CUBE_METADATA_VERSION,
 )
 from kartothek.core.cube.cube import Cube
 from kartothek.core.dataset import DatasetMetadata
 from kartothek.core.index import ExplicitSecondaryIndex, PartitionIndex
+from kartothek.io.eager import store_dataframes_as_dataset
 from kartothek.io.testing.utils import assert_num_row_groups
 from kartothek.io_components.cube.write import MultiTableCommitAborted
 from kartothek.io_components.metapartition import SINGLE_TABLE
@@ -57,6 +59,7 @@ __all__ = (
     "test_nones",
     "test_overwrite",
     "test_overwrite_rollback_ktk_cube",
+    "test_overwrite_rollback_ktk",
     "test_parquet",
     "test_partition_on_enrich_extra",
     "test_partition_on_enrich_none",
@@ -91,7 +94,7 @@ def test_simple_seed_only(driver, function_store):
     assert isinstance(ds.indices["p"], PartitionIndex)
     assert isinstance(ds.indices["x"], ExplicitSecondaryIndex)
 
-    assert ds.table_name == SINGLE_TABLE
+    assert set(ds.table_meta) == {SINGLE_TABLE}
 
 
 def test_simple_two_datasets(driver, function_store):
@@ -132,8 +135,8 @@ def test_simple_two_datasets(driver, function_store):
     assert set(ds_enrich.indices.keys()) == {"p"}
     assert isinstance(ds_enrich.indices["p"], PartitionIndex)
 
-    assert ds_source.table_name == SINGLE_TABLE
-    assert ds_enrich.table_name == SINGLE_TABLE
+    assert set(ds_source.table_meta) == {SINGLE_TABLE}
+    assert set(ds_enrich.table_meta) == {SINGLE_TABLE}
 
 
 def test_indices(driver, function_store):
@@ -1030,7 +1033,6 @@ def test_fails_null_index(driver, function_store):
     assert not DatasetMetadata.exists(cube.ktk_dataset_uuid("seed"), function_store())
 
 
-@pytest.mark.xfail(reason="different")
 def test_fail_all_empty(driver, driver_name, function_store):
     """
     Might happen due to DB-based filters.
@@ -1129,7 +1131,81 @@ def test_overwrite_rollback_ktk_cube(driver, function_store):
     assert isinstance(ds_enrich.indices["p"], PartitionIndex)
     assert set(ds_enrich.indices["i2"].index_dct.keys()) == {20, 21, 22, 23}
 
-    assert ds_source.schema.field("v1").type == pa.int64()
+    assert ds_source.table_meta[SINGLE_TABLE].field("v1").type == pa.int64()
+
+
+def test_overwrite_rollback_ktk(driver, function_store):
+    """
+    Checks that require a rollback (like overlapping columns) should recover the former state correctly.
+    """
+    cube = Cube(
+        dimension_columns=["x"],
+        partition_columns=["p"],
+        uuid_prefix="cube",
+        seed_dataset="source",
+        index_columns=["i1", "i2", "i3", "i4"],
+    )
+
+    df_source1 = pd.DataFrame(
+        {
+            "x": [0, 1, 2, 3],
+            "p": [0, 0, 1, 1],
+            "v1": [10, 11, 12, 13],
+            "i1": [10, 11, 12, 13],
+        }
+    )
+    df_enrich1 = pd.DataFrame(
+        {
+            "x": [0, 1, 2, 3],
+            "p": [0, 0, 1, 1],
+            "i2": [20, 21, 22, 23],
+            "v1": [20, 21, 22, 23],
+        }
+    )
+    store_dataframes_as_dataset(
+        dfs=[{"ktk_source": df_source1, "ktk_enrich": df_enrich1}],
+        store=function_store,
+        dataset_uuid=cube.ktk_dataset_uuid(cube.seed_dataset),
+        metadata_version=KTK_CUBE_METADATA_VERSION,
+        secondary_indices=["i1", "i2"],
+    )
+
+    df_source2 = pd.DataFrame(
+        {
+            "x": [10, 11],
+            "p": [10, 10],
+            "v1": [10.0, 11.0],  # also use another dtype here (was int)
+            "i3": [10, 11],
+        }
+    )
+    df_enrich2 = pd.DataFrame(
+        {
+            "x": [10, 11],
+            "p": [10, 10],
+            "v1": [20.0, 21.0],  # also use another dtype here (was int)
+            "i4": [20, 21],
+        }
+    )
+    with pytest.raises(MultiTableCommitAborted) as exc_info:
+        driver(
+            data={"source": df_source2, "enrich": df_enrich2},
+            cube=cube,
+            store=function_store,
+            overwrite=True,
+        )
+    cause = exc_info.value.__cause__
+    assert str(cause).startswith("Found columns present in multiple datasets:")
+
+    ds_source = DatasetMetadata.load_from_store(
+        uuid=cube.ktk_dataset_uuid(cube.seed_dataset), store=function_store()
+    ).load_all_indices(function_store())
+
+    assert ds_source.uuid == cube.ktk_dataset_uuid(cube.seed_dataset)
+
+    assert len(ds_source.partitions) == 1
+
+    assert ds_source.table_meta["ktk_source"].field("v1").type == pa.int64()
+    assert ds_source.table_meta["ktk_enrich"].field("v1").type == pa.int64()
 
 
 @pytest.mark.parametrize("none_first", [False, True])
@@ -1158,7 +1234,7 @@ def test_nones(driver, function_store, none_first, driver_name):
     assert isinstance(ds.indices["p"], PartitionIndex)
     assert isinstance(ds.indices["x"], ExplicitSecondaryIndex)
 
-    assert ds.table_name == SINGLE_TABLE
+    assert set(ds.table_meta) == {SINGLE_TABLE}
 
 
 def test_fail_not_a_df(driver, function_store):
@@ -1338,8 +1414,8 @@ def test_partition_on_enrich_none(driver, function_store):
 
     assert set(ds_enrich.indices.keys()) == set()
 
-    assert ds_source.table_name == SINGLE_TABLE
-    assert ds_enrich.table_name == SINGLE_TABLE
+    assert set(ds_source.table_meta) == {SINGLE_TABLE}
+    assert set(ds_enrich.table_meta) == {SINGLE_TABLE}
 
 
 def test_partition_on_enrich_extra(driver, function_store):
@@ -1381,8 +1457,8 @@ def test_partition_on_enrich_extra(driver, function_store):
     assert isinstance(ds_enrich.indices["p"], PartitionIndex)
     assert isinstance(ds_enrich.indices["x"], PartitionIndex)
 
-    assert ds_source.table_name == SINGLE_TABLE
-    assert ds_enrich.table_name == SINGLE_TABLE
+    assert set(ds_source.table_meta) == {SINGLE_TABLE}
+    assert set(ds_enrich.table_meta) == {SINGLE_TABLE}
 
 
 def test_partition_on_index_column(driver, function_store):
@@ -1424,8 +1500,8 @@ def test_partition_on_index_column(driver, function_store):
     assert set(ds_enrich.indices.keys()) == {"i"}
     assert isinstance(ds_enrich.indices["i"], PartitionIndex)
 
-    assert ds_source.table_name == SINGLE_TABLE
-    assert ds_enrich.table_name == SINGLE_TABLE
+    assert set(ds_source.table_meta) == {SINGLE_TABLE}
+    assert set(ds_enrich.table_meta) == {SINGLE_TABLE}
 
 
 def test_fail_partition_on_nondistinc_payload(driver, function_store):

--- a/kartothek/io/testing/cleanup_cube.py
+++ b/kartothek/io/testing/cleanup_cube.py
@@ -2,7 +2,7 @@
 import pandas as pd
 import pytest
 
-from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPARATOR
+from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPERATOR
 from kartothek.core.cube.cube import Cube
 from kartothek.io.eager_cube import build_cube, copy_cube
 
@@ -185,7 +185,7 @@ def test_additional_files(driver, function_store):
     key_in_ds = cube.ktk_dataset_uuid(cube.seed_dataset) + "/foo"
     key_with_ds_prefix = cube.ktk_dataset_uuid(cube.seed_dataset) + ".foo"
     key_with_cube_prefix = cube.uuid_prefix + ".foo"
-    key_with_cube_prefix_separator = cube.uuid_prefix + KTK_CUBE_UUID_SEPARATOR + ".foo"
+    key_with_cube_prefix_separator = cube.uuid_prefix + KTK_CUBE_UUID_SEPERATOR + ".foo"
 
     function_store().put(key_in_ds, b"")
     function_store().put(key_with_ds_prefix, b"")

--- a/kartothek/io/testing/extend_cube.py
+++ b/kartothek/io/testing/extend_cube.py
@@ -81,7 +81,7 @@ def test_simple(driver, function_store, existing_cube):
     assert isinstance(ds.indices["p"], PartitionIndex)
     assert isinstance(ds.indices["i3"], ExplicitSecondaryIndex)
 
-    assert ds.table_name == SINGLE_TABLE
+    assert set(ds.table_meta) == {SINGLE_TABLE}
 
 
 @pytest.mark.parametrize("chunk_size", [None, 2])

--- a/kartothek/io/testing/index.py
+++ b/kartothek/io/testing/index.py
@@ -5,6 +5,7 @@ import pytest
 from toolz.dicttoolz import valmap
 
 from kartothek.core.factory import DatasetFactory
+from kartothek.core.index import ExplicitSecondaryIndex
 from kartothek.io.eager import store_dataframes_as_dataset
 
 
@@ -17,8 +18,8 @@ def assert_index_dct_equal(dict1, dict2):
 def test_build_indices(store_factory, metadata_version, bound_build_dataset_indices):
     dataset_uuid = "dataset_uuid"
     partitions = [
-        pd.DataFrame({"p": [1, 2]}),
-        pd.DataFrame({"p": [2, 3]}),
+        {"label": "cluster_1", "data": [("core", pd.DataFrame({"p": [1, 2]}))]},
+        {"label": "cluster_2", "data": [("core", pd.DataFrame({"p": [2, 3]}))]},
     ]
 
     dataset = store_dataframes_as_dataset(
@@ -35,15 +36,8 @@ def test_build_indices(store_factory, metadata_version, bound_build_dataset_indi
 
     # Assert indices are properly created
     dataset_factory = DatasetFactory(dataset_uuid, store_factory, load_all_indices=True)
-    index_dct = dataset_factory.indices["p"].index_dct
-
-    assert len(index_dct[1]) == 1
-    assert len(index_dct[2]) == 2
-    assert len(index_dct[3]) == 1
-
-    assert len(set(index_dct[3]) & set(index_dct[2])) == 1
-    assert len(set(index_dct[1]) & set(index_dct[2])) == 1
-    assert len(set(index_dct[1]) & set(index_dct[3])) == 0
+    expected = {2: ["cluster_1", "cluster_2"], 3: ["cluster_2"], 1: ["cluster_1"]}
+    assert_index_dct_equal(expected, dataset_factory.indices["p"].index_dct)
 
 
 def test_create_index_from_inexistent_column_fails(
@@ -51,8 +45,8 @@ def test_create_index_from_inexistent_column_fails(
 ):
     dataset_uuid = "dataset_uuid"
     partitions = [
-        pd.DataFrame({"p": [1, 2]}),
-        pd.DataFrame({"p": [2, 3]}),
+        {"label": "cluster_1", "data": [("core", pd.DataFrame({"p": [1, 2]}))]},
+        {"label": "cluster_2", "data": [("core", pd.DataFrame({"p": [2, 3]}))]},
     ]
 
     store_dataframes_as_dataset(
@@ -71,8 +65,24 @@ def test_add_column_to_existing_index(
 ):
     dataset_uuid = "dataset_uuid"
     partitions = [
-        pd.DataFrame({"p": [1, 2], "x": [100, 4500]}),
-        pd.DataFrame({"p": [4, 3], "x": [500, 10]}),
+        {
+            "label": "cluster_1",
+            "data": [("core", pd.DataFrame({"p": [1, 2], "x": [100, 4500]}))],
+            "indices": {
+                "p": ExplicitSecondaryIndex(
+                    "p", index_dct={1: ["cluster_1"], 2: ["cluster_1"]}
+                )
+            },
+        },
+        {
+            "label": "cluster_2",
+            "data": [("core", pd.DataFrame({"p": [4, 3], "x": [500, 10]}))],
+            "indices": {
+                "p": ExplicitSecondaryIndex(
+                    "p", index_dct={4: ["cluster_2"], 3: ["cluster_2"]}
+                )
+            },
+        },
     ]
 
     dataset = store_dataframes_as_dataset(
@@ -80,7 +90,6 @@ def test_add_column_to_existing_index(
         store=store_factory,
         dataset_uuid=dataset_uuid,
         metadata_version=metadata_version,
-        secondary_indices="p",
     )
     assert dataset.load_all_indices(store=store_factory()).indices.keys() == {"p"}
 
@@ -105,17 +114,20 @@ def test_indices_uints(store_factory, metadata_version, bound_build_dataset_indi
     p3 = 17128351978467489013
 
     partitions = [
-        pd.DataFrame({"p": pd.Series([p1], dtype=np.uint64)}),
-        pd.DataFrame({"p": pd.Series([p2], dtype=np.uint64)}),
-        pd.DataFrame({"p": pd.Series([p3], dtype=np.uint64)}),
+        {
+            "label": "cluster_1",
+            "data": [("core", pd.DataFrame({"p": pd.Series([p1], dtype=np.uint64)}))],
+        },
+        {
+            "label": "cluster_2",
+            "data": [("core", pd.DataFrame({"p": pd.Series([p2], dtype=np.uint64)}))],
+        },
+        {
+            "label": "cluster_3",
+            "data": [("core", pd.DataFrame({"p": pd.Series([p3], dtype=np.uint64)}))],
+        },
     ]
-
-    def assert_expected(index_dct):
-        assert len(index_dct) == 3
-        referenced_partitions = []
-        for val in index_dct.values():
-            referenced_partitions.extend(val)
-        assert len(referenced_partitions) == 3
+    expected = {p1: ["cluster_1"], p2: ["cluster_2"], p3: ["cluster_3"]}
 
     dataset = store_dataframes_as_dataset(
         dfs=partitions,
@@ -131,24 +143,30 @@ def test_indices_uints(store_factory, metadata_version, bound_build_dataset_indi
 
     # Assert indices are properly created
     dataset_factory = DatasetFactory(dataset_uuid, store_factory, load_all_indices=True)
-    assert_expected(dataset_factory.indices["p"].index_dct)
-    first_run = dataset_factory.indices["p"].index_dct.copy()
+    assert_index_dct_equal(expected, dataset_factory.indices["p"].index_dct)
 
     # Re-create indices
     bound_build_dataset_indices(store_factory, dataset_uuid, columns=["p"])
 
     # Assert indices are properly created
     dataset_factory = DatasetFactory(dataset_uuid, store_factory, load_all_indices=True)
-    assert_index_dct_equal(first_run, dataset_factory.indices["p"].index_dct)
+    assert_index_dct_equal(expected, dataset_factory.indices["p"].index_dct)
 
 
 def test_empty_partitions(store_factory, metadata_version, bound_build_dataset_indices):
     dataset_uuid = "dataset_uuid"
 
     partitions = [
-        pd.DataFrame({"p": pd.Series([], dtype=np.int8)}),
-        pd.DataFrame({"p": pd.Series([1], dtype=np.int8)}),
+        {
+            "label": "cluster_1",
+            "data": [("core", pd.DataFrame({"p": pd.Series([], dtype=np.int8)}))],
+        },
+        {
+            "label": "cluster_2",
+            "data": [("core", pd.DataFrame({"p": pd.Series([1], dtype=np.int8)}))],
+        },
     ]
+    expected = {1: ["cluster_2"]}
 
     dataset = store_dataframes_as_dataset(
         dfs=partitions,
@@ -164,4 +182,4 @@ def test_empty_partitions(store_factory, metadata_version, bound_build_dataset_i
 
     # Assert indices are properly created
     dataset_factory = DatasetFactory(dataset_uuid, store_factory, load_all_indices=True)
-    assert len(dataset_factory.indices["p"].index_dct) == 1
+    assert_index_dct_equal(expected, dataset_factory.indices["p"].index_dct)

--- a/kartothek/io/testing/merge.py
+++ b/kartothek/io/testing/merge.py
@@ -1,0 +1,91 @@
+from collections import OrderedDict
+from datetime import date
+
+import pandas as pd
+import pandas.testing as pdt
+
+from kartothek.io_components.metapartition import SINGLE_TABLE
+
+MERGE_TASKS = [
+    {
+        "left": SINGLE_TABLE,
+        "right": "helper",
+        "merge_kwargs": {"how": "left", "sort": False, "copy": False},
+        "output_label": "first_output",
+    },
+    {
+        "left": "first_output",
+        "right": "PRED",
+        "merge_kwargs": {"how": "left", "sort": False, "copy": False},
+        "output_label": "final",
+    },
+]
+
+MERGE_EXP_CL1 = pd.DataFrame(
+    OrderedDict(
+        [
+            ("P", [1, 1]),
+            ("L", [1, 1]),
+            ("TARGET", [1, 1]),
+            ("HORIZON", [1, 2]),
+            ("info", ["a", "a"]),
+            ("PRED", [10, 20]),
+            ("DATE", pd.to_datetime([date(2010, 1, 1), date(2010, 1, 1)])),
+        ]
+    )
+)
+
+MERGE_EXP_CL2 = pd.DataFrame(
+    OrderedDict(
+        [
+            ("P", [2, 2]),
+            ("L", [2, 2]),
+            ("TARGET", [2, 2]),
+            ("HORIZON", [1, 2]),
+            ("info", ["b", "b"]),
+            ("PRED", [10, 20]),
+            ("DATE", pd.to_datetime([date(2009, 12, 31), date(2009, 12, 31)])),
+        ]
+    )
+)
+
+
+def test_merge_datasets(
+    dataset,
+    evaluation_dataset,
+    store_factory,
+    store_session_factory,
+    frozen_time,
+    bound_merge_datasets,
+):
+    # In the __pipeline case, we also need to check that the write path is
+    # correct, the tests for it are much larger.
+    df_list = bound_merge_datasets(
+        left_dataset_uuid=dataset.uuid,
+        right_dataset_uuid=evaluation_dataset.uuid,
+        store=store_session_factory,
+        merge_tasks=MERGE_TASKS,
+        match_how="prefix",
+    )
+    df_list = [mp.data for mp in df_list]
+
+    # Two partitions
+    assert len(df_list) == 2
+    assert len(df_list[1]) == 1
+    assert len(df_list[0]) == 1
+    # By using values() this test is agnostic to the used key, which is
+    # currently not of any importance
+    pdt.assert_frame_equal(
+        list(df_list[0].values())[0],
+        MERGE_EXP_CL1,
+        check_like=True,
+        check_dtype=False,
+        check_categorical=False,
+    )
+    pdt.assert_frame_equal(
+        list(df_list[1].values())[0],
+        MERGE_EXP_CL2,
+        check_like=True,
+        check_dtype=False,
+        check_categorical=False,
+    )

--- a/kartothek/io/testing/utils.py
+++ b/kartothek/io/testing/utils.py
@@ -1,10 +1,12 @@
 import math
+import string
 
 import numpy as np
 import pandas as pd
 from pyarrow.parquet import ParquetFile
 
 from kartothek.io.eager import store_dataframes_as_dataset
+from kartothek.io_components.metapartition import SINGLE_TABLE
 
 
 def create_dataset(dataset_uuid, store_factory, metadata_version):
@@ -12,14 +14,28 @@ def create_dataset(dataset_uuid, store_factory, metadata_version):
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
 
-    df_list = [df.copy(deep=True), df.copy(deep=True)]
+    df_helper = pd.DataFrame(
+        {"P": np.arange(0, 10), "info": string.ascii_lowercase[:10]}
+    )
+
+    df_list = [
+        {
+            "label": "cluster_1",
+            "data": [(SINGLE_TABLE, df.copy(deep=True)), ("helper", df_helper)],
+            "indices": {"P": {val: ["cluster_2"] for val in df.TARGET.unique()}},
+        },
+        {
+            "label": "cluster_2",
+            "data": [(SINGLE_TABLE, df.copy(deep=True)), ("helper", df_helper)],
+            "indices": {"P": {val: ["cluster_2"] for val in df.TARGET.unique()}},
+        },
+    ]
 
     return store_dataframes_as_dataset(
         dfs=df_list,
         store=store_factory,
         dataset_uuid=dataset_uuid,
         metadata_version=metadata_version,
-        secondary_indices="P",
     )
 
 

--- a/kartothek/io/testing/write.py
+++ b/kartothek/io/testing/write.py
@@ -2,6 +2,7 @@
 # pylint: disable=E1101
 
 
+import string
 from collections import OrderedDict
 from functools import partial
 
@@ -12,8 +13,8 @@ import pytest
 from storefact import get_store_from_url
 
 from kartothek.core.dataset import DatasetMetadata
+from kartothek.core.index import ExplicitSecondaryIndex
 from kartothek.core.uuid import gen_uuid
-from kartothek.io.eager import read_table
 from kartothek.io_components.metapartition import MetaPartition
 from kartothek.serialization import DataFrameSerializer
 
@@ -72,7 +73,20 @@ def test_file_structure_dataset_v4(store_factory, bound_store_dataframes):
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
 
-    df_list = [df.copy(deep=True), df.copy(deep=True)]
+    df_helper = pd.DataFrame(
+        {"P": np.arange(0, 10), "info": string.ascii_lowercase[:10]}
+    )
+
+    df_list = [
+        {
+            "label": "cluster_1",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+        {
+            "label": "cluster_2",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+    ]
 
     dataset = bound_store_dataframes(
         df_list, store=store_factory, dataset_uuid="dataset_uuid", metadata_version=4
@@ -82,10 +96,19 @@ def test_file_structure_dataset_v4(store_factory, bound_store_dataframes):
     assert len(dataset.partitions) == 2
 
     store = store_factory()
-
-    assert len(store.keys()) == 4
-    assert "dataset_uuid/table/_common_metadata" in store
-    assert "dataset_uuid.by-dataset-metadata.json" in store
+    # TODO: json -> msgpack
+    expected_keys = set(
+        [
+            "dataset_uuid.by-dataset-metadata.json",
+            "dataset_uuid/helper/cluster_1.parquet",
+            "dataset_uuid/helper/cluster_2.parquet",
+            "dataset_uuid/helper/_common_metadata",
+            "dataset_uuid/core/cluster_1.parquet",
+            "dataset_uuid/core/cluster_2.parquet",
+            "dataset_uuid/core/_common_metadata",
+        ]
+    )
+    assert set(expected_keys) == set(store.keys())
 
 
 def test_file_structure_dataset_v4_partition_on(store_factory, bound_store_dataframes):
@@ -94,8 +117,24 @@ def test_file_structure_dataset_v4_partition_on(store_factory, bound_store_dataf
     df = pd.DataFrame(
         {"P": [1, 2, 3, 1, 2, 3], "L": [1, 1, 1, 2, 2, 2], "TARGET": np.arange(10, 16)}
     )
+    df_helper = pd.DataFrame(
+        {
+            "P": [1, 2, 3, 1, 2, 3],
+            "L": [1, 1, 1, 2, 2, 2],
+            "info": string.ascii_lowercase[:2],
+        }
+    )
 
-    df_list = [df.copy(deep=True), df.copy(deep=True)]
+    df_list = [
+        {
+            "label": "cluster_1",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+        {
+            "label": "cluster_2",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+    ]
     dataset = bound_store_dataframes(
         df_list,
         store=store_factory,
@@ -111,8 +150,102 @@ def test_file_structure_dataset_v4_partition_on(store_factory, bound_store_dataf
     assert len(dataset.partitions) == 12
 
     store = store_factory()
-    actual_keys = set(store.keys())
-    assert len(actual_keys) == 14  # one per partition + json + schema
+
+    expected_keys = set(
+        [
+            "dataset_uuid.by-dataset-metadata.json",
+            "dataset_uuid/helper/P=1/L=1/cluster_1.parquet",
+            "dataset_uuid/helper/P=1/L=1/cluster_2.parquet",
+            "dataset_uuid/helper/P=1/L=2/cluster_1.parquet",
+            "dataset_uuid/helper/P=1/L=2/cluster_2.parquet",
+            "dataset_uuid/helper/P=2/L=1/cluster_1.parquet",
+            "dataset_uuid/helper/P=2/L=1/cluster_2.parquet",
+            "dataset_uuid/helper/P=2/L=2/cluster_1.parquet",
+            "dataset_uuid/helper/P=2/L=2/cluster_2.parquet",
+            "dataset_uuid/helper/P=3/L=1/cluster_1.parquet",
+            "dataset_uuid/helper/P=3/L=1/cluster_2.parquet",
+            "dataset_uuid/helper/P=3/L=2/cluster_1.parquet",
+            "dataset_uuid/helper/P=3/L=2/cluster_2.parquet",
+            "dataset_uuid/helper/_common_metadata",
+            "dataset_uuid/core/P=1/L=1/cluster_1.parquet",
+            "dataset_uuid/core/P=1/L=1/cluster_2.parquet",
+            "dataset_uuid/core/P=1/L=2/cluster_1.parquet",
+            "dataset_uuid/core/P=1/L=2/cluster_2.parquet",
+            "dataset_uuid/core/P=2/L=1/cluster_1.parquet",
+            "dataset_uuid/core/P=2/L=1/cluster_2.parquet",
+            "dataset_uuid/core/P=2/L=2/cluster_1.parquet",
+            "dataset_uuid/core/P=2/L=2/cluster_2.parquet",
+            "dataset_uuid/core/P=3/L=1/cluster_1.parquet",
+            "dataset_uuid/core/P=3/L=1/cluster_2.parquet",
+            "dataset_uuid/core/P=3/L=2/cluster_1.parquet",
+            "dataset_uuid/core/P=3/L=2/cluster_2.parquet",
+            "dataset_uuid/core/_common_metadata",
+        ]
+    )
+
+    assert set(expected_keys) == set(store.keys())
+
+
+def test_file_structure_dataset_v4_partition_on_second_table_no_index_col(
+    store_factory, bound_store_dataframes
+):
+    df = pd.DataFrame(
+        {"P": np.arange(0, 2), "L": np.arange(0, 2), "TARGET": np.arange(10, 12)}
+    )
+    df_helper = pd.DataFrame({"P": [0, 0, 1], "info": string.ascii_lowercase[:2]})
+
+    df_list = [
+        {
+            "label": "cluster_1",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+        {
+            "label": "cluster_2",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+    ]
+
+    with pytest.raises(Exception):
+        bound_store_dataframes(
+            df_list,
+            store=store_factory,
+            dataset_uuid="dataset_uuid",
+            partition_on=["P", "L"],
+            metadata_version=4,
+        )
+
+
+def test_file_structure_dataset_v4_partition_on_second_table_no_index_col_simple_group(
+    store_factory, bound_store_dataframes
+):
+    """
+    Pandas seems to stop evaluating the groupby expression if the dataframes after the first column split
+    is of length 1. This seems to be an optimization which should, however, still raise a KeyError
+    """
+    df = pd.DataFrame(
+        {"P": np.arange(0, 2), "L": np.arange(0, 2), "TARGET": np.arange(10, 12)}
+    )
+    df_helper = pd.DataFrame({"P": [0, 1], "info": string.ascii_lowercase[:2]})
+
+    df_list = [
+        {
+            "label": "cluster_1",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+        {
+            "label": "cluster_2",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+    ]
+
+    with pytest.raises(Exception):
+        bound_store_dataframes(
+            df_list,
+            store=store_factory,
+            dataset_uuid="dataset_uuid",
+            partition_on=["P", "L"],
+            metadata_version=4,
+        )
 
 
 def test_store_dataframes_as_dataset(
@@ -122,7 +255,20 @@ def test_store_dataframes_as_dataset(
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
 
-    df_list = [df.copy(deep=True), df.copy(deep=True)]
+    df_helper = pd.DataFrame(
+        {"P": np.arange(0, 10), "info": string.ascii_lowercase[:10]}
+    )
+
+    df_list = [
+        {
+            "label": "cluster_1",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+        {
+            "label": "cluster_2",
+            "data": [("core", df.copy(deep=True)), ("helper", df_helper)],
+        },
+    ]
 
     dataset = bound_store_dataframes(
         df_list,
@@ -145,14 +291,24 @@ def test_store_dataframes_as_dataset(
 
     index_dct = stored_dataset.indices["P"].load(store).index_dct
     assert sorted(index_dct.keys()) == list(range(0, 10))
+    assert any([sorted(p) == ["cluster_1", "cluster_2"] for p in index_dct.values()])
 
-    counter = 0
-    for k in store.keys():
-        if "parquet" in k and "indices" not in k:
-            counter += 1
-            df_stored = DataFrameSerializer.restore_dataframe(key=k, store=store)
-            pdt.assert_frame_equal(df, df_stored)
-    assert counter == 2
+    df_stored = DataFrameSerializer.restore_dataframe(
+        key=dataset.partitions["cluster_1"].files["core"], store=store
+    )
+    pdt.assert_frame_equal(df, df_stored)
+    df_stored = DataFrameSerializer.restore_dataframe(
+        key=dataset.partitions["cluster_2"].files["core"], store=store
+    )
+    pdt.assert_frame_equal(df, df_stored)
+    df_stored = DataFrameSerializer.restore_dataframe(
+        key=dataset.partitions["cluster_1"].files["helper"], store=store
+    )
+    pdt.assert_frame_equal(df_helper, df_stored)
+    df_stored = DataFrameSerializer.restore_dataframe(
+        key=dataset.partitions["cluster_2"].files["helper"], store=store
+    )
+    pdt.assert_frame_equal(df_helper, df_stored)
 
 
 def test_store_dataframes_as_dataset_empty_dataframe(
@@ -164,8 +320,25 @@ def test_store_dataframes_as_dataset_empty_dataframe(
     """
     df_empty = df_all_types.drop(0)
 
+    # Store a second table with shared columns. All shared columns must be of the same type
+    # This may fail in the presence of empty partitions if the schema validation doesn't account for it
+    df_shared_cols = df_all_types.loc[:, df_all_types.columns[:3]]
+    df_shared_cols["different_col"] = "a"
+
     assert df_empty.empty
-    df_list = [df_empty]
+    df_list = [
+        {
+            "label": "cluster_1",
+            "data": [("tableA", df_empty), ("tableB", df_shared_cols.copy(deep=True))],
+        },
+        {
+            "label": "cluster_2",
+            "data": [
+                ("tableA", df_all_types),
+                ("tableB", df_shared_cols.copy(deep=True)),
+            ],
+        },
+    ]
 
     dataset = bound_store_dataframes(
         df_list,
@@ -175,7 +348,7 @@ def test_store_dataframes_as_dataset_empty_dataframe(
     )
 
     assert isinstance(dataset, DatasetMetadata)
-    assert len(dataset.partitions) == 1
+    assert len(dataset.partitions) == 2
 
     store = store_factory()
     stored_dataset = DatasetMetadata.load_from_store("dataset_uuid", store)
@@ -184,28 +357,63 @@ def test_store_dataframes_as_dataset_empty_dataframe(
     assert dataset.partitions == stored_dataset.partitions
 
     df_stored = DataFrameSerializer.restore_dataframe(
-        key=next(iter(dataset.partitions.values())).files["table"], store=store
+        key=dataset.partitions["cluster_1"].files["tableA"], store=store
     )
     pdt.assert_frame_equal(df_empty, df_stored)
+
+    df_stored = DataFrameSerializer.restore_dataframe(
+        key=dataset.partitions["cluster_2"].files["tableA"], store=store
+    )
+    # Roundtrips for type date are not type preserving
+    df_stored["date"] = df_stored["date"].dt.date
+    pdt.assert_frame_equal(df_all_types, df_stored)
+
+    df_stored = DataFrameSerializer.restore_dataframe(
+        key=dataset.partitions["cluster_1"].files["tableB"], store=store
+    )
+    pdt.assert_frame_equal(df_shared_cols, df_stored)
+    df_stored = DataFrameSerializer.restore_dataframe(
+        key=dataset.partitions["cluster_2"].files["tableB"], store=store
+    )
+    pdt.assert_frame_equal(df_shared_cols, df_stored)
 
 
 def test_store_dataframes_as_dataset_batch_mode(
     store_factory, metadata_version, bound_store_dataframes
 ):
-    # TODO: Kick this out?
     values_p1 = [1, 2, 3]
     values_p2 = [4, 5, 6]
     df = pd.DataFrame({"P": values_p1})
     df2 = pd.DataFrame({"P": values_p2})
 
-    df_list = [[df, df2]]
+    df_list = [
+        [
+            {
+                "label": "cluster_1",
+                "data": [("core", df)],
+                "indices": {
+                    "P": ExplicitSecondaryIndex(
+                        "P", {v: ["cluster_1"] for v in values_p1}
+                    )
+                },
+            },
+            {
+                "label": "cluster_2",
+                "data": [("core", df2)],
+                "indices": {
+                    "P": ExplicitSecondaryIndex(
+                        "P", {v: ["cluster_2"] for v in values_p2}
+                    )
+                },
+            },
+        ]
+    ]
 
     dataset = bound_store_dataframes(
         df_list,
         store=store_factory,
         dataset_uuid="dataset_uuid",
         metadata_version=metadata_version,
-        secondary_indices="P",
     )
 
     assert isinstance(dataset, DatasetMetadata)
@@ -219,7 +427,23 @@ def test_store_dataframes_as_dataset_batch_mode(
     assert dataset.metadata == stored_dataset.metadata
     assert dataset.partitions == stored_dataset.partitions
 
-    assert "P" in dataset.indices
+    df_stored = DataFrameSerializer.restore_dataframe(
+        key=dataset.partitions["cluster_1"].files["core"], store=store
+    )
+    pdt.assert_frame_equal(df, df_stored)
+    df_stored = DataFrameSerializer.restore_dataframe(
+        key=dataset.partitions["cluster_2"].files["core"], store=store
+    )
+    pdt.assert_frame_equal(df2, df_stored)
+
+    assert stored_dataset.indices["P"].to_dict() == {
+        1: np.array(["cluster_1"], dtype=object),
+        2: np.array(["cluster_1"], dtype=object),
+        3: np.array(["cluster_1"], dtype=object),
+        4: np.array(["cluster_2"], dtype=object),
+        5: np.array(["cluster_2"], dtype=object),
+        6: np.array(["cluster_2"], dtype=object),
+    }
 
 
 def test_store_dataframes_as_dataset_auto_uuid(
@@ -229,14 +453,33 @@ def test_store_dataframes_as_dataset_auto_uuid(
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
 
-    df_list = [df.copy(deep=True)]
+    df_helper = pd.DataFrame(
+        {"P": np.arange(0, 10), "info": string.ascii_lowercase[:10]}
+    )
+
+    df_list = [
+        {
+            "label": "cluster_1",
+            "data": [
+                ("core", df.copy(deep=True)),
+                ("helper", df_helper.copy(deep=True)),
+            ],
+        },
+        {
+            "label": "cluster_2",
+            "data": [
+                ("core", df.copy(deep=True)),
+                ("helper", df_helper.copy(deep=True)),
+            ],
+        },
+    ]
 
     dataset = bound_store_dataframes(
         df_list, store=store_factory, metadata_version=metadata_version
     )
 
     assert isinstance(dataset, DatasetMetadata)
-    assert len(dataset.partitions) == 1
+    assert len(dataset.partitions) == 2
 
     stored_dataset = DatasetMetadata.load_from_store(
         "auto_dataset_uuid", store_factory()
@@ -246,6 +489,34 @@ def test_store_dataframes_as_dataset_auto_uuid(
     assert dataset.partitions == stored_dataset.partitions
 
 
+def test_store_dataframes_as_dataset_list_input(
+    store_factory, metadata_version, bound_store_dataframes
+):
+    df = pd.DataFrame(
+        {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
+    )
+    df2 = pd.DataFrame(
+        {
+            "P": np.arange(100, 110),
+            "L": np.arange(100, 110),
+            "TARGET": np.arange(10, 20),
+        }
+    )
+    df_list = [df, df2]
+
+    dataset = bound_store_dataframes(
+        df_list,
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        metadata_version=metadata_version,
+    )
+
+    assert isinstance(dataset, DatasetMetadata)
+    assert len(dataset.partitions) == 2
+    stored_dataset = DatasetMetadata.load_from_store("dataset_uuid", store_factory())
+    assert dataset == stored_dataset
+
+
 def test_store_dataframes_as_dataset_mp_partition_on_none(
     metadata_version, store, store_factory, bound_store_dataframes
 ):
@@ -253,7 +524,13 @@ def test_store_dataframes_as_dataset_mp_partition_on_none(
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
 
-    mp = MetaPartition(label=gen_uuid(), data=df, metadata_version=metadata_version)
+    df2 = pd.DataFrame({"P": np.arange(0, 10), "info": np.arange(100, 110)})
+
+    mp = MetaPartition(
+        label=gen_uuid(),
+        data={"core": df, "helper": df2},
+        metadata_version=metadata_version,
+    )
 
     df_list = [None, mp]
     dataset = bound_store_dataframes(
@@ -280,14 +557,24 @@ def test_store_dataframes_partition_on(store_factory, bound_store_dataframes):
     )
 
     # First partition is empty, test this edgecase
-    input_ = [df.head(0), df]
+    input_ = [
+        {
+            "label": "label",
+            "data": [("order_proposals", df.head(0))],
+            "indices": {"location": {}},
+        },
+        {
+            "label": "label",
+            "data": [("order_proposals", df)],
+            "indices": {"location": {k: ["label"] for k in df["location"].unique()}},
+        },
+    ]
     dataset = bound_store_dataframes(
         input_,
         store=store_factory,
         dataset_uuid="dataset_uuid",
         metadata_version=4,
         partition_on=["other"],
-        secondary_indices="location",
     )
 
     assert len(dataset.partitions) == 1
@@ -415,10 +702,11 @@ def _exception_str(exception):
     ],
 )
 def test_schema_check_write(dfs, ok, store_factory, bound_store_dataframes):
+    df_list = [{"label": "cluster_1", "data": [("core", df)]} for df in dfs]
 
     if ok:
         bound_store_dataframes(
-            dfs,
+            df_list,
             store=store_factory,
             dataset_uuid="dataset_uuid",
             partition_on=["P"],
@@ -427,22 +715,41 @@ def test_schema_check_write(dfs, ok, store_factory, bound_store_dataframes):
     else:
         with pytest.raises(Exception) as exc:
             bound_store_dataframes(
-                dfs,
+                df_list,
                 store=store_factory,
                 dataset_uuid="dataset_uuid",
                 partition_on=["P"],
                 metadata_version=4,
             )
         assert (
-            "Schemas for dataset 'dataset_uuid' are not compatible!"
+            "Schemas for table 'core' of dataset 'dataset_uuid' are not compatible!"
             in _exception_str(exc.value)
         )
 
 
-@pytest.mark.xfail(reason="mocking doesn't work for dask atm")
-def test_schema_check_write_nice_error(
-    store_factory, bound_store_dataframes, mock_uuid
-):
+def test_schema_check_write_shared(store_factory, bound_store_dataframes):
+    df1 = pd.DataFrame(
+        {"P": pd.Series([1], dtype=np.int64), "X": pd.Series([1], dtype=np.int64)}
+    )
+    df2 = pd.DataFrame(
+        {"P": pd.Series([1], dtype=np.uint64), "Y": pd.Series([1], dtype=np.int64)}
+    )
+    df_list = [
+        {"label": "cluster_1", "data": [("core", df1)]},
+        {"label": "cluster_2", "data": [("prediction", df2)]},
+    ]
+    with pytest.raises(Exception) as exc:
+        bound_store_dataframes(
+            df_list,
+            store=store_factory,
+            dataset_uuid="dataset_uuid",
+            partition_on=["P"],
+            metadata_version=4,
+        )
+    assert 'Found incompatible entries for column "P"' in str(exc.value)
+
+
+def test_schema_check_write_nice_error(store_factory, bound_store_dataframes):
     df1 = pd.DataFrame(
         {
             "P": pd.Series([1, 1], dtype=np.int64),
@@ -458,8 +765,8 @@ def test_schema_check_write_nice_error(
         }
     )
     df_list = [
-        df1,
-        df2,
+        {"label": "uuid1", "data": [("core", df1)]},
+        {"label": "uuid2", "data": [("core", df2)]},
     ]
     with pytest.raises(Exception) as exc:
         bound_store_dataframes(
@@ -469,22 +776,20 @@ def test_schema_check_write_nice_error(
             partition_on=["P", "Q"],
             metadata_version=4,
         )
-
     assert _exception_str(exc.value).startswith(
-        """Schemas for dataset 'dataset_uuid' are not compatible!
+        """Schemas for table 'core' of dataset 'dataset_uuid' are not compatible!
 
 Schema violation
 
-Origin schema: {P=2/Q=2/auto_dataset_uuid}
-Origin reference: {P=1/Q=2/auto_dataset_uuid}
+Origin schema: {core/P=2/Q=2/uuid2}
+Origin reference: {core/P=1/Q=2/uuid1}
 
 Diff:
 """
     )
 
 
-@pytest.mark.xfail(reason="mocking doesn't work for dask atm")
-def test_schema_check_write_cut_error(store_factory, bound_store_dataframes, mock_uuid):
+def test_schema_check_write_cut_error(store_factory, bound_store_dataframes):
     df1 = pd.DataFrame(
         {
             "P": pd.Series([1] * 100, dtype=np.int64),
@@ -500,8 +805,8 @@ def test_schema_check_write_cut_error(store_factory, bound_store_dataframes, moc
         }
     )
     df_list = [
-        df1,
-        df2,
+        {"label": "uuid1", "data": [("core", df1)]},
+        {"label": "uuid2", "data": [("core", df2)]},
     ]
     with pytest.raises(Exception) as exc:
         bound_store_dataframes(
@@ -512,12 +817,12 @@ def test_schema_check_write_cut_error(store_factory, bound_store_dataframes, moc
             metadata_version=4,
         )
     assert _exception_str(exc.value).startswith(
-        """Schemas for dataset 'dataset_uuid' are not compatible!
+        """Schemas for table 'core' of dataset 'dataset_uuid' are not compatible!
 
 Schema violation
 
-Origin schema: {P=2/Q=99/auto_dataset_uuid}
-Origin reference: {P=1/Q=99/auto_dataset_uuid}
+Origin schema: {core/P=2/Q=99/uuid2}
+Origin reference: {core/P=1/Q=99/uuid1}
 
 Diff:
 """
@@ -533,16 +838,41 @@ def test_metadata_consistency_errors_fails(
         {"P": np.arange(10, 20), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
 
-    df_list = [df, df_2]
+    df_list = [
+        {"label": "cluster_1", "data": [("core", df)]},
+        {"label": "cluster_2", "data": [("core", df_2)]},
+    ]
 
     # Also test `df_list` in reverse order, as this could lead to different results
     for dfs in [df_list, list(reversed(df_list))]:
         with pytest.raises(
-            Exception, match=r"Schemas for dataset .* are not compatible!"
+            Exception, match=r"Schemas for table .* of dataset .* are not compatible!"
         ):
             return bound_store_dataframes(
                 dfs, store=store_factory, metadata_version=metadata_version
             )
+
+
+def test_table_consistency_resistance(
+    store_factory, metadata_version, bound_store_dataframes
+):
+    df = pd.DataFrame({"P": np.arange(0, 10)})
+
+    df_helper = pd.DataFrame(
+        {"P": np.arange(15, 35), "info": string.ascii_lowercase[:10]}
+    )
+
+    df_list = [
+        {"label": "cluster_1", "data": [("core", df)]},
+        {"label": "cluster_2", "data": [("core", df), ("helper", df_helper)]},
+    ]
+
+    store_kwargs = dict(store=store_factory, metadata_version=metadata_version)
+    metadata1 = bound_store_dataframes(df_list, **store_kwargs)
+
+    metadata2 = bound_store_dataframes(list(reversed(df_list)), **store_kwargs)
+
+    assert set(metadata1.tables) == set(metadata2.tables) == {"core", "helper"}
 
 
 def test_store_dataframes_as_dataset_overwrite(
@@ -563,14 +893,13 @@ def test_store_dataframes_as_dataset_overwrite(
     )
 
 
-@pytest.mark.skip("What is the intended behaviour for this?")
 def test_store_empty_dataframes_partition_on(store_factory, bound_store_dataframes):
     df1 = pd.DataFrame({"x": [1], "y": [1]}).iloc[[]]
     md1 = bound_store_dataframes(
         [df1], store=store_factory, dataset_uuid="uuid", partition_on=["x"]
     )
     assert md1.tables == ["table"]
-    assert set(md1.schema.names) == set(df1.columns)
+    assert set(md1.table_meta["table"].names) == set(df1.columns)
 
     df2 = pd.DataFrame({"x": [1], "y": [1], "z": [1]}).iloc[[]]
     md2 = bound_store_dataframes(
@@ -581,7 +910,7 @@ def test_store_empty_dataframes_partition_on(store_factory, bound_store_datafram
         overwrite=True,
     )
     assert md2.tables == ["table"]
-    assert set(md2.schema.names) == set(df2.columns)
+    assert set(md2.table_meta["table"].names) == set(df2.columns)
 
     df3 = pd.DataFrame({"x": [1], "y": [1], "a": [1]}).iloc[[]]
     md3 = bound_store_dataframes(
@@ -592,20 +921,19 @@ def test_store_empty_dataframes_partition_on(store_factory, bound_store_datafram
         overwrite=True,
     )
     assert md3.tables == ["table2"]
-    assert set(md3.schema.names) == set(df3.columns)
+    assert set(md3.table_meta["table2"].names) == set(df3.columns)
 
 
-@pytest.mark.skip("What is the intended behaviour for this?")
 def test_store_overwrite_none(store_factory, bound_store_dataframes):
     df1 = pd.DataFrame({"x": [1], "y": [1]})
     md1 = bound_store_dataframes(
         [df1], store=store_factory, dataset_uuid="uuid", partition_on=["x"]
     )
     assert md1.tables == ["table"]
-    assert set(md1.schema.names) == set(df1.columns)
+    assert set(md1.table_meta["table"].names) == set(df1.columns)
 
     md2 = bound_store_dataframes(
-        [None],
+        [{}],
         store=store_factory,
         dataset_uuid="uuid",
         partition_on=["x"],
@@ -622,16 +950,3 @@ def test_secondary_index_on_partition_column(store_factory, bound_store_datafram
         bound_store_dataframes(
             [df1], store=store_factory, partition_on=["x"], secondary_indices=["x"]
         )
-
-
-def test_non_default_table_name_roundtrip(store_factory, bound_store_dataframes):
-    df = pd.DataFrame({"A": [1]})
-    bound_store_dataframes(
-        [df], store=store_factory, dataset_uuid="dataset_uuid", table_name="foo"
-    )
-    for k in store_factory():
-        if k.endswith(".parquet") and "indices" not in k:
-            assert "foo" in k
-    result = read_table(dataset_uuid="dataset_uuid", store=store_factory)
-
-    pdt.assert_frame_equal(df, result)

--- a/kartothek/io_components/cube/cleanup.py
+++ b/kartothek/io_components/cube/cleanup.py
@@ -1,6 +1,6 @@
 from functools import reduce
 
-from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPARATOR
+from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPERATOR
 from kartothek.utils.ktk_adapters import get_dataset_keys
 
 __all__ = ("get_keys_to_clean",)
@@ -27,7 +27,7 @@ def get_keys_to_clean(cube_uuid_prefix, datasets, store):
     )
 
     keys_present = {
-        k for k in store.iter_keys(cube_uuid_prefix + KTK_CUBE_UUID_SEPARATOR)
+        k for k in store.iter_keys(cube_uuid_prefix + KTK_CUBE_UUID_SEPERATOR)
     }
 
     return keys_present - keys_should

--- a/kartothek/io_components/cube/query/__init__.py
+++ b/kartothek/io_components/cube/query/__init__.py
@@ -21,6 +21,7 @@ from kartothek.io_components.cube.query._intention import (
     determine_intention,
 )
 from kartothek.io_components.cube.query._regroup import regroup
+from kartothek.io_components.metapartition import SINGLE_TABLE
 from kartothek.utils.ktk_adapters import get_dataset_columns
 
 __all__ = ("QueryGroup", "QueryIntention", "load_group", "plan_query", "quick_concat")
@@ -332,7 +333,7 @@ def plan_query(
     empty_df = {
         ktk_cube_dataset_id: _reduce_empty_dtype_sizes(
             empty_dataframe_from_schema(
-                schema=ds.schema,
+                schema=ds.table_meta[SINGLE_TABLE],
                 columns=sorted(
                     get_dataset_columns(ds) & set(load_columns[ktk_cube_dataset_id])
                 ),

--- a/kartothek/io_components/cube/query/_group.py
+++ b/kartothek/io_components/cube/query/_group.py
@@ -6,7 +6,7 @@ import typing
 import attr
 import pandas as pd
 
-from kartothek.io_components.metapartition import MetaPartition
+from kartothek.io_components.metapartition import SINGLE_TABLE, MetaPartition
 from kartothek.utils.converters import converter_str
 from kartothek.utils.pandas import (
     concat_dataframes,
@@ -85,10 +85,11 @@ def _load_all_mps(mps, store, load_columns, predicates, empty):
         mp = mp.load_dataframes(
             store=store,
             predicate_pushdown_to_io=True,
-            columns=sorted(load_columns),
+            tables=[SINGLE_TABLE],
+            columns={SINGLE_TABLE: sorted(load_columns)},
             predicates=predicates,
         )
-        df = mp.data
+        df = mp.data[SINGLE_TABLE]
         df.columns = df.columns.map(converter_str)
         dfs_mp.append(df)
     return concat_dataframes(dfs_mp, empty)

--- a/kartothek/io_components/cube/query/_intention.py
+++ b/kartothek/io_components/cube/query/_intention.py
@@ -12,7 +12,7 @@ import pyarrow as pa
 from kartothek.core.cube.conditions import Conjunction
 from kartothek.serialization._parquet import _normalize_value
 from kartothek.utils.converters import converter_str_set, converter_str_tupleset
-from kartothek.utils.ktk_adapters import get_dataset_columns
+from kartothek.utils.ktk_adapters import get_dataset_columns, get_dataset_schema
 
 __all__ = ("QueryIntention", "determine_intention")
 
@@ -120,7 +120,7 @@ def _test_condition_types(conditions, datasets):
 
             for ktk_cube_dataset_id in sorted(datasets.keys()):
                 dataset = datasets[ktk_cube_dataset_id]
-                meta = dataset.schema
+                meta = get_dataset_schema(dataset)
                 if col not in meta.names:
                     continue
                 pa_type = meta.field(col).type

--- a/kartothek/io_components/cube/query/_regroup.py
+++ b/kartothek/io_components/cube/query/_regroup.py
@@ -306,8 +306,8 @@ def _map_ktk_mps_to_groups(cube, datasets, label2gp):
         label2gp_sub = label2gp[ktk_cube_dataset_id]
         for mp in dispatch_metapartitions_from_factory(
             dataset_factory=metadata_factory_from_dataset(ds),
+            concat_partitions_on_primary_index=False,
         ):
-            # FIXME: can this be simplified?
             if mp.label not in label2gp_sub:
                 # filtered out by pre-condition
                 continue

--- a/kartothek/io_components/gc.py
+++ b/kartothek/io_components/gc.py
@@ -7,7 +7,10 @@ from kartothek.core.naming import TABLE_METADATA_FILE
 
 def dispatch_files_to_gc(dataset_uuid, store_factory, chunk_size, factory):
     ds_factory = _ensure_factory(
-        dataset_uuid=dataset_uuid, store=store_factory, factory=factory,
+        dataset_uuid=dataset_uuid,
+        store=store_factory,
+        factory=factory,
+        load_dataset_metadata=False,
     )
     dataset_uuid = dataset_uuid or ds_factory.uuid
 

--- a/kartothek/io_components/merge.py
+++ b/kartothek/io_components/merge.py
@@ -1,0 +1,120 @@
+import logging
+from typing import Callable, Generator, List, Union
+
+from kartothek.core.dataset import DatasetMetadata
+from kartothek.core.typing import StoreInput
+from kartothek.core.utils import ensure_store
+from kartothek.io_components.metapartition import MetaPartition
+
+LOGGER = logging.getLogger(__name__)
+
+try:
+    from typing_extensions import Literal  # type: ignore
+except ImportError:
+    from typing import Literal  # type: ignore
+
+
+def align_datasets(
+    left_dataset_uuid: str,
+    right_dataset_uuid: str,
+    store: StoreInput,
+    match_how: Union[Literal["exact", "prefix", "all"], Callable] = "exact",
+) -> Generator[List[MetaPartition], None, None]:
+    """
+    Determine dataset partition alignment
+
+    Parameters
+    ----------
+    left_dataset_uuid
+    right_dataset_uuid
+    store
+    match_how
+
+
+    Yields
+    ------
+    List
+
+    """
+    store = ensure_store(store)
+    left_dataset = DatasetMetadata.load_from_store(uuid=left_dataset_uuid, store=store)
+    right_dataset = DatasetMetadata.load_from_store(
+        uuid=right_dataset_uuid, store=store
+    )
+
+    metadata_version = left_dataset.metadata_version
+
+    # Loop over the dataset with fewer partitions, treating its keys as
+    # partition label prefixes
+    if (
+        callable(match_how)
+        or match_how == "left"
+        or (
+            match_how == "prefix"
+            and len(list(left_dataset.partitions.keys())[0])
+            < len(list(right_dataset.partitions.keys())[0])
+        )
+    ):
+        first_dataset = left_dataset
+        second_dataset = right_dataset
+    else:
+        first_dataset = right_dataset
+        second_dataset = left_dataset
+    # The del statements are here to reduce confusion below
+    del left_dataset
+    del right_dataset
+
+    # For every partition in the 'small' dataset, at least one partition match
+    # needs to be found in the larger dataset.
+    available_partitions = list(second_dataset.partitions.items())
+    partition_stack = available_partitions[:]
+
+    # TODO: write a test which protects against the following scenario!!
+    # Sort the partition labels by length of the labels, starting with the
+    # labels which are the longest. This way we prevent label matching for
+    # similar partitions, e.g. cluster_100 and cluster_1. This, of course,
+    # works only as long as the internal loop removes elements which were
+    # matched already (here improperly called stack)
+    for l_1 in sorted(first_dataset.partitions, key=len, reverse=True):
+        p_1 = first_dataset.partitions[l_1]
+        res = [
+            MetaPartition.from_partition(
+                partition=p_1, metadata_version=metadata_version
+            )
+        ]
+        for parts in available_partitions:
+            l_2, p_2 = parts
+            if callable(match_how) and not match_how(l_1, l_2):
+                continue
+            if match_how == "exact" and l_1 != l_2:
+                continue
+            elif match_how == "prefix" and not l_2.startswith(l_1):
+                LOGGER.debug("rejecting (%s, %s)", l_1, l_2)
+                continue
+
+            LOGGER.debug(
+                "Found alignment between partitions " "(%s, %s) and" "(%s, %s)",
+                first_dataset.uuid,
+                p_1.label,
+                second_dataset.uuid,
+                p_2.label,
+            )
+            res.append(
+                MetaPartition.from_partition(
+                    partition=p_2, metadata_version=metadata_version
+                )
+            )
+
+            # In exact or prefix matching schemes, it is expected to only
+            # find one partition alignment. in this case reduce the size of
+            # the inner loop
+            if match_how in ["exact", "prefix"]:
+                partition_stack.remove((l_2, p_2))
+        # Need to copy, otherwise remove will alter the loop iterator
+        available_partitions = partition_stack[:]
+        if len(res) == 1:
+            raise RuntimeError(
+                "No matching partition for {} in dataset {} "
+                "found".format(p_1, first_dataset)
+            )
+        yield res

--- a/tests/api/test_discover.py
+++ b/tests/api/test_discover.py
@@ -25,7 +25,7 @@ from kartothek.io.eager import (
     store_dataframes_as_dataset,
     update_dataset_from_dataframes,
 )
-from kartothek.io_components.metapartition import MetaPartition
+from kartothek.io_components.metapartition import SINGLE_TABLE, MetaPartition
 
 
 @pytest.fixture
@@ -56,7 +56,9 @@ def store_data(
         partition_on = cube.partition_columns
 
     if isinstance(df, pd.DataFrame):
-        mp = MetaPartition(label=gen_uuid(), data=df, metadata_version=metadata_version)
+        mp = MetaPartition(
+            label=gen_uuid(), data={SINGLE_TABLE: df}, metadata_version=metadata_version
+        )
 
         indices_to_build = set(cube.index_columns) & set(df.columns)
         if name == cube.seed_dataset:
@@ -440,6 +442,47 @@ class TestDiscoverDatasets:
                 partition_on=None,
             )
 
+    def test_raises_wrong_table(self, cube, function_store):
+        store_data(
+            cube=cube,
+            function_store=function_store,
+            df=MetaPartition(
+                label=gen_uuid(),
+                data={"foo": pd.DataFrame({"x": [0], "y": [0], "p": [0], "q": [0]})},
+                metadata_version=KTK_CUBE_METADATA_VERSION,
+            ),
+            name=cube.seed_dataset,
+        )
+        with pytest.raises(ValueError) as exc:
+            discover_datasets(cube, function_store)
+        assert (
+            str(exc.value)
+            == "Invalid datasets because table is wrong. Expected table: myseed (foo)"
+        )
+
+    def test_raises_extra_table(self, cube, function_store):
+        store_data(
+            cube=cube,
+            function_store=function_store,
+            df=MetaPartition(
+                label=gen_uuid(),
+                data={
+                    SINGLE_TABLE: pd.DataFrame(
+                        {"x": [0], "y": [0], "p": [0], "q": [0]}
+                    ),
+                    "foo": pd.DataFrame({"x": [0], "y": [0], "p": [0], "q": [0]}),
+                },
+                metadata_version=KTK_CUBE_METADATA_VERSION,
+            ).build_indices(["x", "y"]),
+            name=cube.seed_dataset,
+        )
+        with pytest.raises(ValueError) as exc:
+            discover_datasets(cube, function_store)
+        assert (
+            str(exc.value)
+            == "Invalid datasets because table is wrong. Expected table: myseed (foo, table)"
+        )
+
     def test_raises_dtypes(self, cube, function_store):
         store_data(
             cube=cube,
@@ -498,7 +541,7 @@ class TestDiscoverDatasets:
             function_store=function_store,
             df=MetaPartition(
                 label=gen_uuid(),
-                data=pd.DataFrame({"x": [0], "p": [0], "q": [0]}),
+                data={SINGLE_TABLE: pd.DataFrame({"x": [0], "p": [0], "q": [0]})},
                 metadata_version=KTK_CUBE_METADATA_VERSION,
             ).build_indices(["x"]),
             name=cube.seed_dataset,
@@ -535,7 +578,9 @@ class TestDiscoverDatasets:
             function_store=function_store,
             df=MetaPartition(
                 label=gen_uuid(),
-                data=pd.DataFrame({"x": [0], "y": [0], "p": [0], "q": [0]}),
+                data={
+                    SINGLE_TABLE: pd.DataFrame({"x": [0], "y": [0], "p": [0], "q": [0]})
+                },
                 metadata_version=KTK_CUBE_METADATA_VERSION,
             ),
             name=cube.seed_dataset,
@@ -553,7 +598,9 @@ class TestDiscoverDatasets:
             function_store=function_store,
             df=MetaPartition(
                 label=gen_uuid(),
-                data=pd.DataFrame({"x": [0], "y": [0], "p": [0], "q": [0]}),
+                data={
+                    SINGLE_TABLE: pd.DataFrame({"x": [0], "y": [0], "p": [0], "q": [0]})
+                },
                 metadata_version=KTK_CUBE_METADATA_VERSION,
             ).build_indices(["x", "y"]),
             name=cube.seed_dataset,
@@ -563,9 +610,11 @@ class TestDiscoverDatasets:
             function_store=function_store,
             df=MetaPartition(
                 label=gen_uuid(),
-                data=pd.DataFrame(
-                    {"x": [0], "y": [0], "p": [0], "q": [0], "i1": [1337]}
-                ),
+                data={
+                    SINGLE_TABLE: pd.DataFrame(
+                        {"x": [0], "y": [0], "p": [0], "q": [0], "i1": [1337]}
+                    )
+                },
                 metadata_version=KTK_CUBE_METADATA_VERSION,
             ),
             name="enrich",
@@ -584,9 +633,11 @@ class TestDiscoverDatasets:
                 function_store=function_store,
                 df=MetaPartition(
                     label=gen_uuid(),
-                    data=pd.DataFrame(
-                        {"x": [0], "y": [0], "p": [0], "q": [0], "v1": [0]}
-                    ),
+                    data={
+                        SINGLE_TABLE: pd.DataFrame(
+                            {"x": [0], "y": [0], "p": [0], "q": [0], "v1": [0]}
+                        )
+                    },
                     metadata_version=KTK_CUBE_METADATA_VERSION,
                 ).build_indices(["x", "y", "v1"]),
                 name=cube.seed_dataset,
@@ -596,16 +647,18 @@ class TestDiscoverDatasets:
                 function_store=function_store,
                 df=MetaPartition(
                     label=gen_uuid(),
-                    data=pd.DataFrame(
-                        {
-                            "x": [0],
-                            "y": [0],
-                            "p": [0],
-                            "q": [0],
-                            "i1": [1337],
-                            "v2": [42],
-                        }
-                    ),
+                    data={
+                        SINGLE_TABLE: pd.DataFrame(
+                            {
+                                "x": [0],
+                                "y": [0],
+                                "p": [0],
+                                "q": [0],
+                                "i1": [1337],
+                                "v2": [42],
+                            }
+                        )
+                    },
                     metadata_version=KTK_CUBE_METADATA_VERSION,
                 ).build_indices(["i1", "x", "v2"]),
                 name="enrich",
@@ -627,7 +680,11 @@ class TestDiscoverDatasets:
                 function_store=function_store,
                 df=MetaPartition(
                     label=gen_uuid(),
-                    data=pd.DataFrame({"x": [0], "y": [0], "i1": [1337], "v2": [42]}),
+                    data={
+                        SINGLE_TABLE: pd.DataFrame(
+                            {"x": [0], "y": [0], "i1": [1337], "v2": [42]}
+                        )
+                    },
                     metadata_version=KTK_CUBE_METADATA_VERSION,
                 ),
                 name="enrich",
@@ -665,7 +722,11 @@ class TestDiscoverDatasets:
                 function_store=function_store,
                 df=MetaPartition(
                     label=gen_uuid(),
-                    data=pd.DataFrame({"x": [0], "y": [0], "p": [0], "q": [0]}),
+                    data={
+                        SINGLE_TABLE: pd.DataFrame(
+                            {"x": [0], "y": [0], "p": [0], "q": [0]}
+                        )
+                    },
                     metadata_version=KTK_CUBE_METADATA_VERSION,
                 ).build_indices(["x", "y"]),
                 name=cube.seed_dataset,
@@ -675,7 +736,11 @@ class TestDiscoverDatasets:
                 function_store=function_store,
                 df=MetaPartition(
                     label=gen_uuid(),
-                    data=pd.DataFrame({"x": [0], "p": [0], "q": [0], "v1": [42]}),
+                    data={
+                        SINGLE_TABLE: pd.DataFrame(
+                            {"x": [0], "p": [0], "q": [0], "v1": [42]}
+                        )
+                    },
                     metadata_version=KTK_CUBE_METADATA_VERSION,
                 ),
                 name="x",
@@ -685,7 +750,11 @@ class TestDiscoverDatasets:
                 function_store=function_store,
                 df=MetaPartition(
                     label=gen_uuid(),
-                    data=pd.DataFrame({"y": [0], "p": [0], "q": [0], "v2": [42]}),
+                    data={
+                        SINGLE_TABLE: pd.DataFrame(
+                            {"y": [0], "p": [0], "q": [0], "v2": [42]}
+                        )
+                    },
                     metadata_version=KTK_CUBE_METADATA_VERSION,
                 ),
                 name="y",

--- a/tests/core/cube/test_constants.py
+++ b/tests/core/cube/test_constants.py
@@ -1,6 +1,6 @@
-from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPARATOR
+from kartothek.core.cube.constants import KTK_CUBE_UUID_SEPERATOR
 from kartothek.core.dataset import _validate_uuid
 
 
 def test_uuid_seperator_valid():
-    assert _validate_uuid(KTK_CUBE_UUID_SEPARATOR)
+    assert _validate_uuid(KTK_CUBE_UUID_SEPERATOR)

--- a/tests/core/test_builder.py
+++ b/tests/core/test_builder.py
@@ -75,7 +75,10 @@ def test_builder_full(metadata_version, frozen_time):
         "dataset_metadata_version": metadata_version,
         "partitions": {
             "run_id=1/L=1/P=1/part_1": {
-                "files": {"core": "uuid/core/run_id=1/L=1/P=1/part_1.parquet"}
+                "files": {
+                    "core": "uuid/core/run_id=1/L=1/P=1/part_1.parquet",
+                    "helper": "uuid/helper/run_id=1/L=1/P=1/part_1.parquet",
+                }
             }
         },
         "metadata": {"key": "value", "creation_time": TIME_TO_FREEZE_ISO},
@@ -94,7 +97,10 @@ def test_builder_full(metadata_version, frozen_time):
     )
     part_2 = Partition(
         label="run_id=1/L=1/P=1/part_1",
-        files={"core": "uuid/core/run_id=1/L=1/P=1/part_1.parquet"},
+        files={
+            "core": "uuid/core/run_id=1/L=1/P=1/part_1.parquet",
+            "helper": "uuid/helper/run_id=1/L=1/P=1/part_1.parquet",
+        },
     )
     builder.add_partition("run_id=1/L=1/P=1/part_1", part_2)
     builder.add_metadata("key", "value")

--- a/tests/core/test_dataset_explicit_part.py
+++ b/tests/core/test_dataset_explicit_part.py
@@ -85,24 +85,6 @@ def test_roundtrip_json(metadata_version):
     assert expected == result
 
 
-def test_raise_multitable(metadata_version):
-    expected = {
-        "dataset_metadata_version": metadata_version,
-        "dataset_uuid": "uuid",
-        "metadata": {},
-        "partitions": {
-            "part_1": {"files": {"tableA": "file.parquet", "tableB": "file.parquet"}}
-        },
-        "partition_keys": [],
-    }
-
-    with pytest.raises(
-        RuntimeError,
-        match=r"Dataset uuid has tables.*but read support for multi tabled dataset was dropped with kartothek 4\.0\.",
-    ):
-        DatasetMetadata.from_dict(expected)
-
-
 def test_roundtrip_msgpack():
     expected = {
         "dataset_metadata_version": 4,
@@ -154,19 +136,29 @@ def test_read_table_meta(store):
         "dataset_uuid": "dataset_uuid",
         "partitions": {
             "location_id=1/part_1": {
-                "files": {"table1": "dataset_uuid/table1/location_id=1/part_1.parquet"}
+                "files": {
+                    "table1": "dataset_uuid/table1/location_id=1/part_1.parquet",
+                    "table2": "dataset_uuid/table2/location_id=1/part_1.parquet",
+                }
             }
         },
     }
     df1 = pd.DataFrame(
         {"location_id": pd.Series([1], dtype=int), "x": pd.Series([True], dtype=bool)}
     )
+    df2 = pd.DataFrame(
+        {"location_id": pd.Series([1], dtype=int), "y": pd.Series([1.0], dtype=float)}
+    )
     schema1 = make_meta(df1, origin="1")
+    schema2 = make_meta(df2, origin="2")
     store_schema_metadata(schema1, "dataset_uuid", store, "table1")
+    store_schema_metadata(schema2, "dataset_uuid", store, "table2")
 
     dmd = DatasetMetadata.load_from_dict(meta_dct, store)
 
-    assert dmd.schema == schema1
+    actual = dmd.table_meta
+    expected = {"table1": schema1, "table2": schema2}
+    assert actual == expected
 
 
 def test_load_indices_embedded(metadata_version):
@@ -214,7 +206,7 @@ def test_load_all_indices(store, metadata_version):
         },
     }
     dmd = DatasetMetadata.from_dict(meta_dct)
-    dmd.schema = make_meta(
+    dmd.table_meta["core_data"] = make_meta(
         pd.DataFrame({"location_id": pd.Series([1], dtype=int)}), origin="core"
     )
 

--- a/tests/core/test_docs.py
+++ b/tests/core/test_docs.py
@@ -17,8 +17,10 @@ from kartothek.io.dask.dataframe import (
 )
 from kartothek.io.dask.delayed import (
     delete_dataset__delayed,
+    merge_datasets_as_delayed,
     read_dataset_as_delayed,
     read_dataset_as_delayed_metapartitions,
+    read_table_as_delayed,
     store_delayed_as_dataset,
     update_dataset_from_delayed,
 )
@@ -54,8 +56,10 @@ from kartothek.io.iter import (
         store_dataset_from_ddf,
         update_dataset_from_ddf,
         delete_dataset__delayed,
+        merge_datasets_as_delayed,
         read_dataset_as_delayed_metapartitions,
         read_dataset_as_delayed,
+        read_table_as_delayed,
         update_dataset_from_delayed,
         store_delayed_as_dataset,
         delete_dataset,
@@ -89,12 +93,7 @@ def test_docs(function):
             f"Wrong or missing docstrings for parameters {valid_docs[False]}.\n\n{docstrings}"
         )
 
-    sorted_arguments = sorted(arguments)
-    args_in_docs = [argument in docstrings for argument in sorted_arguments]
-
-    assert all(args_in_docs), [
-        sorted_arguments[ix] for ix, val in enumerate(args_in_docs) if val is False
-    ]
+    assert all([argument in docstrings for argument in arguments])
 
 
 def test_docs_duplicity():

--- a/tests/io/dask/bag/test_read.py
+++ b/tests/io/dask/bag/test_read.py
@@ -12,7 +12,7 @@ from kartothek.io.iter import store_dataframes_as_dataset__iter
 from kartothek.io.testing.read import *  # noqa
 
 
-@pytest.fixture(params=["dataframe"])
+@pytest.fixture(params=["dataframe", "metapartition"])
 def output_type(request):
     return request.param
 
@@ -47,7 +47,8 @@ def test_read_dataset_as_dataframes_partition_size(store_factory, metadata_versi
     cluster4 = pd.DataFrame(
         {"A": [2, 2], "B": [10, 10], "C": [1, 2], "Content": ["cluster4", "cluster4"]}
     )
-    partitions = [cluster1, cluster2, cluster3, cluster4]
+    clusters = [cluster1, cluster2, cluster3, cluster4]
+    partitions = [{"data": [("data", c)]} for c in clusters]
 
     store_dataframes_as_dataset__iter(
         df_generator=partitions,

--- a/tests/io/dask/dataframe/test_read.py
+++ b/tests/io/dask/dataframe/test_read.py
@@ -32,7 +32,8 @@ def _read_as_ddf(
     **kwargs,
 ):
     table = tables or SINGLE_TABLE
-
+    if categoricals:
+        categoricals = categoricals[table]
     ddf = read_dataset_as_ddf(
         dataset_uuid=dataset_uuid,
         store=store,
@@ -84,6 +85,7 @@ def test_load_dataframe_categoricals_with_index(dataset_with_index_factory):
         bound_load_dataframes=func,
         use_categoricals=True,
         output_type="table",
+        label_filter=None,
         dates_as_object=False,
     )
 

--- a/tests/io/dask/dataframe/test_shuffle.py
+++ b/tests/io/dask/dataframe/test_shuffle.py
@@ -183,7 +183,7 @@ def test_update_shuffle_buckets(
         range(unique_secondaries)
     )
 
-    assert set(dataset.schema.names) == {
+    assert set(dataset.table_meta["core"].names) == {
         "primary",
         "secondary",
         "sorted_column",
@@ -197,8 +197,9 @@ def test_update_shuffle_buckets(
 
         assert not ind_df.duplicated().any()
 
-    for df in read_dataset_as_dataframes__iterator(
+    for data_dct in read_dataset_as_dataframes__iterator(
         dataset_uuid=dataset.uuid, store=store_factory
     ):
+        df = data_dct["core"]
         assert len(df.primary.unique()) == 1
         assert df.sorted_column.is_monotonic

--- a/tests/io/dask/delayed/test_merge.py
+++ b/tests/io/dask/delayed/test_merge.py
@@ -1,0 +1,19 @@
+import pickle
+
+import dask
+import pytest
+
+from kartothek.io.dask.delayed import merge_datasets_as_delayed
+from kartothek.io.testing.merge import *  # noqa
+
+
+def _merge_datasets(*args, **kwargs):
+    df_list = merge_datasets_as_delayed(*args, **kwargs)
+    s = pickle.dumps(df_list, pickle.HIGHEST_PROTOCOL)
+    df_list = pickle.loads(s)
+    return dask.compute(df_list)[0]
+
+
+@pytest.fixture
+def bound_merge_datasets(request):
+    return _merge_datasets

--- a/tests/io/dask/delayed/test_read.py
+++ b/tests/io/dask/delayed/test_read.py
@@ -3,20 +3,29 @@ from functools import partial
 
 import pytest
 
-from kartothek.io.dask.delayed import read_dataset_as_delayed
+from kartothek.io.dask.delayed import (
+    read_dataset_as_delayed,
+    read_dataset_as_delayed_metapartitions,
+    read_table_as_delayed,
+)
 from kartothek.io.testing.read import *  # noqa
 
 
-@pytest.fixture(params=["table"])
+@pytest.fixture(params=["dataframe", "metapartition", "table"])
 def output_type(request):
     return request.param
 
 
 def _load_dataframes(output_type, *args, **kwargs):
-    if "tables" in kwargs:
-        param_tables = kwargs.pop("tables")
-        kwargs["table"] = param_tables
-    func = partial(read_dataset_as_delayed)
+    if output_type == "dataframe":
+        func = read_dataset_as_delayed
+    elif output_type == "metapartition":
+        func = read_dataset_as_delayed_metapartitions
+    elif output_type == "table":
+        if "tables" in kwargs:
+            param_tables = kwargs.pop("tables")
+            kwargs["table"] = param_tables
+        func = partial(read_table_as_delayed)
     tasks = func(*args, **kwargs)
 
     s = pickle.dumps(tasks, pickle.HIGHEST_PROTOCOL)

--- a/tests/io/dask/test_common_cube.py
+++ b/tests/io/dask/test_common_cube.py
@@ -21,7 +21,7 @@ def test_cube_with_valid_indices_is_not_modified_by_validation():
         {
             "dataset_uuid": "source",
             "dataset_metadata_version": 4,
-            "schema": FakeSeedTableMetadata(),
+            "table_meta": {"table": FakeSeedTableMetadata()},
             "partition_keys": ["p"],
             "indices": {
                 "d1": {"1": ["part_1"]},
@@ -34,7 +34,7 @@ def test_cube_with_valid_indices_is_not_modified_by_validation():
         {
             "dataset_uuid": "extra",
             "dataset_metadata_version": 4,
-            "schema": FakeExtraTableMetadata(),
+            "table_meta": {"table": FakeExtraTableMetadata()},
             "partition_keys": ["p"],
             "indices": {"i1": {"1": ["part_1"]}},
         }
@@ -62,7 +62,7 @@ def test_existing_indices_are_added_when_missing_in_cube():
         {
             "dataset_uuid": "source",
             "dataset_metadata_version": 4,
-            "schema": FakeExtraTableMetadata(),
+            "table_meta": {"table": FakeSeedTableMetadata()},
             "partition_keys": ["p"],
             "indices": {
                 "d1": {"1": ["part_1"]},
@@ -76,7 +76,7 @@ def test_existing_indices_are_added_when_missing_in_cube():
         {
             "dataset_uuid": "extra",
             "dataset_metadata_version": 4,
-            "schema": FakeExtraTableMetadata(),
+            "table_meta": {"table": FakeExtraTableMetadata()},
             "partition_keys": ["p"],
             "indices": {"i1": {"1": ["part_1"]}},
         }
@@ -104,7 +104,7 @@ def test_raises_when_cube_defines_index_not_in_dataset():
         {
             "dataset_uuid": "source",
             "dataset_metadata_version": 4,
-            "schema": FakeSeedTableMetadata(),
+            "table_meta": {"table": FakeSeedTableMetadata()},
             "partition_keys": ["p"],
             "indices": {
                 "d1": {"1": ["part_1"]},
@@ -117,7 +117,7 @@ def test_raises_when_cube_defines_index_not_in_dataset():
         {
             "dataset_uuid": "extra",
             "dataset_metadata_version": 4,
-            "schema": FakeExtraTableMetadata(),
+            "table_meta": {"table": FakeExtraTableMetadata()},
             "partition_keys": ["p"],
             "indices": {"i1": {"1": ["part_1"]}},
         }
@@ -145,7 +145,7 @@ def test_no_indices_are_suppressed_when_they_already_exist():
         {
             "dataset_uuid": "source",
             "dataset_metadata_version": 4,
-            "schema": FakeSeedTableMetadata(),
+            "table_meta": {"table": FakeSeedTableMetadata()},
             "partition_keys": ["p"],
             "indices": {
                 "d1": {"1": ["part_1"]},
@@ -158,7 +158,7 @@ def test_no_indices_are_suppressed_when_they_already_exist():
         {
             "dataset_uuid": "extra",
             "dataset_metadata_version": 4,
-            "schema": FakeExtraTableMetadata(),
+            "table_meta": {"table": FakeExtraTableMetadata()},
             "partition_keys": ["p"],
             "indices": {"i1": {"1": ["part_1"]}},
         }

--- a/tests/io/eager/test_commit.py
+++ b/tests/io/eager/test_commit.py
@@ -7,6 +7,7 @@ from pandas.testing import assert_frame_equal
 
 from kartothek.core.common_metadata import make_meta
 from kartothek.core.dataset import DatasetMetadata
+from kartothek.core.index import ExplicitSecondaryIndex
 from kartothek.io.eager import (
     commit_dataset,
     create_empty_dataset_header,
@@ -14,21 +15,25 @@ from kartothek.io.eager import (
     store_dataframes_as_dataset,
     write_single_partition,
 )
+from kartothek.io_components.metapartition import SINGLE_TABLE
 
 
 def test_commit_dataset_from_metapartition(dataset_function, store):
-    new_data = [
-        pd.DataFrame(
-            OrderedDict(
-                [
-                    ("P", [5]),
-                    ("L", [5]),
-                    ("TARGET", [5]),
-                    ("DATE", [datetime.date(2016, 3, 23)]),
-                ]
-            )
-        )
-    ]
+    new_data = {
+        "data": {
+            SINGLE_TABLE: pd.DataFrame(
+                OrderedDict(
+                    [
+                        ("P", [5]),
+                        ("L", [5]),
+                        ("TARGET", [5]),
+                        ("DATE", [datetime.date(2016, 3, 23)]),
+                    ]
+                )
+            ),
+            "helper": pd.DataFrame(OrderedDict([("P", [1]), ("info", ["a"])])),
+        }
+    }
     new_partition = write_single_partition(
         store=store, dataset_uuid=dataset_function.uuid, data=new_data
     )
@@ -59,17 +64,21 @@ def test_commit_dataset_from_metapartition(dataset_function, store):
     # Read the data and check whether the rows above are included.
     # This checks whether all necessary informations were updated in the header
     # (e.g. files attributes of the partitions)
-    actual = read_table(store=store, dataset_uuid=dataset_function.uuid)
+    actual = read_table(
+        store=store, table=SINGLE_TABLE, dataset_uuid=dataset_function.uuid
+    )
     df_expected = pd.DataFrame(
         OrderedDict(
             [
                 (
                     "DATE",
-                    [
-                        datetime.date(2016, 3, 23),
-                        datetime.date(2010, 1, 1),
-                        datetime.date(2009, 12, 31),
-                    ],
+                    pd.to_datetime(
+                        [
+                            datetime.date(2016, 3, 23),
+                            datetime.date(2010, 1, 1),
+                            datetime.date(2009, 12, 31),
+                        ]
+                    ),
                 ),
                 ("L", [5, 1, 2]),
                 ("P", [5, 1, 2]),
@@ -82,7 +91,87 @@ def test_commit_dataset_from_metapartition(dataset_function, store):
     assert_frame_equal(df_expected, actual)
 
 
-# TODO: document changes for write_single_partition / commit workflow
+def test_commit_dataset_from_dict(dataset_function, store):
+
+    new_data = {
+        "data": {
+            SINGLE_TABLE: pd.DataFrame(
+                OrderedDict(
+                    [
+                        ("P", [5]),
+                        ("L", [5]),
+                        ("TARGET", [5]),
+                        ("DATE", [datetime.date(2016, 3, 23)]),
+                    ]
+                )
+            ),
+            "helper": pd.DataFrame(OrderedDict([("P", [1]), ("info", ["a"])])),
+        }
+    }
+    new_metapartition = write_single_partition(
+        store=store, dataset_uuid=dataset_function.uuid, data=new_data
+    )
+    new_partition = [
+        {
+            "label": new_metapartition.label,
+            "data": [(SINGLE_TABLE, None), ("helper", None)],
+        }
+    ]
+    pre_commit_dataset = DatasetMetadata.load_from_store(
+        uuid=dataset_function.uuid, store=store
+    )
+    # Cannot assert equal since the metadata is differently ordered
+    assert pre_commit_dataset == dataset_function
+
+    updated_dataset = commit_dataset(
+        store=store,
+        dataset_uuid=dataset_function.uuid,
+        new_partitions=new_partition,
+        delete_scope=None,
+        partition_on=None,
+    )
+    assert updated_dataset != dataset_function
+    assert updated_dataset.explicit_partitions is True
+
+    assert updated_dataset.uuid == dataset_function.uuid
+    assert len(updated_dataset.partitions) == len(dataset_function.partitions) + 1
+
+    # ensure that the new dataset is actually the one on disc
+    loaded_dataset = DatasetMetadata.load_from_store(
+        uuid=updated_dataset.uuid, store=store
+    )
+    assert loaded_dataset == updated_dataset
+
+    # Read the data and check whether the rows above are included.
+    # This checks whether all necessary informations were updated in the header
+    # (e.g. files attributes of the partitions)
+    actual = read_table(
+        store=store, table=SINGLE_TABLE, dataset_uuid=dataset_function.uuid
+    )
+    df_expected = pd.DataFrame(
+        OrderedDict(
+            [
+                (
+                    "DATE",
+                    pd.to_datetime(
+                        [
+                            datetime.date(2016, 3, 23),
+                            datetime.date(2010, 1, 1),
+                            datetime.date(2009, 12, 31),
+                        ]
+                    ),
+                ),
+                ("L", [5, 1, 2]),
+                ("P", [5, 1, 2]),
+                ("TARGET", [5, 1, 2]),
+            ]
+        )
+    )
+    actual = actual.sort_values("DATE", ascending=False).reset_index(drop=True)
+
+    assert_frame_equal(df_expected, actual)
+
+
 def test_commit_dataset_from_nested_metapartition(store):
     """
     Check it is possible to use `commit_dataset` with nested metapartitions as input.
@@ -94,7 +183,7 @@ def test_commit_dataset_from_nested_metapartition(store):
     create_empty_dataset_header(
         store=store,
         dataset_uuid="uuid",
-        schema=make_meta(df, "table", ["a"]),
+        table_meta={"table": make_meta(df, "table", ["a"])},
         partition_on=["a"],
     )
 
@@ -102,7 +191,10 @@ def test_commit_dataset_from_nested_metapartition(store):
     for x in range(2):
         partitions.append(
             write_single_partition(
-                store=store, dataset_uuid="uuid", data=df, partition_on=["a"],
+                store=store,
+                dataset_uuid="uuid",
+                data={"data": {"table": df}},
+                partition_on=["a"],
             )
         )
 
@@ -118,25 +210,26 @@ def test_initial_commit(store):
     df = pd.DataFrame(OrderedDict([("P", [5]), ("L", [5]), ("TARGET", [5])]))
     dataset = create_empty_dataset_header(
         store=store,
-        schema=make_meta(df, origin="1"),
+        table_meta={"core": make_meta(df, origin="1")},
         dataset_uuid=dataset_uuid,
         metadata_version=4,
     )
     assert dataset.explicit_partitions is False
+    new_data = {"data": {"core": df}}
     new_metapartition = write_single_partition(
-        store=store, dataset_uuid=dataset.uuid, data=df
+        store=store, dataset_uuid=dataset.uuid, data=new_data
     )
 
+    new_partition = [{"label": new_metapartition.label, "data": [("core", None)]}]
     updated_dataset = commit_dataset(
         store=store,
         dataset_uuid=dataset.uuid,
-        # FIXME: is this breaking and if so, is it expected?
-        new_partitions=[new_metapartition],
+        new_partitions=new_partition,
         delete_scope=None,
         partition_on=None,
     )
     assert updated_dataset.explicit_partitions is True
-    actual = read_table(store=store, dataset_uuid=updated_dataset.uuid)
+    actual = read_table(store=store, table="core", dataset_uuid=updated_dataset.uuid)
     df_expected = pd.DataFrame(OrderedDict([("L", [5]), ("P", [5]), ("TARGET", [5])]))
 
     assert_frame_equal(df_expected, actual)
@@ -144,15 +237,22 @@ def test_initial_commit(store):
 
 def test_commit_dataset_only_delete(store, metadata_version):
     partitions = [
-        pd.DataFrame({"p": [1]}),
-        pd.DataFrame({"p": [2]}),
+        {
+            "label": "cluster_1",
+            "data": [("core", pd.DataFrame({"p": [1]}))],
+            "indices": {"p": ExplicitSecondaryIndex("p", index_dct={1: ["cluster_1"]})},
+        },
+        {
+            "label": "cluster_2",
+            "data": [("core", pd.DataFrame({"p": [2]}))],
+            "indices": {"p": ExplicitSecondaryIndex("p", index_dct={2: ["cluster_2"]})},
+        },
     ]
     dataset = store_dataframes_as_dataset(
         dfs=partitions,
         store=lambda: store,
         metadata={"dataset": "metadata"},
         dataset_uuid="dataset_uuid",
-        secondary_indices="p",
         metadata_version=metadata_version,
     )
     dataset = dataset.load_index("p", store)
@@ -167,18 +267,23 @@ def test_commit_dataset_only_delete(store, metadata_version):
         partition_on=None,
     )
     assert len(updated_dataset.partitions) == 1
+    assert list(updated_dataset.partitions.keys()) == ["cluster_2"]
     assert updated_dataset.explicit_partitions is True
 
 
 def test_commit_dataset_delete_all(store, metadata_version):
-    partitions = [pd.DataFrame({"p": [1]})]
-
+    partitions = [
+        {
+            "label": "cluster_1",
+            "data": [("core", pd.DataFrame({"p": [1]}))],
+            "indices": {"p": ExplicitSecondaryIndex("p", index_dct={1: ["cluster_1"]})},
+        }
+    ]
     dataset = store_dataframes_as_dataset(
         dfs=partitions,
         store=lambda: store,
         metadata={"dataset": "metadata"},
         dataset_uuid="dataset_uuid",
-        secondary_indices="p",
         metadata_version=metadata_version,
     )
     dataset = dataset.load_index("p", store)

--- a/tests/io/eager/test_update.py
+++ b/tests/io/eager/test_update.py
@@ -28,7 +28,7 @@ def test_create_empty_header_from_pyarrow_schema(store_factory):
     dm = create_empty_dataset_header(
         store=store_factory,
         dataset_uuid=dataset_uuid,
-        schema=schema,
+        table_meta={"table": schema},
         partition_on=["part"],
     )
 
@@ -36,7 +36,7 @@ def test_create_empty_header_from_pyarrow_schema(store_factory):
         write_single_partition(
             store=store_factory,
             dataset_uuid=dataset_uuid,
-            data=[df.loc[df["part"] == 1]],
+            data=[{"table": df.loc[df["part"] == 1]}],
             partition_on=["part"],
         )
     ]

--- a/tests/io/eager/test_write.py
+++ b/tests/io/eager/test_write.py
@@ -7,6 +7,7 @@ import pytest
 
 from kartothek.core.common_metadata import make_meta, read_schema_metadata
 from kartothek.core.dataset import DatasetMetadata
+from kartothek.core.index import ExplicitSecondaryIndex
 from kartothek.core.uuid import gen_uuid
 from kartothek.io.eager import (
     create_empty_dataset_header,
@@ -34,40 +35,50 @@ def bound_store_dataframes():
 def test_write_single_partition(store_factory, mock_uuid, metadata_version):
     create_empty_dataset_header(
         store=store_factory(),
-        schema=pd.DataFrame({"col": [1]}),
+        table_meta={
+            "table1": pd.DataFrame({"col": [1]}),
+            "table2": pd.DataFrame({"other_col": ["a"]}),
+        },
         dataset_uuid="some_dataset",
         metadata_version=metadata_version,
-        table_name="table1",
     )
 
-    new_data = pd.DataFrame({"col": [1, 2]})
+    new_data = {
+        "data": {
+            "table1": pd.DataFrame({"col": [1, 2]}),
+            "table2": pd.DataFrame({"other_col": ["a", "b"]}),
+        }
+    }
     keys_in_store = set(store_factory().keys())
     new_mp = write_single_partition(
-        store=store_factory,
-        dataset_uuid="some_dataset",
-        data=new_data,
-        table_name="table1",
+        store=store_factory, dataset_uuid="some_dataset", data=new_data
     )
 
     keys_in_store.add("some_dataset/table1/auto_dataset_uuid.parquet")
+    keys_in_store.add("some_dataset/table2/auto_dataset_uuid.parquet")
     assert set(store_factory().keys()) == keys_in_store
     expected_mp = MetaPartition(
         label="auto_dataset_uuid",  # this will be a hash of the input
-        file="some_dataset/table1/auto_dataset_uuid.parquet",
+        files={
+            "table1": "some_dataset/table1/auto_dataset_uuid.parquet",
+            "table2": "some_dataset/table2/auto_dataset_uuid.parquet",
+        },
         metadata_version=4,
-        schema=make_meta(pd.DataFrame({"col": [1, 2]}), origin="table1"),
+        table_meta={
+            "table1": make_meta(pd.DataFrame({"col": [1, 2]}), origin="table1"),
+            "table2": make_meta(
+                pd.DataFrame({"other_col": ["a", "b"]}), origin="table2"
+            ),
+        },
     )
 
     assert new_mp == expected_mp
 
     with pytest.raises(ValueError):
         # col is an integer column so this is incompatible.
-        new_data = pd.DataFrame({"col": [datetime.date(2010, 1, 1)]})
+        new_data["data"]["table1"] = pd.DataFrame({"col": [datetime.date(2010, 1, 1)]})
         write_single_partition(
-            store=store_factory,
-            dataset_uuid="some_dataset",
-            data=new_data,
-            table_name="table1",
+            store=store_factory, dataset_uuid="some_dataset", data=new_data
         )
 
 
@@ -75,14 +86,14 @@ def test_create_dataset_header_minimal_version(store, metadata_storage_format):
     with pytest.raises(NotImplementedError):
         create_empty_dataset_header(
             store=store,
-            schema=pd.DataFrame({"col": [1]}),
+            table_meta={"table": pd.DataFrame({"col": [1]})},
             dataset_uuid="new_dataset_uuid",
             metadata_storage_format=metadata_storage_format,
             metadata_version=3,
         )
     create_empty_dataset_header(
         store=store,
-        schema=pd.DataFrame({"col": [1]}),
+        table_meta={"table": pd.DataFrame({"col": [1]})},
         dataset_uuid="new_dataset_uuid",
         metadata_storage_format=metadata_storage_format,
         metadata_version=4,
@@ -90,10 +101,10 @@ def test_create_dataset_header_minimal_version(store, metadata_storage_format):
 
 
 def test_create_dataset_header(store, metadata_storage_format, frozen_time):
-    schema = make_meta(pd.DataFrame({"col": [1]}), origin="1")
+    table_meta = {"table": make_meta(pd.DataFrame({"col": [1]}), origin="1")}
     new_dataset = create_empty_dataset_header(
         store=store,
-        schema=schema,
+        table_meta=table_meta,
         dataset_uuid="new_dataset_uuid",
         metadata_storage_format=metadata_storage_format,
         metadata_version=4,
@@ -103,7 +114,7 @@ def test_create_dataset_header(store, metadata_storage_format, frozen_time):
         uuid="new_dataset_uuid",
         metadata_version=4,
         explicit_partitions=False,
-        schema=schema,
+        table_meta=table_meta,
     )
     assert new_dataset == expected_dataset
 
@@ -114,7 +125,7 @@ def test_create_dataset_header(store, metadata_storage_format, frozen_time):
     assert loaded == expected_dataset
 
     # If the read succeeds, the schema is written
-    read_schema_metadata(dataset_uuid=new_dataset.uuid, store=store)
+    read_schema_metadata(dataset_uuid=new_dataset.uuid, store=store, table="table")
 
 
 # TODO: move `store_dataframes_as_dataset` tests to generic tests or remove if redundant
@@ -123,10 +134,12 @@ def test_store_dataframes_as_dataset_no_pipeline_partition_on(store):
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
 
+    df2 = pd.DataFrame({"P": np.arange(0, 10), "info": np.arange(100, 110)})
+
     dataset = store_dataframes_as_dataset(
         store=store,
         dataset_uuid="dataset_uuid",
-        dfs=[df],
+        dfs=[{"core": df, "helper": df2}],
         partition_on="P",
         metadata_version=4,
     )
@@ -139,20 +152,23 @@ def test_store_dataframes_as_dataset_no_pipeline_partition_on(store):
     assert dataset == stored_dataset
 
 
-def test_store_dataframes_as_dataset_partition_on_inconsistent(store):
+@pytest.mark.parametrize("test_input", ["NOT_IN_COLUMNS"])
+def test_store_dataframes_as_dataset_partition_on_inconsistent(test_input, store):
     df = pd.DataFrame(
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
+
+    df2 = pd.DataFrame({"P": np.arange(0, 10), "info": np.arange(100, 110)})
 
     with pytest.raises(ValueError) as excinfo:
         store_dataframes_as_dataset(
             store=store,
             dataset_uuid="dataset_uuid",
-            dfs=[df],
-            partition_on=["NOT_IN_COLUMNS"],
+            dfs=[{"core": df, "helper": df2}],
+            partition_on=[test_input],
             metadata_version=4,
         )
-    assert str(excinfo.value) == "Partition column(s) missing: NOT_IN_COLUMNS"
+    assert str(excinfo.value) == "Partition column(s) missing: {}".format(test_input)
 
 
 def test_store_dataframes_as_dataset_no_pipeline(metadata_version, store):
@@ -160,10 +176,12 @@ def test_store_dataframes_as_dataset_no_pipeline(metadata_version, store):
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
 
+    df2 = pd.DataFrame({"P": np.arange(0, 10), "info": np.arange(100, 110)})
+
     dataset = store_dataframes_as_dataset(
         store=store,
         dataset_uuid="dataset_uuid",
-        dfs=[df],
+        dfs=[{"core": df, "helper": df2}],
         metadata_version=metadata_version,
     )
 
@@ -176,12 +194,35 @@ def test_store_dataframes_as_dataset_no_pipeline(metadata_version, store):
     assert dataset == stored_dataset
 
 
+def test_store_dataframes_as_dataset_dfs_input_formats(store):
+    df1 = pd.DataFrame({"B": [pd.Timestamp("2019")]})
+    df2 = pd.DataFrame({"A": [1.4]})
+    formats = [
+        {"data": {"D": df1, "S": df2}},
+        {"D": df1, "S": df2},
+        {"data": [("D", df1), ("S", df2)]},
+        [("D", df1), ("S", df2)],
+    ]
+    for input_format in formats:
+        dataset = store_dataframes_as_dataset(
+            store=store, dataset_uuid="dataset_uuid", dfs=[input_format], overwrite=True
+        )
+        stored_dataset = DatasetMetadata.load_from_store("dataset_uuid", store)
+        assert dataset == stored_dataset
+
+
 def test_store_dataframes_as_dataset_mp(metadata_version, store):
     df = pd.DataFrame(
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
 
-    mp = MetaPartition(label=gen_uuid(), data=df, metadata_version=metadata_version,)
+    df2 = pd.DataFrame({"P": np.arange(0, 10), "info": np.arange(100, 110)})
+
+    mp = MetaPartition(
+        label=gen_uuid(),
+        data={"core": df, "helper": df2},
+        metadata_version=metadata_version,
+    )
 
     dataset = store_dataframes_as_dataset(
         store=store,
@@ -204,8 +245,13 @@ def test_write_single_partition_different_partitioning(store_factory):
         OrderedDict([("location", ["0", "1", "2"]), ("other", ["a", "a", "a"])])
     )
 
-    input_ = [df]
-
+    input_ = [
+        {
+            "label": "label",
+            "data": [("order_proposals", df)],
+            "indices": {"location": {k: ["label"] for k in df["location"].unique()}},
+        }
+    ]
     dataset = store_dataframes_as_dataset(
         dfs=input_,
         store=store_factory,
@@ -214,11 +260,13 @@ def test_write_single_partition_different_partitioning(store_factory):
         partition_on=["other"],
     )
 
-    new_data = [
-        pd.DataFrame(
-            OrderedDict([("other", ["b", "b", "b"]), ("location", ["0", "1", "2"])])
-        )
-    ]
+    new_data = {
+        "data": {
+            "order_proposals": pd.DataFrame(
+                OrderedDict([("other", ["b", "b", "b"]), ("location", ["0", "1", "2"])])
+            )
+        }
+    }
     initial_keys = len(list(store_factory().keys()))
     with pytest.raises(ValueError):
         write_single_partition(
@@ -236,8 +284,29 @@ def test_write_single_partition_different_partitioning(store_factory):
     )
     assert initial_keys + 1 == len(list(store_factory().keys()))
 
+    new_data["label"] = "some_other_label"
     # If no partitioning is given, it will be determined based on the existing dataset
     write_single_partition(
         store=store_factory, dataset_uuid=dataset.uuid, data=new_data
     )
     assert initial_keys + 2 == len(list(store_factory().keys()))
+
+
+def test_store_dataframes_as_dataset_does_not_allow_invalid_indices(store_factory):
+    partitions = [
+        {
+            "label": "part1",
+            "data": [("core", pd.DataFrame({"p": [1, 2]}))],
+            "indices": {"x": ExplicitSecondaryIndex("x", {1: ["part1"], 2: ["part2"]})},
+        }
+    ]
+
+    with pytest.raises(
+        ValueError, match="In table core, no column corresponding to index x"
+    ):
+        store_dataframes_as_dataset(
+            dfs=partitions,
+            store=store_factory,
+            metadata={"dataset": "metadata"},
+            dataset_uuid="dataset_uuid",
+        )

--- a/tests/io/iter/test_read.py
+++ b/tests/io/iter/test_read.py
@@ -9,7 +9,7 @@ from kartothek.io.iter import (
 from kartothek.io.testing.read import *  # noqa
 
 
-@pytest.fixture(params=["dataframe"])
+@pytest.fixture(params=["dataframe", "metapartition"])
 def output_type(request):
     return request.param
 
@@ -17,6 +17,8 @@ def output_type(request):
 def _load_dataframes(output_type, *args, **kwargs):
     if output_type == "dataframe":
         func = read_dataset_as_dataframes__iterator
+    elif output_type == "metapartition":
+        func = read_dataset_as_metapartitions__iterator
     else:
         raise ValueError("Unknown output type {}".format(output_type))
     return list(func(*args, **kwargs))

--- a/tests/io_components/test_dataset.py
+++ b/tests/io_components/test_dataset.py
@@ -16,7 +16,7 @@ def test_dataset_get_indices_as_dataframe_partition_keys_only(
     dataset_with_index, store_session
 ):
     expected = pd.DataFrame(
-        {"P": [1, 2]},
+        OrderedDict([("P", [1, 2])]),
         index=pd.Index(["P=1/cluster_1", "P=2/cluster_2"], name="partition"),
     )
     ds = dataset_with_index.load_partition_indices()

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1,3 +1,7 @@
+# -*- coding: utf-8 -*-
+
+
+import string
 from collections import OrderedDict
 from datetime import date, datetime
 
@@ -20,21 +24,29 @@ from kartothek.io_components.metapartition import (
 from kartothek.serialization import DataFrameSerializer, ParquetSerializer
 
 
-def test_store_single_dataframe_as_partition(store, metadata_version):
+def test_store_single_dataframe_as_partition(
+    store, metadata_storage_format, metadata_version
+):
     df = pd.DataFrame(
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
-    mp = MetaPartition(label="test_label", data=df, metadata_version=metadata_version)
-
-    meta_partition = mp.store_dataframes(
-        store=store, df_serializer=ParquetSerializer(), dataset_uuid="dataset_uuid"
+    mp = MetaPartition(
+        label="test_label", data={"core": df}, metadata_version=metadata_version
     )
 
-    assert meta_partition.data is None
+    meta_partition = mp.store_dataframes(
+        store=store,
+        df_serializer=ParquetSerializer(),
+        dataset_uuid="dataset_uuid",
+        store_metadata=True,
+        metadata_storage_format=metadata_storage_format,
+    )
 
-    expected_key = "dataset_uuid/table/test_label.parquet"
+    assert len(meta_partition.data) == 0
 
-    assert meta_partition.file == expected_key
+    expected_key = "dataset_uuid/core/test_label.parquet"
+
+    assert meta_partition.files == {"core": expected_key}
     assert meta_partition.label == "test_label"
 
     files_in_store = list(store.keys())
@@ -47,37 +59,123 @@ def test_store_single_dataframe_as_partition(store, metadata_version):
     assert len(files_in_store) == expected_num_files - 1
 
 
-def test_load_dataframe_logical_conjunction(store, metadata_version):
+def test_store_single_dataframe_as_partition_no_metadata(store, metadata_version):
+    df = pd.DataFrame(
+        {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
+    )
+    mp = MetaPartition(
+        label="test_label", data={"core": df}, metadata_version=metadata_version
+    )
+    partition = mp.store_dataframes(
+        store=store,
+        df_serializer=ParquetSerializer(),
+        dataset_uuid="dataset_uuid",
+        store_metadata=False,
+    )
+
+    assert len(partition.data) == 0
+
+    expected_file = "dataset_uuid/core/test_label.parquet"
+
+    assert partition.files == {"core": expected_file}
+    assert partition.label == "test_label"
+
+    # One meta one actual file
+    files_in_store = list(store.keys())
+    assert len(files_in_store) == 1
+
+    stored_df = DataFrameSerializer.restore_dataframe(store=store, key=expected_file)
+    pdt.assert_frame_equal(df, stored_df)
+
+
+def test_load_dataframe_logical_conjunction(
+    store, meta_partitions_files_only, metadata_version, metadata_storage_format
+):
     df = pd.DataFrame(
         {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
     )
     mp = MetaPartition(
         label="cluster_1",
-        data=df,
+        data={"core": df},
         metadata_version=metadata_version,
         logical_conjunction=[("P", ">", 4)],
     )
     meta_partition = mp.store_dataframes(
-        store=store, df_serializer=None, dataset_uuid="dataset_uuid"
+        store=store,
+        df_serializer=None,
+        dataset_uuid="dataset_uuid",
+        store_metadata=True,
+        metadata_storage_format=metadata_storage_format,
     )
     predicates = None
     loaded_mp = meta_partition.load_dataframes(store=store, predicates=predicates)
-    data = pd.DataFrame(
-        {"P": [5, 6, 7, 8, 9], "L": [5, 6, 7, 8, 9], "TARGET": [15, 16, 17, 18, 19]}
-    ).set_index(np.arange(5, 10))
-    pdt.assert_frame_equal(loaded_mp.data, data)
+    data = {
+        "core": pd.DataFrame(
+            {"P": [5, 6, 7, 8, 9], "L": [5, 6, 7, 8, 9], "TARGET": [15, 16, 17, 18, 19]}
+        ).set_index(np.arange(5, 10))
+    }
+    pdt.assert_frame_equal(loaded_mp.data["core"], data["core"])
 
     predicates = [[("L", ">", 6), ("TARGET", "<", 18)]]
     loaded_mp = meta_partition.load_dataframes(store=store, predicates=predicates)
-    data = pd.DataFrame({"P": [7], "L": [7], "TARGET": [17]}).set_index(np.array([7]))
-    pdt.assert_frame_equal(loaded_mp.data, data)
+    data = {
+        "core": pd.DataFrame({"P": [7], "L": [7], "TARGET": [17]}).set_index(
+            np.array([7])
+        )
+    }
+    pdt.assert_frame_equal(loaded_mp.data["core"], data["core"])
 
     predicates = [[("L", ">", 2), ("TARGET", "<", 17)], [("TARGET", "==", 19)]]
     loaded_mp = meta_partition.load_dataframes(store=store, predicates=predicates)
-    data = pd.DataFrame(
-        {"P": [5, 6, 9], "L": [5, 6, 9], "TARGET": [15, 16, 19]}
-    ).set_index(np.array([5, 6, 9]))
-    pdt.assert_frame_equal(loaded_mp.data, data)
+    data = {
+        "core": pd.DataFrame(
+            {"P": [5, 6, 9], "L": [5, 6, 9], "TARGET": [15, 16, 19]}
+        ).set_index(np.array([5, 6, 9]))
+    }
+    pdt.assert_frame_equal(loaded_mp.data["core"], data["core"])
+
+
+def test_store_multiple_dataframes_as_partition(
+    store, metadata_storage_format, metadata_version
+):
+    df = pd.DataFrame(
+        {"P": np.arange(0, 10), "L": np.arange(0, 10), "TARGET": np.arange(10, 20)}
+    )
+    df_2 = pd.DataFrame({"P": np.arange(0, 10), "info": string.ascii_lowercase[:10]})
+    mp = MetaPartition(
+        label="cluster_1",
+        data={"core": df, "helper": df_2},
+        metadata_version=metadata_version,
+    )
+    meta_partition = mp.store_dataframes(
+        store=store,
+        df_serializer=None,
+        dataset_uuid="dataset_uuid",
+        store_metadata=True,
+        metadata_storage_format=metadata_storage_format,
+    )
+
+    expected_file = "dataset_uuid/core/cluster_1.parquet"
+    expected_file_helper = "dataset_uuid/helper/cluster_1.parquet"
+
+    assert meta_partition.files == {
+        "core": expected_file,
+        "helper": expected_file_helper,
+    }
+    assert meta_partition.label == "cluster_1"
+
+    files_in_store = list(store.keys())
+    assert len(files_in_store) == 2
+
+    stored_df = DataFrameSerializer.restore_dataframe(store=store, key=expected_file)
+    pdt.assert_frame_equal(df, stored_df)
+    files_in_store.remove(expected_file)
+
+    stored_df = DataFrameSerializer.restore_dataframe(
+        store=store, key=expected_file_helper
+    )
+    pdt.assert_frame_equal(df_2, stored_df)
+    files_in_store.remove(expected_file_helper)
 
 
 @pytest.mark.parametrize("predicate_pushdown_to_io", [True, False])
@@ -86,48 +184,62 @@ def test_load_dataframes(
 ):
     expected_df = pd.DataFrame(
         OrderedDict(
-            [("P", [1]), ("L", [1]), ("TARGET", [1]), ("DATE", [date(2010, 1, 1)])]
+            [
+                ("P", [1]),
+                ("L", [1]),
+                ("TARGET", [1]),
+                ("DATE", pd.to_datetime([date(2010, 1, 1)])),
+            ]
         )
     )
+    expected_df_2 = pd.DataFrame(OrderedDict([("P", [1]), ("info", ["a"])]))
     mp = meta_partitions_files_only[0]
-    assert mp.file
-    assert mp.data is not None
+    assert len(mp.files) > 0
+    assert len(mp.data) == 0
     mp = meta_partitions_files_only[0].load_dataframes(
         store=store_session, predicate_pushdown_to_io=predicate_pushdown_to_io
     )
-    assert mp.data is not None
+    assert len(mp.data) == 2
     data = mp.data
 
-    pdt.assert_frame_equal(data, expected_df, check_dtype=False)
+    pdt.assert_frame_equal(data[SINGLE_TABLE], expected_df, check_dtype=False)
+    pdt.assert_frame_equal(data["helper"], expected_df_2, check_dtype=False)
 
     empty_mp = MetaPartition("empty_mp", metadata_version=mp.metadata_version)
     empty_mp.load_dataframes(
         store_session, predicate_pushdown_to_io=predicate_pushdown_to_io
     )
-    assert empty_mp.data is None
+    assert empty_mp.data == {}
 
 
 def test_remove_dataframes(meta_partitions_files_only, store_session):
     mp = meta_partitions_files_only[0].load_dataframes(store=store_session)
-    assert mp.data is not None
+    assert len(mp.data) == 2
     mp = mp.remove_dataframes()
-    assert mp.data is None
+    assert mp.data == {}
 
 
 def test_load_dataframes_selective(meta_partitions_files_only, store_session):
     expected_df = pd.DataFrame(
         OrderedDict(
-            [("P", [1]), ("L", [1]), ("TARGET", [1]), ("DATE", [date(2010, 1, 1)])]
+            [
+                ("P", [1]),
+                ("L", [1]),
+                ("TARGET", [1]),
+                ("DATE", pd.to_datetime([date(2010, 1, 1)])),
+            ]
         )
     )
     mp = meta_partitions_files_only[0]
-    assert mp.file is not None
-    assert mp.data is not None
-    mp = meta_partitions_files_only[0].load_dataframes(store=store_session)
-
+    assert len(mp.files) > 0
+    assert len(mp.data) == 0
+    mp = meta_partitions_files_only[0].load_dataframes(
+        store=store_session, tables=[SINGLE_TABLE]
+    )
+    assert len(mp.data) == 1
     data = mp.data
 
-    pdt.assert_frame_equal(data, expected_df, check_dtype=False)
+    pdt.assert_frame_equal(data[SINGLE_TABLE], expected_df, check_dtype=False)
 
 
 def test_load_dataframes_columns_projection(
@@ -135,36 +247,60 @@ def test_load_dataframes_columns_projection(
 ):
     expected_df = pd.DataFrame(OrderedDict([("P", [1]), ("L", [1]), ("HORIZON", [1])]))
     mp = meta_partitions_evaluation_files_only[0]
-    assert mp.file is not None
-    assert mp.data is not None
+    assert len(mp.files) > 0
+    assert len(mp.data) == 0
     mp = meta_partitions_evaluation_files_only[0].load_dataframes(
-        store=store_session, columns=["P", "L", "HORIZON"]
+        store=store_session, tables=["PRED"], columns={"PRED": ["P", "L", "HORIZON"]}
     )
-
+    assert len(mp.data) == 1
     data = mp.data
 
-    pdt.assert_frame_equal(data, expected_df, check_dtype=False)
+    pdt.assert_frame_equal(data["PRED"], expected_df, check_dtype=False)
 
 
 def test_load_dataframes_columns_raises_missing(
     meta_partitions_evaluation_files_only, store_session
 ):
     mp = meta_partitions_evaluation_files_only[0]
-    assert mp.file is not None
-    assert mp.data is not None
+    assert len(mp.files) > 0
+    assert len(mp.data) == 0
     with pytest.raises(ValueError) as e:
         meta_partitions_evaluation_files_only[0].load_dataframes(
-            store=store_session, columns=["P", "L", "HORIZON", "foo", "bar"]
+            store=store_session,
+            tables=["PRED"],
+            columns={"PRED": ["P", "L", "HORIZON", "foo", "bar"]},
         )
     assert str(e.value) == "Columns cannot be found in stored dataframe: bar, foo"
 
 
+def test_load_dataframes_columns_table_missing(
+    meta_partitions_evaluation_files_only, store_session
+):
+    # test behavior of load_dataframes for columns argument given
+    # specifying table that doesn't exist
+    mp = meta_partitions_evaluation_files_only[0]
+    assert len(mp.files) > 0
+    assert len(mp.data) == 0
+    with pytest.raises(
+        ValueError,
+        match=r"You are trying to read columns from invalid table\(s\). .*PRED_typo.*",
+    ):
+        mp.load_dataframes(
+            store=store_session,
+            columns={"PRED_typo": ["P", "L", "HORIZON", "foo", "bar"]},
+        )
+
+    # ensure typo in tables argument doesn't raise, as specified in docstring
+    dfs = mp.load_dataframes(store=store_session, tables=["PRED_typo"])
+    assert len(dfs) > 0
+
+
 def test_from_dict():
     df = pd.DataFrame({"a": [1]})
-    dct = {"data": df, "label": "test_label"}
+    dct = {"data": {"core": df}, "label": "test_label"}
     meta_partition = MetaPartition.from_dict(dct)
 
-    pdt.assert_frame_equal(meta_partition.data, df)
+    pdt.assert_frame_equal(meta_partition.data["core"], df)
     assert meta_partition.metadata_version == DEFAULT_METADATA_VERSION
 
 
@@ -175,53 +311,69 @@ def test_eq():
     df_diff_col = pd.DataFrame({"b": [1]})
     df_diff_type = pd.DataFrame({"b": [1.0]})
 
-    meta_partition = MetaPartition.from_dict({"label": "test_label", "data": df})
+    meta_partition = MetaPartition.from_dict(
+        {"label": "test_label", "data": {"core": df}}
+    )
     assert meta_partition == meta_partition
 
     meta_partition_same = MetaPartition.from_dict(
-        {"label": "test_label", "data": df_same}
+        {"label": "test_label", "data": {"core": df_same}}
     )
     assert meta_partition == meta_partition_same
 
     meta_partition_diff_label = MetaPartition.from_dict(
-        {"label": "another_label", "data": df}
+        {"label": "another_label", "data": {"core": df}}
     )
     assert meta_partition != meta_partition_diff_label
     assert meta_partition_diff_label != meta_partition
 
     meta_partition_diff_files = MetaPartition.from_dict(
-        {"label": "another_label", "data": df, "file": "something"}
+        {"label": "another_label", "data": {"core": df}, "files": {"core": "something"}}
     )
     assert meta_partition != meta_partition_diff_files
     assert meta_partition_diff_files != meta_partition
 
     meta_partition_diff_col = MetaPartition.from_dict(
-        {"label": "test_label", "data": df_diff_col}
+        {"label": "test_label", "data": {"core": df_diff_col}}
     )
     assert meta_partition != meta_partition_diff_col
     assert meta_partition_diff_col != meta_partition
 
     meta_partition_diff_type = MetaPartition.from_dict(
-        {"label": "test_label", "data": df_diff_type}
+        {"label": "test_label", "data": {"core": df_diff_type}}
     )
     assert meta_partition != meta_partition_diff_type
     assert meta_partition_diff_type != meta_partition
 
     meta_partition_diff_metadata = MetaPartition.from_dict(
-        {"label": "test_label", "data": df_diff_type}
+        {
+            "label": "test_label",
+            "data": {"core": df_diff_type},
+            "dataset_metadata": {"some": "metadata"},
+        }
     )
     assert meta_partition != meta_partition_diff_metadata
     assert meta_partition_diff_metadata != meta_partition
 
     meta_partition_different_df = MetaPartition.from_dict(
-        {"label": "test_label", "data": df_other}
+        {"label": "test_label", "data": {"core": df_other}}
     )
     assert not meta_partition == meta_partition_different_df
 
+    meta_partition_different_label = MetaPartition.from_dict(
+        {"label": "test_label", "data": {"not_core": df_same}}
+    )
+    assert not meta_partition == meta_partition_different_label
+
     meta_partition_empty_data = MetaPartition.from_dict(
-        {"label": "test_label", "data": None}
+        {"label": "test_label", "data": {}}
     )
     assert meta_partition_empty_data == meta_partition_empty_data
+
+    meta_partition_more_data = MetaPartition.from_dict(
+        {"label": "test_label", "data": {"core": df, "not_core": df}}
+    )
+    assert not (meta_partition == meta_partition_more_data)
 
     assert not meta_partition == "abc"
 
@@ -229,20 +381,21 @@ def test_eq():
 def test_add_nested_to_plain():
     mp = MetaPartition(
         label="label_1",
-        file="file",
-        data=pd.DataFrame({"test": [1, 2, 3]}),
+        files={"core": "file"},
+        data={"core": pd.DataFrame({"test": [1, 2, 3]})},
         indices={"test": [1, 2, 3]},
+        dataset_metadata={"dataset": "metadata"},
     )
 
     to_nest = [
         MetaPartition(
             label="label_2",
-            data=pd.DataFrame({"test": [4, 5, 6]}),
+            data={"core": pd.DataFrame({"test": [4, 5, 6]})},
             indices={"test": [4, 5, 6]},
         ),
         MetaPartition(
             label="label_22",
-            data=pd.DataFrame({"test": [4, 5, 6]}),
+            data={"core": pd.DataFrame({"test": [4, 5, 6]})},
             indices={"test": [4, 5, 6]},
         ),
     ]
@@ -258,15 +411,17 @@ def test_add_nested_to_nested():
     mps1 = [
         MetaPartition(
             label="label_1",
-            file="file",
-            data=pd.DataFrame({"test": [1, 2, 3]}),
+            files={"core": "file"},
+            data={"core": pd.DataFrame({"test": [1, 2, 3]})},
             indices={"test": [1, 2, 3]},
+            dataset_metadata={"dataset": "metadata"},
         ),
         MetaPartition(
             label="label_33",
-            file="file",
-            data=pd.DataFrame({"test": [1, 2, 3]}),
+            files={"core": "file"},
+            data={"core": pd.DataFrame({"test": [1, 2, 3]})},
             indices={"test": [1, 2, 3]},
+            dataset_metadata={"dataset": "metadata"},
         ),
     ]
 
@@ -275,12 +430,12 @@ def test_add_nested_to_nested():
     mps2 = [
         MetaPartition(
             label="label_2",
-            data=pd.DataFrame({"test": [4, 5, 6]}),
+            data={"core": pd.DataFrame({"test": [4, 5, 6]})},
             indices={"test": [4, 5, 6]},
         ),
         MetaPartition(
             label="label_22",
-            data=pd.DataFrame({"test": [4, 5, 6]}),
+            data={"core": pd.DataFrame({"test": [4, 5, 6]})},
             indices={"test": [4, 5, 6]},
         ),
     ]
@@ -298,14 +453,15 @@ def test_add_nested_to_nested():
 def test_eq_nested():
     mp_1 = MetaPartition(
         label="label_1",
-        file="file",
-        data=pd.DataFrame({"test": [1, 2, 3]}),
+        files={"core": "file"},
+        data={"core": pd.DataFrame({"test": [1, 2, 3]})},
         indices={"test": [1, 2, 3]},
+        dataset_metadata={"dataset": "metadata"},
     )
 
     mp_2 = MetaPartition(
         label="label_2",
-        data=pd.DataFrame({"test": [4, 5, 6]}),
+        data={"core": pd.DataFrame({"test": [4, 5, 6]})},
         indices={"test": [4, 5, 6]},
     )
 
@@ -315,7 +471,9 @@ def test_eq_nested():
     assert mp != mp_2
     assert mp_2 != mp
 
-    mp_other = MetaPartition(label="label_3", data=pd.DataFrame({"test": [4, 5, 6]}))
+    mp_other = MetaPartition(
+        label="label_3", data={"core": pd.DataFrame({"test": [4, 5, 6]})}
+    )
     mp_other = mp_1.add_metapartition(mp_other)
     assert mp != mp_other
     assert mp_other != mp
@@ -324,17 +482,66 @@ def test_eq_nested():
 def test_nested_incompatible_meta():
     mp = MetaPartition(
         label="label_1",
-        data=pd.DataFrame({"test": np.array([1, 2, 3], dtype=np.int8)}),
+        data={"core": pd.DataFrame({"test": np.array([1, 2, 3], dtype=np.int8)})},
         metadata_version=4,
     )
 
     mp_2 = MetaPartition(
         label="label_2",
-        data=pd.DataFrame({"test": np.array([4, 5, 6], dtype=np.float64)}),
+        data={"core": pd.DataFrame({"test": np.array([4, 5, 6], dtype=np.float64)})},
         metadata_version=4,
     )
     with pytest.raises(ValueError):
         mp.add_metapartition(mp_2)
+
+
+def test_concatenate_no_change():
+    input_dct = {
+        "first_0": pd.DataFrame({"A": [1], "B": [1]}),
+        "second": pd.DataFrame({"A": [3], "B": [3], "C": [3]}),
+    }
+    dct = {"label": "test_label", "data": input_dct}
+    meta_partition = MetaPartition.from_dict(dct)
+    result = meta_partition.concat_dataframes()
+    assert result == meta_partition
+
+
+def test_concatenate_identical_col_df():
+    input_dct = {
+        "first_0": pd.DataFrame({"A": [1], "B": [1]}),
+        "first_1": pd.DataFrame({"A": [2], "B": [2]}),
+        "second": pd.DataFrame({"A": [3], "B": [3], "C": [3]}),
+    }
+    dct = {"label": "test_label", "data": input_dct}
+    meta_partition = MetaPartition.from_dict(dct)
+    result = meta_partition.concat_dataframes().data
+
+    assert len(result) == 2
+    assert "first" in result
+    first_expected = pd.DataFrame({"A": [1, 2], "B": [1, 2]})
+    pdt.assert_frame_equal(result["first"], first_expected)
+    assert "second" in result
+    first_expected = pd.DataFrame({"A": [3], "B": [3], "C": [3]})
+    pdt.assert_frame_equal(result["second"], first_expected)
+
+
+def test_concatenate_identical_col_df_naming():
+    input_dct = {
+        "some": pd.DataFrame({"A": [1], "B": [1]}),
+        "name": pd.DataFrame({"A": [2], "B": [2]}),
+        "second": pd.DataFrame({"A": [3], "B": [3], "C": [3]}),
+    }
+    dct = {"label": "test_label", "data": input_dct}
+    meta_partition = MetaPartition.from_dict(dct)
+    result = meta_partition.concat_dataframes().data
+
+    assert len(result) == 2
+    assert "some_name" in result
+    first_expected = pd.DataFrame({"A": [1, 2], "B": [1, 2]})
+    pdt.assert_frame_equal(result["some_name"], first_expected)
+    assert "second" in result
+    first_expected = pd.DataFrame({"A": [3], "B": [3], "C": [3]})
+    pdt.assert_frame_equal(result["second"], first_expected)
 
 
 def test_unique_label():
@@ -353,6 +560,88 @@ def test_unique_label():
     label_list = ["something", "else"]
 
     assert _unique_label(label_list) == "something_else"
+
+
+def test_merge_dataframes():
+    df_core = pd.DataFrame(
+        {
+            "P": [1, 1, 1, 1, 3],
+            "L": [1, 2, 1, 2, 3],
+            "C": [1, 1, 2, 2, 3],
+            "TARGET": [1, 2, 3, 4, -1],
+            "info": ["a", "b", "c", "d", "e"],
+        }
+    )
+    df_preds = pd.DataFrame(
+        {
+            "P": [1, 1, 1, 1],
+            "L": [1, 2, 1, 2],
+            "C": [1, 1, 2, 2],
+            "PRED": [11, 22, 33, 44],
+            "HORIZONS": [1, 1, 2, 2],
+        }
+    )
+    mp = MetaPartition(label="part_label", data={"core": df_core, "pred": df_preds})
+
+    mp = mp.merge_dataframes(left="core", right="pred", output_label="merged")
+
+    assert len(mp.data) == 1
+    df_result = mp.data["merged"]
+
+    df_expected = pd.DataFrame(
+        {
+            "P": [1, 1, 1, 1],
+            "L": [1, 2, 1, 2],
+            "C": [1, 1, 2, 2],
+            "PRED": [11, 22, 33, 44],
+            "TARGET": [1, 2, 3, 4],
+            "info": ["a", "b", "c", "d"],
+            "HORIZONS": [1, 1, 2, 2],
+        }
+    )
+    pdt.assert_frame_equal(df_expected, df_result, check_like=True)
+
+
+def test_merge_dataframes_kwargs():
+    df_core = pd.DataFrame(
+        {
+            "P": [1, 1, 1, 1, 3],
+            "L": [1, 2, 1, 2, 3],
+            "C": [1, 1, 2, 2, 3],
+            "TARGET": [1, 2, 3, 4, -1],
+            "info": ["a", "b", "c", "d", "e"],
+        }
+    )
+    df_preds = pd.DataFrame(
+        {
+            "P": [1, 1, 1, 1],
+            "L": [1, 2, 1, 2],
+            "C": [1, 1, 2, 2],
+            "PRED": [11, 22, 33, 44],
+            "HORIZONS": [1, 1, 2, 2],
+        }
+    )
+    mp = MetaPartition(label="part_label", data={"core": df_core, "pred": df_preds})
+
+    mp = mp.merge_dataframes(
+        left="core", right="pred", output_label="merged", merge_kwargs={"how": "left"}
+    )
+
+    assert len(mp.data) == 1
+    df_result = mp.data["merged"]
+
+    df_expected = pd.DataFrame(
+        {
+            "P": [1, 1, 1, 1, 3],
+            "L": [1, 2, 1, 2, 3],
+            "C": [1, 1, 2, 2, 3],
+            "TARGET": [1, 2, 3, 4, -1],
+            "info": ["a", "b", "c", "d", "e"],
+            "PRED": [11, 22, 33, 44, np.NaN],
+            "HORIZONS": [1, 1, 2, 2, np.NaN],
+        }
+    )
+    pdt.assert_frame_equal(df_expected, df_result, check_like=True)
 
 
 def test_merge_indices():
@@ -389,7 +678,7 @@ def test_build_indices():
             [("location", ["Loc1", "Loc2"]), ("product", ["Product1", "Product2"])]
         )
     )
-    mp = MetaPartition(label="partition_label", data=df)
+    mp = MetaPartition(label="partition_label", data={"core": df})
     result_mp = mp.build_indices(columns)
     result = result_mp.indices
     loc_index = ExplicitSecondaryIndex(
@@ -406,13 +695,13 @@ def test_build_indices():
 def test_add_metapartition():
     mp = MetaPartition(
         label="label_1",
-        data=pd.DataFrame({"test": [1, 2, 3]}),
+        data={"core": pd.DataFrame({"test": [1, 2, 3]})},
         indices={"test": [1, 2, 3]},
     )
 
     mp_2 = MetaPartition(
         label="label_2",
-        data=pd.DataFrame({"test": [4, 5, 6]}),
+        data={"core": pd.DataFrame({"test": [4, 5, 6]})},
         indices={"test": [4, 5, 6]},
     )
 
@@ -426,7 +715,7 @@ def test_add_metapartition():
     with pytest.raises(AttributeError):
         new_mp.data
     with pytest.raises(AttributeError):
-        new_mp.file
+        new_mp.files
     with pytest.raises(AttributeError):
         new_mp.indices
     with pytest.raises(AttributeError):
@@ -447,7 +736,7 @@ def test_add_metapartition():
     # This tests whether it is possible to add to an already nested MetaPartition
     mp_3 = MetaPartition(
         label="label_3",
-        data=pd.DataFrame({"test": [7, 8, 9]}),
+        data={"core": pd.DataFrame({"test": [7, 8, 9]})},
         indices={"test": [7, 8, 9]},
     )
     new_mp = new_mp.add_metapartition(mp_3)
@@ -470,27 +759,25 @@ def test_add_metapartition():
 
 
 def test_to_dict(metadata_version):
-    df = pd.DataFrame({"A": [1]})
-    schema = make_meta(df, origin="test")
     mp = MetaPartition(
         label="label_1",
-        file="file",
-        data=df,
+        files={"core": "file"},
+        data={"core": "placeholder"},
         indices={"test": [1, 2, 3]},
         metadata_version=metadata_version,
-        schema=schema,
+        table_meta={"core": {"test": "int8"}},
     )
     mp_dct = mp.to_dict()
     assert mp_dct == {
         "label": "label_1",
-        "data": df,
-        "file": "file",
+        "data": {"core": "placeholder"},
+        "files": {"core": "file"},
         "indices": {"test": [1, 2, 3]},
+        "dataset_metadata": {},
         "metadata_version": metadata_version,
-        "schema": schema,
+        "table_meta": {"core": {"test": "int8"}},
         "partition_keys": [],
         "logical_conjunction": None,
-        "table_name": SINGLE_TABLE,
     }
 
 
@@ -504,7 +791,11 @@ def test_add_metapartition_duplicate_labels():
 
 def test_copy():
     mp = MetaPartition(
-        label="label_1", file="file", data=pd.DataFrame(), indices={"test": [1, 2, 3]}
+        label="label_1",
+        files={"core": "file"},
+        data={"core": pd.DataFrame()},
+        indices={"test": [1, 2, 3]},
+        dataset_metadata={"dataset": "metadata"},
     )
     new_mp = mp.copy()
 
@@ -513,32 +804,38 @@ def test_copy():
     # ... but not the same object
     assert id(new_mp) != id(mp)
 
-    new_mp = mp.copy(file="new_file")
+    new_mp = mp.copy(files={"new": "file"})
     assert id(new_mp) != id(mp)
-    assert new_mp.file == "new_file"
+    assert new_mp.files == {"new": "file"}
 
     new_mp = mp.copy(indices={"new": [1, 2, 3]})
     assert id(new_mp) != id(mp)
     assert new_mp.indices == {"new": [1, 2, 3]}
 
+    new_mp = mp.copy(dataset_metadata={"new": "metadata"})
+    assert id(new_mp) != id(mp)
+    assert new_mp.dataset_metadata == {"new": "metadata"}
+
 
 def test_nested_copy():
     mp = MetaPartition(
         label="label_1",
-        file="file",
-        data=pd.DataFrame({"test": [1, 2, 3]}),
+        files={"core": "file"},
+        data={"core": pd.DataFrame({"test": [1, 2, 3]})},
         indices={"test": {1: "label_1", 2: "label_2", 3: "label_3"}},
+        dataset_metadata={"dataset": "metadata"},
     )
 
     mp_2 = MetaPartition(
         label="label_2",
-        data=pd.DataFrame({"test": [4, 5, 6]}),
+        data={"core": pd.DataFrame({"test": [4, 5, 6]})},
         indices={"test": [4, 5, 6]},
     )
     mp = mp.add_metapartition(mp_2)
     assert len(mp.metapartitions) == 2
     new_mp = mp.copy()
 
+    assert new_mp.dataset_metadata == mp.dataset_metadata
     # Check if the copy is identical
     assert len(new_mp.metapartitions) == len(mp.metapartitions)
     assert new_mp == mp
@@ -549,7 +846,11 @@ def test_nested_copy():
 def test_partition_on_one_level():
     original_df = pd.DataFrame({"test": [1, 2, 3], "some_values": [1, 2, 3]})
     mp = MetaPartition(
-        label="label_1", file="file", data=original_df, metadata_version=4
+        label="label_1",
+        files={"core": "file"},
+        data={"core": original_df},
+        dataset_metadata={"dataset": "metadata"},
+        metadata_version=4,
     )
 
     new_mp = mp.partition_on(["test"])
@@ -560,8 +861,8 @@ def test_partition_on_one_level():
     for mp in new_mp:
         labels.add(mp.label)
         assert len(mp.data) == 1
-        assert mp.data is not None
-        df = mp.data
+        assert "core" in mp.data
+        df = mp.data["core"]
         assert df._is_view
 
         # try to be agnostic about the order
@@ -583,7 +884,11 @@ def test_partition_on_one_level_ts():
         }
     )
     mp = MetaPartition(
-        label="label_1", file="file", data=original_df, metadata_version=4
+        label="label_1",
+        files={"core": "file"},
+        data={"core": original_df},
+        dataset_metadata={"dataset": "metadata"},
+        metadata_version=4,
     )
 
     new_mp = mp.partition_on(["test"])
@@ -594,8 +899,8 @@ def test_partition_on_one_level_ts():
     for mp in new_mp:
         labels.add(mp.label)
         assert len(mp.data) == 1
-        assert mp.data is not None
-        df = mp.data
+        assert "core" in mp.data
+        df = mp.data["core"]
         assert df._is_view
 
         # try to be agnostic about the order
@@ -615,30 +920,35 @@ def test_partition_on_roundtrip(store):
     original_df = pd.DataFrame(
         OrderedDict([("test", [1, 2, 3]), ("some_values", [1, 2, 3])])
     )
-    mp = MetaPartition(label="label_1", data=original_df, metadata_version=4)
+    mp = MetaPartition(
+        label="label_1",
+        data={"core": original_df},
+        dataset_metadata={"dataset": "metadata"},
+        metadata_version=4,
+    )
 
     new_mp = mp.partition_on(["test"])
     new_mp = new_mp.store_dataframes(store=store, dataset_uuid="some_uuid")
-    store_schema_metadata(new_mp.schema, "some_uuid", store)
+    store_schema_metadata(new_mp.table_meta["core"], "some_uuid", store, "core")
     # Test immediately after dropping and later once with new metapartition to check table meta reloading
     new_mp = new_mp.load_dataframes(store=store)
     assert len(new_mp.metapartitions) == 3
     dfs = []
     for internal_mp in new_mp:
-        dfs.append(internal_mp.data)
+        dfs.append(internal_mp.data["core"])
     actual_df = pd.concat(dfs).sort_values(by="test").reset_index(drop=True)
     pdt.assert_frame_equal(original_df, actual_df)
 
     for i in range(1, 4):
         # Check with fresh metapartitions
         new_mp = MetaPartition(
-            label=f"test={i}/label_1",
-            file=f"some_uuid/table/test={i}/label_1.parquet",
+            label="test={}/label_1".format(i),
+            files={"core": "some_uuid/core/test={}/label_1.parquet".format(i)},
             metadata_version=4,
         )
         new_mp = new_mp.load_dataframes(store=store)
 
-        actual_df = new_mp.data
+        actual_df = new_mp.data["core"]
 
         expected_df = pd.DataFrame(OrderedDict([("test", [i]), ("some_values", [i])]))
         pdt.assert_frame_equal(expected_df, actual_df)
@@ -650,7 +960,11 @@ def test_partition_on_raises_no_cols_left(empty):
     if empty:
         original_df = original_df.loc[[]]
     mp = MetaPartition(
-        label="label_1", file="file", data=original_df, metadata_version=4
+        label="label_1",
+        files={"core": "file"},
+        data={"core": original_df},
+        dataset_metadata={"dataset": "metadata"},
+        metadata_version=4,
     )
     with pytest.raises(ValueError) as e:
         mp.partition_on(["test"])
@@ -663,7 +977,11 @@ def test_partition_on_raises_pocols_missing(empty):
     if empty:
         original_df = original_df.loc[[]]
     mp = MetaPartition(
-        label="label_1", file="file", data=original_df, metadata_version=4
+        label="label_1",
+        files={"core": "file"},
+        data={"core": original_df},
+        dataset_metadata={"dataset": "metadata"},
+        metadata_version=4,
     )
     with pytest.raises(ValueError) as e:
         mp.partition_on(["test", "foo", "bar"])
@@ -672,7 +990,7 @@ def test_partition_on_raises_pocols_missing(empty):
 
 def test_partition_urlencode():
     original_df = pd.DataFrame({"ÖŒå": [1, 2, 3], "some_values": [1, 2, 3]})
-    mp = MetaPartition(label="label_1", data=original_df, metadata_version=4)
+    mp = MetaPartition(label="label_1", data={"core": original_df}, metadata_version=4)
 
     new_mp = mp.partition_on(["ÖŒå"])
 
@@ -682,8 +1000,8 @@ def test_partition_urlencode():
     for mp in new_mp:
         labels.add(mp.label)
         assert len(mp.data) == 1
-        assert mp.data is not None
-        df = mp.data
+        assert "core" in mp.data
+        df = mp.data["core"]
         assert df._is_view
 
         # try to be agnostic about the order
@@ -708,7 +1026,11 @@ def test_partition_two_level():
         }
     )
     mp = MetaPartition(
-        label="label_1", file="file", data=original_df, metadata_version=4
+        label="label_1",
+        files={"core": "file"},
+        data={"core": original_df},
+        dataset_metadata={"dataset": "metadata"},
+        metadata_version=4,
     )
 
     new_mp = mp.partition_on(["level1", "level2"])
@@ -718,8 +1040,8 @@ def test_partition_two_level():
     for mp in new_mp:
         labels.append(mp.label)
         assert len(mp.data) == 1
-        assert mp.data is not None
-        df = mp.data
+        assert "core" in mp.data
+        df = mp.data["core"]
         assert df._is_view
 
         # try to be agnostic about the order
@@ -747,10 +1069,18 @@ def test_partition_on_nested():
         }
     )
     mp = MetaPartition(
-        label="label_1", file="file", data=original_df, metadata_version=4
+        label="label_1",
+        files={"core": "file"},
+        data={"core": original_df},
+        dataset_metadata={"dataset": "metadata"},
+        metadata_version=4,
     )
     mp2 = MetaPartition(
-        label="label_2", file="file", data=original_df, metadata_version=4
+        label="label_2",
+        files={"core": "file"},
+        data={"core": original_df},
+        dataset_metadata={"dataset": "metadata"},
+        metadata_version=4,
     )
     mp = mp.add_metapartition(mp2)
     new_mp = mp.partition_on(["level1", "level2"])
@@ -760,8 +1090,8 @@ def test_partition_on_nested():
     for mp in new_mp:
         labels.append(mp.label)
         assert len(mp.data) == 1
-        assert mp.data is not None
-        df = mp.data
+        assert "core" in mp.data
+        df = mp.data["core"]
         assert df._is_view
 
         # try to be agnostic about the order
@@ -786,6 +1116,28 @@ def test_partition_on_nested():
     assert sorted(labels) == sorted(expected_labels)
 
 
+def test_partition_on_multiple_tables_empty_table():
+    original_df = pd.DataFrame({"level1": [1, 2, 3], "no_index_col": np.arange(0, 3)})
+    mp = MetaPartition(
+        label="label_1",
+        data=OrderedDict(
+            [
+                ("core", original_df),
+                ("empty_table", pd.DataFrame(columns=["level1", "another_col"])),
+            ]
+        ),
+        metadata_version=4,
+    )
+    new_mp = mp.partition_on("level1")
+
+    labels = []
+    for mp in new_mp:
+        labels.append(mp.label)
+        assert "empty_table" in mp.data
+        assert mp.data["empty_table"].empty
+        assert set(mp.data["empty_table"].columns) == {"another_col"}
+
+
 def test_partition_on_stable_order():
     """
     Assert that the partition_on algo is stable wrt to row ordering
@@ -799,38 +1151,43 @@ def test_partition_on_stable_order():
     df = pd.DataFrame(
         {"partition_key": random_index, "sorted_col": range(total_values)}
     )
-    mp = MetaPartition(label="label_1", data=df, metadata_version=4)
+    mp = MetaPartition(
+        label="label_1", data=OrderedDict([("table", df)]), metadata_version=4
+    )
     new_mp = mp.partition_on("partition_key")
     for sub_mp in new_mp:
-        sub_df = sub_mp.data
+        sub_df = sub_mp.data["table"]
         assert sub_df.sorted_col.is_monotonic
 
 
 def test_table_meta(store):
     mp = MetaPartition(
         label="label_1",
-        data=pd.DataFrame(
-            {
-                "i32": np.array([1, 2, 3, 1, 2, 3], dtype="int32"),
-                "float": np.array([1, 1, 1, 2, 2, 2], dtype="float64"),
-            }
-        ),
+        data={
+            "core": pd.DataFrame(
+                {
+                    "i32": np.array([1, 2, 3, 1, 2, 3], dtype="int32"),
+                    "float": np.array([1, 1, 1, 2, 2, 2], dtype="float64"),
+                }
+            )
+        },
         metadata_version=4,
     )
 
-    assert mp.schema is not None
+    assert len(mp.table_meta) == 1
+    assert "core" in mp.table_meta
     expected_meta = make_meta(
         pd.DataFrame(
             {"i32": np.array([], dtype="int32"), "float": np.array([], dtype="float64")}
         ),
         origin="1",
     )
-    actual_meta = mp.schema
+    actual_meta = mp.table_meta["core"]
     assert actual_meta == expected_meta
 
     mp = mp.store_dataframes(store, "dataset_uuid")
 
-    actual_meta = mp.schema
+    actual_meta = mp.table_meta["core"]
     assert actual_meta == expected_meta
 
 
@@ -844,8 +1201,8 @@ def test_partition_on_explicit_index():
     )
     mp = MetaPartition(
         label="label_1",
-        file="file",
-        data=original_df,
+        files={"core": "file"},
+        data={"core": original_df},
         indices={
             "explicit_index_col": {value: ["label_1"] for value in np.arange(0, 6)}
         },
@@ -894,17 +1251,17 @@ def test_reconstruct_index_duplicates(store):
     key = ser.store(store, key_prefix, df)
 
     schema = make_meta(df, origin="1", partition_keys="index_col")
-    store_schema_metadata(schema, "uuid", store)
+    store_schema_metadata(schema, "uuid", store, "table")
 
     mp = MetaPartition(
         label="dontcare",
-        file=key,
+        files={"table": key},
         metadata_version=4,
-        schema=schema,
+        table_meta={"table": schema},
         partition_keys=["index_col"],
     )
     mp = mp.load_dataframes(store)
-    df_actual = mp.data
+    df_actual = mp.data["table"]
     df_expected = pd.DataFrame(
         OrderedDict([("index_col", [2, 2]), ("column", list("ab"))])
     )
@@ -922,18 +1279,18 @@ def test_reconstruct_index_categories(store):
     key = ser.store(store, key_prefix, df)
 
     schema = make_meta(df, origin="1", partition_keys="index_col")
-    store_schema_metadata(schema, "uuid", store)
+    store_schema_metadata(schema, "uuid", store, "table")
 
     mp = MetaPartition(
         label="index_col=2/dontcare",
-        file=key,
+        files={"table": key},
         metadata_version=4,
-        schema=schema,
+        table_meta={"table": schema},
         partition_keys=["index_col", "second_index_col"],
     )
     categories = ["second_index_col", "index_col"]
-    mp = mp.load_dataframes(store, categoricals=categories)
-    df_actual = mp.data
+    mp = mp.load_dataframes(store, categoricals={"table": categories})
+    df_actual = mp.data["table"]
     df_expected = pd.DataFrame(
         OrderedDict(
             [
@@ -958,20 +1315,20 @@ def test_reconstruct_index_empty_df(store, categoricals):
     key = ser.store(store, key_prefix, df)
 
     schema = make_meta(df, origin="1", partition_keys="index_col")
-    store_schema_metadata(schema, "uuid", store)
+    store_schema_metadata(schema, "uuid", store, "table")
 
     mp = MetaPartition(
         label="index_col=2/dontcare",
-        file=key,
+        files={"table": key},
         metadata_version=4,
-        schema=schema,
+        table_meta={"table": schema},
         partition_keys=["index_col"],
     )
     categoricals = None
     if categoricals:
-        categoricals = ["index_col"]
+        categoricals = {"table": ["index_col"]}
     mp = mp.load_dataframes(store, categoricals=categoricals)
-    df_actual = mp.data
+    df_actual = mp.data["table"]
     df_expected = pd.DataFrame(
         OrderedDict([("index_col", [2, 2]), ("column", list("ab"))])
     )
@@ -994,18 +1351,18 @@ def test_reconstruct_date_index(store, metadata_version, dates_as_object):
     key = ser.store(store, key_prefix, df)
 
     schema = make_meta(df, origin="1", partition_keys="index_col")
-    store_schema_metadata(schema, "uuid", store)
+    store_schema_metadata(schema, "uuid", store, "table")
 
     mp = MetaPartition(
         label="dontcare",
-        file=key,
+        files={"table": key},
         metadata_version=metadata_version,
-        schema=schema,
+        table_meta={"table": schema},
         partition_keys=["index_col"],
     )
 
     mp = mp.load_dataframes(store, dates_as_object=dates_as_object)
-    df_actual = mp.data
+    df_actual = mp.data["table"]
     if dates_as_object:
         dt_constructor = date
     else:
@@ -1029,23 +1386,26 @@ def test_iter_empty_metapartition():
 
 
 def test_concat_metapartition(df_all_types):
-    mp1 = MetaPartition(label="first", data=df_all_types, metadata_version=4)
-    mp2 = MetaPartition(label="second", data=df_all_types, metadata_version=4)
+    mp1 = MetaPartition(label="first", data={"table": df_all_types}, metadata_version=4)
+    mp2 = MetaPartition(
+        label="second", data={"table": df_all_types}, metadata_version=4
+    )
 
     new_mp = MetaPartition.concat_metapartitions([mp1, mp2])
 
     # what the label actually is, doesn't matter so much
     assert new_mp.label is not None
+    assert new_mp.tables == ["table"]
     df_expected = pd.concat([df_all_types, df_all_types])
-    df_actual = new_mp.data
+    df_actual = new_mp.data["table"]
     pdt.assert_frame_equal(df_actual, df_expected)
 
 
 def test_concat_metapartition_wrong_types(df_all_types):
-    mp1 = MetaPartition(label="first", data=df_all_types, metadata_version=4)
+    mp1 = MetaPartition(label="first", data={"table": df_all_types}, metadata_version=4)
     df_corrupt = df_all_types.copy()
     df_corrupt["int8"] = "NoInteger"
-    mp2 = MetaPartition(label="second", data=df_corrupt, metadata_version=4)
+    mp2 = MetaPartition(label="second", data={"table": df_corrupt}, metadata_version=4)
 
     with pytest.raises(ValueError, match="Schema violation"):
         MetaPartition.concat_metapartitions([mp1, mp2])
@@ -1054,21 +1414,22 @@ def test_concat_metapartition_wrong_types(df_all_types):
 def test_concat_metapartition_partitioned(df_all_types):
     mp1 = MetaPartition(
         label="int8=1/1234",
-        data=df_all_types,
+        data={"table": df_all_types},
         metadata_version=4,
         partition_keys=["int8"],
     )
     mp2 = MetaPartition(
         label="int8=1/4321",
-        data=df_all_types,
+        data={"table": df_all_types},
         metadata_version=4,
         partition_keys=["int8"],
     )
 
     new_mp = MetaPartition.concat_metapartitions([mp1, mp2])
 
+    assert new_mp.tables == ["table"]
     df_expected = pd.concat([df_all_types, df_all_types])
-    df_actual = new_mp.data
+    df_actual = new_mp.data["table"]
     pdt.assert_frame_equal(df_actual, df_expected)
 
     assert new_mp.partition_keys == ["int8"]
@@ -1077,13 +1438,13 @@ def test_concat_metapartition_partitioned(df_all_types):
 def test_concat_metapartition_different_partitioning(df_all_types):
     mp1 = MetaPartition(
         label="int8=1/1234",
-        data=df_all_types,
+        data={"table": df_all_types},
         metadata_version=4,
         partition_keys=["int8"],
     )
     mp2 = MetaPartition(
         label="float8=1.0/4321",
-        data=df_all_types,
+        data={"table": df_all_types},
         metadata_version=4,
         partition_keys=["float8"],
     )
@@ -1095,21 +1456,21 @@ def test_concat_metapartition_different_partitioning(df_all_types):
 def test_concat_metapartition_categoricals(df_all_types):
     mp1 = MetaPartition(
         label="first",
-        data=pd.DataFrame({"a": [0, 0], "b": ["a", "a"]}, dtype="category"),
+        data={"table": pd.DataFrame({"a": [0, 0], "b": ["a", "a"]}, dtype="category")},
         metadata_version=4,
         partition_keys=["a"],
     )
     mp2 = MetaPartition(
         label="second",
-        data=pd.DataFrame({"a": [1, 1], "b": ["a", "b"]}, dtype="category"),
+        data={"table": pd.DataFrame({"a": [1, 1], "b": ["a", "b"]}, dtype="category")},
         metadata_version=4,
         partition_keys=["a"],
     )
 
     new_mp = MetaPartition.concat_metapartitions([mp1, mp2])
 
-    assert new_mp.table_name == "table"
-    assert pd.api.types.is_categorical_dtype(new_mp.data["b"].dtype)
+    assert new_mp.tables == ["table"]
+    assert pd.api.types.is_categorical_dtype(new_mp.data["table"]["b"].dtype)
 
 
 # We can't partition on null columns (gh-262)
@@ -1121,7 +1482,9 @@ def test_partition_on_scalar_intermediate(df_not_nested, col):
     Test against a bug where grouping leaves a scalar value
     """
     assert len(df_not_nested) == 1
-    mp = MetaPartition(label="somelabel", data=df_not_nested, metadata_version=4)
+    mp = MetaPartition(
+        label="somelabel", data={"table": df_not_nested}, metadata_version=4
+    )
     new_mp = mp.partition_on(col)
     assert len(new_mp) == 1
 
@@ -1129,7 +1492,7 @@ def test_partition_on_scalar_intermediate(df_not_nested, col):
 def test_partition_on_with_primary_index_invalid(df_not_nested):
     mp = MetaPartition(
         label="pkey=1/pkey2=2/base_label",
-        data=df_not_nested,
+        data={"table": df_not_nested},
         partition_keys=["pkey", "pkey2"],
         metadata_version=4,
     )
@@ -1152,7 +1515,7 @@ def test_partition_on_with_primary_index_invalid(df_not_nested):
 def test_partition_on_with_primary_index(df_not_nested):
     mp = MetaPartition(
         label="pkey=1/base_label",
-        data=df_not_nested,
+        data={"table": df_not_nested},
         partition_keys=["pkey"],
         metadata_version=4,
     )
@@ -1200,12 +1563,12 @@ def test_column_string_cast(df_all_types, store, metadata_version):
     key = ser.store(store, "uuid/table/something", df_all_types)
     mp = MetaPartition(
         label="something",
-        file=key,
-        schema=make_meta(df_all_types, origin="table"),
+        files={"table": key},
+        table_meta={"table": make_meta(df_all_types, origin="table")},
         metadata_version=metadata_version,
     )
     mp = mp.load_dataframes(store)
-    df = mp.data
+    df = mp.data["table"]
     assert all(original_columns == df.columns)
 
 
@@ -1215,11 +1578,18 @@ def test_partition_on_valid_schemas():
     sub partitions may be different
     """
     df = pd.DataFrame({"partition_col": [0, 1], "values": [None, "str"]})
-    mp = MetaPartition(label="base_label", data=df, metadata_version=4)
+    mp = MetaPartition(label="base_label", data={"table": df}, metadata_version=4)
     mp = mp.partition_on(["partition_col"])
     assert len(mp) == 2
     expected_meta = make_meta(df, origin="1", partition_keys="partition_col")
-    assert mp.schema == expected_meta
+    assert mp.table_meta["table"] == expected_meta
+
+
+def test_dataframe_input_to_metapartition():
+    with pytest.raises(ValueError):
+        parse_input_to_metapartition(tuple([1]))
+    with pytest.raises(ValueError):
+        parse_input_to_metapartition("abc")
 
 
 def test_input_to_metaframes_empty():
@@ -1235,28 +1605,74 @@ def test_input_to_metaframes_simple():
 
     assert isinstance(mp, MetaPartition)
     assert len(mp.data) == 1
-    assert mp.file is None
+    assert len(mp.files) == 0
 
-    df = mp.data
+    df = list(mp.data.values())[0]
     pdt.assert_frame_equal(df, df_input)
 
     assert isinstance(mp.label, str)
 
 
+def test_input_to_metaframes_dict():
+    df_input = {
+        "label": "cluster_1",
+        "data": [
+            ("some_file", pd.DataFrame({"A": [1]})),
+            ("some_other_file", pd.DataFrame({"B": [2]})),
+        ],
+    }
+    mp = parse_input_to_metapartition(obj=df_input)
+    assert isinstance(mp, MetaPartition)
+    assert len(mp.data) == 2
+    assert len(mp.files) == 0
+
+    assert mp.label == "cluster_1"
+
+    data = mp.data
+
+    df = data["some_file"]
+    pdt.assert_frame_equal(
+        df, pd.DataFrame({"A": [1]}), check_dtype=False, check_like=True
+    )
+
+    df2 = data["some_other_file"]
+    pdt.assert_frame_equal(
+        df2, pd.DataFrame({"B": [2]}), check_dtype=False, check_like=True
+    )
+
+
 def test_parse_nested_input_schema_compatible_but_different():
     # Ensure that input can be parsed even though the schemas are not identical but compatible
-    df_input = [[pd.DataFrame({"A": [None]}), pd.DataFrame({"A": ["str"]})]]
+    df_input = [
+        [
+            {"data": {"table": pd.DataFrame({"A": [None]})}},
+            {"data": {"table": pd.DataFrame({"A": ["str"]})}},
+        ]
+    ]
     mp = parse_input_to_metapartition(df_input, metadata_version=4)
     expected_schema = make_meta(pd.DataFrame({"A": ["str"]}), origin="expected")
-    assert mp.schema == expected_schema
+    assert mp.table_meta["table"] == expected_schema
+
+
+def test_parse_input_schema_formats():
+    df = pd.DataFrame({"B": [pd.Timestamp("2019")]})
+    formats_obj = [
+        {"data": {"table1": df}},
+        {"table1": df},
+        {"data": [("table1", df)]},
+        [("table1", df)],
+    ]
+    for obj in formats_obj:
+        mp = parse_input_to_metapartition(obj=obj, metadata_version=4)
+        assert mp.data == {"table1": df}
 
 
 def test_get_parquet_metadata(store):
     df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
-    mp = MetaPartition(label="test_label", data=df)
-    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid")
+    mp = MetaPartition(label="test_label", data={"core": df},)
+    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
 
-    actual = meta_partition.get_parquet_metadata(store=store)
+    actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
     actual.drop(labels="serialized_size", axis=1, inplace=True)
     actual.drop(labels="row_group_compressed_size", axis=1, inplace=True)
     actual.drop(labels="row_group_uncompressed_size", axis=1, inplace=True)
@@ -1275,10 +1691,10 @@ def test_get_parquet_metadata(store):
 
 def test_get_parquet_metadata_empty_df(store):
     df = pd.DataFrame()
-    mp = MetaPartition(label="test_label", data=df)
-    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid")
+    mp = MetaPartition(label="test_label", data={"core": df},)
+    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
 
-    actual = meta_partition.get_parquet_metadata(store=store)
+    actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
     actual.drop(
         columns=[
             "serialized_size",
@@ -1304,13 +1720,13 @@ def test_get_parquet_metadata_empty_df(store):
 
 def test_get_parquet_metadata_row_group_size(store):
     df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
-    mp = MetaPartition(label="test_label", data=df)
+    mp = MetaPartition(label="test_label", data={"core": df},)
     ps = ParquetSerializer(chunk_size=5)
 
     meta_partition = mp.store_dataframes(
         store=store, dataset_uuid="dataset_uuid", df_serializer=ps
     )
-    actual = meta_partition.get_parquet_metadata(store=store)
+    actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
     actual.drop(
         columns=[
             "serialized_size",
@@ -1333,25 +1749,12 @@ def test_get_parquet_metadata_row_group_size(store):
     pd.testing.assert_frame_equal(actual, expected)
 
 
-def test__reconstruct_index_columns():
-    df = pd.DataFrame({"x": [0], "a": [-1], "b": [-2], "c": [-3]})
-    mp = MetaPartition(label="test_label", data=df)
-    df_with_index_columns = mp._reconstruct_index_columns(
-        df=df[["x"]],
-        key_indices=[("a", 1), ("b", 2), ("c", 3)],
-        columns=["x", "c"],
-        categories=None,
-        date_as_object=False,
-    )
-    # Index columns first
-    pdt.assert_frame_equal(df_with_index_columns, pd.DataFrame({"c": [3], "x": [0]}))
+def test_get_parquet_metadata_table_name_not_str(store):
+    df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
+    mp = MetaPartition(label="test_label", data={"core": df, "another_table": df},)
+    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
 
-
-def test_partition_on_keeps_table_name():
-    mp = MetaPartition(
-        label="label_1",
-        data=pd.DataFrame({"P": [1, 2, 1, 2], "L": [1, 1, 2, 2]}),
-        table_name="non-default-name",
-    )
-    repartitioned_mp = mp.partition_on(["P"])
-    assert repartitioned_mp.table_name == "non-default-name"
+    with pytest.raises(TypeError):
+        meta_partition.get_parquet_metadata(
+            store=store, table_name=["core", "another_table"]
+        )

--- a/tests/io_components/test_mutate.py
+++ b/tests/io_components/test_mutate.py
@@ -1,0 +1,234 @@
+import types
+
+import pandas as pd
+import pytest
+
+from kartothek.io_components.merge import align_datasets
+from kartothek.io_components.metapartition import MetaPartition
+from kartothek.io_components.write import store_dataset_from_partitions
+
+
+def test_align_datasets_prefix(dataset, evaluation_dataset, store_session):
+    generator = align_datasets(
+        left_dataset_uuid=dataset.uuid,
+        right_dataset_uuid=evaluation_dataset.uuid,
+        store=store_session,
+        match_how="prefix",
+    )
+    assert isinstance(generator, types.GeneratorType)
+    list_metapartitions = list(generator)
+
+    # Two separate cluster_groups (e.g. cluster_1*)
+    assert len(list_metapartitions) == 2
+
+    mp_list = list_metapartitions[0]
+
+    assert len(mp_list) == 3, [mp.label for mp in mp_list]
+
+    mp_list = list_metapartitions[1]
+    assert len(mp_list) == 3, [mp.label for mp in mp_list]
+
+    # Test sorting of datasets by length, i.e. order of dataframes is different
+    generator = align_datasets(
+        left_dataset_uuid=evaluation_dataset.uuid,
+        right_dataset_uuid=dataset.uuid,
+        store=store_session,
+        match_how="prefix",
+    )
+    list_metapartitions = list(generator)
+    mp_list = list_metapartitions[0]
+
+
+def test_align_datasets_prefix__equal_number_of_partitions(
+    dataset, evaluation_dataset, store_session
+):
+    """
+    Test a scenario where the simple prefix match algorithm didn't find any
+    matches in case of equal number of partitions in both datasets.
+    """
+
+    # Create a reference dataset which matches the problem (equal number of
+    # partitions and suitable for prefix matching)
+    mp = MetaPartition(label="cluster_1_1", metadata_version=dataset.metadata_version)
+    mp2 = MetaPartition(label="cluster_2_1", metadata_version=dataset.metadata_version)
+    metapartitions = [mp, mp2]
+    store_dataset_from_partitions(
+        partition_list=metapartitions,
+        dataset_uuid="reference_dataset_uuid",
+        store=store_session,
+    )
+
+    generator = align_datasets(
+        left_dataset_uuid=dataset.uuid,
+        right_dataset_uuid="reference_dataset_uuid",
+        store=store_session,
+        match_how="prefix",
+    )
+    assert isinstance(generator, types.GeneratorType)
+    list_metapartitions = list(generator)
+
+    # Two separate cluster_groups (e.g. cluster_1*)
+    assert len(list_metapartitions) == 2
+
+    mp_list = list_metapartitions[0]
+
+    assert len(mp_list) == 2
+
+    mp_list = list_metapartitions[1]
+    assert len(mp_list) == 2
+
+    # Test sorting of datasets by length, i.e. order of dataframes is different
+    generator = align_datasets(
+        left_dataset_uuid=evaluation_dataset.uuid,
+        right_dataset_uuid=dataset.uuid,
+        store=store_session,
+        match_how="prefix",
+    )
+    list_metapartitions = list(generator)
+    mp_list = list_metapartitions[0]
+
+
+def test_align_datasets_exact(dataset, evaluation_dataset, store_session):
+    with pytest.raises(RuntimeError):
+        list(
+            align_datasets(
+                left_dataset_uuid=dataset.uuid,
+                right_dataset_uuid=evaluation_dataset.uuid,
+                store=store_session,
+                match_how="exact",
+            )
+        )
+
+    generator = align_datasets(
+        left_dataset_uuid=dataset.uuid,
+        right_dataset_uuid=dataset.uuid,
+        store=store_session,
+        match_how="exact",
+    )
+    assert isinstance(generator, types.GeneratorType)
+    list_metapartitions = list(generator)
+
+    # Two separate cluster_groups (e.g. cluster_1*)
+    assert len(list_metapartitions) == 2
+
+    mp_list = list_metapartitions[0]
+    assert len(mp_list) == 2, [mp.label for mp in mp_list]
+    assert [mp.label for mp in mp_list] == ["cluster_1", "cluster_1"]
+
+    mp_list = list_metapartitions[1]
+    assert len(mp_list) == 2, [mp.label for mp in mp_list]
+    assert [mp.label for mp in mp_list] == ["cluster_2", "cluster_2"]
+
+
+def test_align_datasets_left(dataset, evaluation_dataset, store_session):
+    generator = align_datasets(
+        left_dataset_uuid=dataset.uuid,
+        right_dataset_uuid=evaluation_dataset.uuid,
+        store=store_session,
+        match_how="left",
+    )
+    assert isinstance(generator, types.GeneratorType)
+    list_metapartitions = list(generator)
+
+    assert len(list_metapartitions) == len(dataset.partitions)
+
+    mp_list = list_metapartitions[0]
+    assert len(mp_list) == 5, [mp.label for mp in mp_list]
+    expected = ["cluster_1", "cluster_1_1", "cluster_1_2", "cluster_2_1", "cluster_2_2"]
+    assert [mp.label for mp in mp_list] == expected
+
+    mp_list = list_metapartitions[1]
+    assert len(mp_list) == 5, [mp.label for mp in mp_list]
+    expected = ["cluster_2", "cluster_1_1", "cluster_1_2", "cluster_2_1", "cluster_2_2"]
+    assert [mp.label for mp in mp_list] == expected
+
+
+def test_align_datasets_right(dataset, evaluation_dataset, store_session):
+    generator = align_datasets(
+        left_dataset_uuid=dataset.uuid,
+        right_dataset_uuid=evaluation_dataset.uuid,
+        store=store_session,
+        match_how="right",
+    )
+    assert isinstance(generator, types.GeneratorType)
+    list_metapartitions = list(generator)
+
+    assert len(list_metapartitions) == len(evaluation_dataset.partitions)
+
+    mp_list = list_metapartitions[0]
+    assert len(mp_list) == 3, [mp.label for mp in mp_list]
+    expected = ["cluster_1_1", "cluster_1", "cluster_2"]
+    assert [mp.label for mp in mp_list] == expected
+
+    mp_list = list_metapartitions[1]
+    assert len(mp_list) == 3, [mp.label for mp in mp_list]
+    expected = ["cluster_1_2", "cluster_1", "cluster_2"]
+    assert [mp.label for mp in mp_list] == expected
+
+    mp_list = list_metapartitions[2]
+    assert len(mp_list) == 3, [mp.label for mp in mp_list]
+    expected = ["cluster_2_1", "cluster_1", "cluster_2"]
+    assert [mp.label for mp in mp_list] == expected
+
+    mp_list = list_metapartitions[3]
+    assert len(mp_list) == 3, [mp.label for mp in mp_list]
+    expected = ["cluster_2_2", "cluster_1", "cluster_2"]
+    assert [mp.label for mp in mp_list] == expected
+
+
+def test_align_datasets_callable(dataset, evaluation_dataset, store_session):
+    def comp(left, right):
+        return left == right
+
+    with pytest.raises(RuntimeError):
+        list(
+            align_datasets(
+                left_dataset_uuid=dataset.uuid,
+                right_dataset_uuid=evaluation_dataset.uuid,
+                store=store_session,
+                match_how=comp,
+            )
+        )
+
+    generator = align_datasets(
+        left_dataset_uuid=dataset.uuid,
+        right_dataset_uuid=dataset.uuid,
+        store=store_session,
+        match_how=comp,
+    )
+    assert isinstance(generator, types.GeneratorType)
+    list_metapartitions = list(generator)
+
+    # Two separate cluster_groups (e.g. cluster_1*)
+    assert len(list_metapartitions) == 2
+
+    mp_list = list_metapartitions[0]
+    assert len(mp_list) == 2, [mp.label for mp in mp_list]
+    assert [mp.label for mp in mp_list] == ["cluster_1", "cluster_1"]
+
+    mp_list = list_metapartitions[1]
+    assert len(mp_list) == 2, [mp.label for mp in mp_list]
+    assert [mp.label for mp in mp_list] == ["cluster_2", "cluster_2"]
+
+
+def test_merge_metapartitions():
+    df = pd.DataFrame({"P": [1, 1], "L": [1, 2], "TARGET": [1, 2]})
+    df_2 = pd.DataFrame({"P": [1], "info": "a"})
+    mp = MetaPartition(label="cluster_1", data={"core": df, "helper": df_2})
+    df_3 = pd.DataFrame({"P": [1, 1], "L": [1, 2], "PRED": [0.1, 0.2]})
+
+    mp2 = MetaPartition(label="cluster_1", data={"predictions": df_3})
+    merged_mp = MetaPartition.merge_metapartitions(metapartitions=[mp, mp2])
+
+    df = pd.DataFrame(
+        {
+            "P": [1, 1],
+            "L": [1, 2],
+            "TARGET": [1, 2],
+            "info": ["a", "a"],
+            "PRED": [0.1, 0.2],
+        }
+    )
+
+    assert merged_mp.label == "cluster_1"
+    assert len(merged_mp.data) == 3

--- a/tests/io_components/test_write.py
+++ b/tests/io_components/test_write.py
@@ -35,7 +35,7 @@ def test_store_dataset_from_partitions(meta_partitions_files_only, store, frozen
     # Dataset metadata: 1 file
     expected_number_files = 1
     # common metadata for v4 datasets
-    expected_number_files += 1
+    expected_number_files += 2
     assert len(store_files) == expected_number_files
 
     # Ensure the dataset can be loaded properly
@@ -46,15 +46,15 @@ def test_store_dataset_from_partitions(meta_partitions_files_only, store, frozen
 def test_store_dataset_from_partitions_update(store, metadata_version, frozen_time):
     mp1 = MetaPartition(
         label="cluster_1",
-        data=pd.DataFrame({"p": [1]}),
-        file="1.parquet",
+        data={"df": pd.DataFrame({"p": [1]})},
+        files={"df": "1.parquet"},
         indices={"p": ExplicitSecondaryIndex("p", index_dct={1: ["cluster_1"]})},
         metadata_version=metadata_version,
     )
     mp2 = MetaPartition(
         label="cluster_2",
-        data=pd.DataFrame({"p": [2]}),
-        file="2.parquet",
+        data={"df": pd.DataFrame({"p": [2]})},
+        files={"df": "2.parquet"},
         indices={"p": ExplicitSecondaryIndex("p", index_dct={2: ["cluster_2"]})},
         metadata_version=metadata_version,
     )
@@ -68,8 +68,8 @@ def test_store_dataset_from_partitions_update(store, metadata_version, frozen_ti
 
     mp3 = MetaPartition(
         label="cluster_3",
-        data=pd.DataFrame({"p": [3]}),
-        file="3.parquet",
+        data={"df": pd.DataFrame({"p": [3]})},
+        files={"df": "3.parquet"},
         indices={"p": ExplicitSecondaryIndex("p", index_dct={3: ["cluster_3"]})},
         metadata_version=metadata_version,
     )

--- a/tests/utils/test_ktk_adapters.py
+++ b/tests/utils/test_ktk_adapters.py
@@ -11,11 +11,12 @@ from kartothek.core.cube.constants import (
 from kartothek.core.cube.cube import Cube
 from kartothek.core.dataset import DatasetMetadata
 from kartothek.io.dask.bag import store_bag_as_dataset
-from kartothek.io_components.metapartition import MetaPartition
+from kartothek.io_components.metapartition import SINGLE_TABLE, MetaPartition
 from kartothek.io_components.read import dispatch_metapartitions
 from kartothek.utils.ktk_adapters import (
     get_dataset_columns,
     get_dataset_keys,
+    get_dataset_schema,
     get_partition_dataframe,
     get_physical_partition_stats,
     metadata_factory_from_dataset,
@@ -41,7 +42,9 @@ def ds(function_store, cube_has_ts_col):
 
     mps = [
         MetaPartition(
-            label="mp{}".format(i), data=df, metadata_version=KTK_CUBE_METADATA_VERSION,
+            label="mp{}".format(i),
+            data={SINGLE_TABLE: df},
+            metadata_version=KTK_CUBE_METADATA_VERSION,
         )
         .partition_on(["p"] + (["KLEE_TS"] if cube_has_ts_col else []))
         .build_indices(["i"])
@@ -57,6 +60,10 @@ def ds(function_store, cube_has_ts_col):
         metadata_version=KTK_CUBE_METADATA_VERSION,
         df_serializer=KTK_CUBE_DF_SERIALIZER,
     ).compute()
+
+
+def test_get_dataset_schema(ds):
+    assert get_dataset_schema(ds) == ds.table_meta[SINGLE_TABLE]
 
 
 def test_get_dataset_columns(ds):


### PR DESCRIPTION
This pull request reverts all changes made in 4.x and brings the codebase back to 3.20.0. This should become a starting point for a new stable 5.x release. (See issue #471.)