### PR TITLE
Fix test by matching error messages appearing from dask > 2021.5.0, fix documentation build and prepare release 5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-Version 5.0.0 (2021-05-xx)
+Version 5.0.0 (2021-06-23)
 ==========================
 
 This release rolls all the changes introduced with 4.x back to 3.20.0.

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -35,7 +35,7 @@ dependencies:
   - setuptools_scm
 
   # Documentation
-  - sphinx
+  - sphinx<4.0
   - sphinx_rtd_theme
   - sphinx-click
   - IPython

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -62,7 +62,7 @@ def test_delayed_as_delete_scope(store_factory, df_all_types):
 
 @pytest.mark.parametrize("shuffle", [True, False])
 def test_update_dataset_from_ddf_empty(store_factory, shuffle):
-    with pytest.raises(ValueError, match="Cannot store empty datasets"):
+    with pytest.raises(ValueError) as exc_info:
         update_dataset_from_ddf(
             dask.dataframe.from_delayed([], meta=(("a", int),)),
             store_factory,
@@ -71,3 +71,8 @@ def test_update_dataset_from_ddf_empty(store_factory, shuffle):
             shuffle=shuffle,
             partition_on=["a"],
         ).compute()
+    assert str(exc_info.value) in [
+        "Cannot store empty datasets",  # dask <= 2021.5.0
+        "Cannot store empty datasets, partition_list must not be empty if in store mode.",  # dask > 2021.5.0 + shuffle == True
+        "No data left to save outside partition columns",  # dask > 2021.5.0 + shuffle == False
+    ]


### PR DESCRIPTION
# Description:
With #475 we pinned dask do not use 2021.5.1 and 2021.6.0 since they contained known issues (dask/dask#7586).
That issue should have been fixed by https://github.com/dask/dask/pull/7769 which should have been included in >2021.6.0.
However, the the release of dask 2021.6.1, the original issue is gone, but there is another (possibly different) issue.
The message text for empty Dask Data Frames changed in a way that it's dependent on a shuffle operation. See https://github.com/JDASoftwareGroup/kartothek/runs/2880306923?check_suite_focus=true for the exact error messages.

This PR proposes to check for all 3 kind of error message to make sure the test runs with all dask versions and indepedently of the `shuffle` parameter. I decided against checking only for `ValueError` because then we might miss some other `ValueErrors` which actually are bugs.

@fjetter fyi, since this could be of interest  for you because it might be a follow up for https://github.com/dask/dask/pull/7769