### PR TITLE
Maintenance/additional tests

### DIFF
--- a/kartothek/io/testing/read.py
+++ b/kartothek/io/testing/read.py
@@ -638,11 +638,17 @@ def test_read_dataset_alternative_table_name(
         store_factory = None
         ds_factory = dataset_factory_alternative_table_name
 
+    # the table to be read must be passed either as string or list
     if isinstance(bound_load_dataframes, functools.partial):
+        # iter
         read_kwargs = {"tables": [alternative_table_name]}
-    elif bound_load_dataframes.__name__ == "_read_table":
+    elif (bound_load_dataframes.__name__ == "_read_table") or (
+        bound_load_dataframes.__name__ == "_read_as_ddf"
+    ):
+        # eager table or dask dataframe
         read_kwargs = {"tables": alternative_table_name}
     else:
+        # eager dataframe
         read_kwargs = {"tables": [alternative_table_name]}
 
     _perform_read_test(

--- a/kartothek/io/testing/read.py
+++ b/kartothek/io/testing/read.py
@@ -619,7 +619,7 @@ def test_read_dataset_as_dataframes(
 
 def test_read_dataset_alternative_table_name(
     dataset_alternative_table_name,
-    store_session_factory,
+    store_factory,
     dataset_factory_alternative_table_name,
     use_dataset_factory,
     bound_load_dataframes,
@@ -631,7 +631,6 @@ def test_read_dataset_alternative_table_name(
 ):
     if use_dataset_factory:
         dataset_uuid = dataset_alternative_table_name.uuid
-        store_factory = store_session_factory
         ds_factory = None
     else:
         dataset_uuid = None
@@ -640,8 +639,12 @@ def test_read_dataset_alternative_table_name(
 
     # the table to be read must be passed either as string or list
     if isinstance(bound_load_dataframes, functools.partial):
-        # iter
-        read_kwargs = {"tables": [alternative_table_name]}
+        if output_type == "table":
+            # dask delayed
+            read_kwargs = {"tables": alternative_table_name}
+        else:
+            # iter or dask bag
+            read_kwargs = {"tables": [alternative_table_name]}
     elif (bound_load_dataframes.__name__ == "_read_table") or (
         bound_load_dataframes.__name__ == "_read_as_ddf"
     ):

--- a/kartothek/io/testing/read.py
+++ b/kartothek/io/testing/read.py
@@ -31,7 +31,6 @@ The following fixtures should be present (see tests.read.conftest)
 """
 
 import datetime
-import functools
 from distutils.version import LooseVersion
 from functools import partial
 from itertools import permutations
@@ -638,7 +637,7 @@ def test_read_dataset_alternative_table_name(
         ds_factory = dataset_factory_alternative_table_name
 
     # the table to be read must be passed either as string or list
-    if isinstance(bound_load_dataframes, functools.partial):
+    if isinstance(bound_load_dataframes, partial):
         if output_type == "table":
             # dask delayed
             read_kwargs = {"tables": alternative_table_name}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,7 +280,7 @@ def df_not_nested():
 
 
 def _get_meta_partitions_with_dataframe(
-    metadata_version, table_name=SINGLE_TABLE, table_name_2=SINGLE_TABLE
+    metadata_version, table_name=SINGLE_TABLE, table_name_2="helper"
 ):
     df = pd.DataFrame(
         OrderedDict(
@@ -293,11 +293,14 @@ def _get_meta_partitions_with_dataframe(
         )
     )
     df_2 = pd.DataFrame(OrderedDict([("P", [1]), ("info", ["a"])]))
-    mp = MetaPartition(
-        label="cluster_1",
-        data={table_name: df, "helper": df_2},
-        metadata_version=metadata_version,
-    )
+    if table_name_2 is not None:
+        data = {table_name: df, table_name_2: df_2}
+    else:
+        data = {
+            table_name: df,
+        }
+
+    mp = MetaPartition(label="cluster_1", data=data, metadata_version=metadata_version,)
     df_3 = pd.DataFrame(
         OrderedDict(
             [
@@ -309,10 +312,15 @@ def _get_meta_partitions_with_dataframe(
         )
     )
     df_4 = pd.DataFrame(OrderedDict([("P", [2]), ("info", ["b"])]))
+    if table_name_2 is not None:
+        data = {table_name: df_3, table_name_2: df_4}
+    else:
+        data = {
+            table_name: df_3,
+        }
+
     mp2 = MetaPartition(
-        label="cluster_2",
-        data={table_name_2: df_3, "helper": df_4},
-        metadata_version=metadata_version,
+        label="cluster_2", data=data, metadata_version=metadata_version,
     )
     return [mp, mp2]
 
@@ -460,7 +468,7 @@ def alternative_table_name():
     return "other_table"
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def meta_partitions_dataframe_alternative_table_name(
     metadata_version, alternative_table_name
 ):
@@ -470,22 +478,20 @@ def meta_partitions_dataframe_alternative_table_name(
     """
     with cm_frozen_time(TIME_TO_FREEZE):
         return _get_meta_partitions_with_dataframe(
-            metadata_version,
-            table_name=alternative_table_name,
-            table_name_2=alternative_table_name,
+            metadata_version, table_name=alternative_table_name, table_name_2=None,
         )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def meta_partitions_complete_alternative_table_name(
-    meta_partitions_dataframe_alternative_table_name, store_session
+    meta_partitions_dataframe_alternative_table_name, store
 ):
     return _store_metapartitions(
-        meta_partitions_dataframe_alternative_table_name, store_session
+        meta_partitions_dataframe_alternative_table_name, store
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def meta_partitions_files_only_alternative_table_name(
     meta_partitions_complete_alternative_table_name,
 ):
@@ -500,9 +506,9 @@ def meta_partitions_files_only_alternative_table_name(
     return result
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def dataset_alternative_table_name(
-    meta_partitions_files_only_alternative_table_name, store_session_factory
+    meta_partitions_files_only_alternative_table_name, store_factory
 ):
     """
     Create a proper kartothek dataset in store with two partitions
@@ -511,7 +517,7 @@ def dataset_alternative_table_name(
         return store_dataset_from_partitions(
             partition_list=meta_partitions_files_only_alternative_table_name,
             dataset_uuid="dataset_uuid_alternative_name",
-            store=store_session_factory(),
+            store=store_factory(),
             dataset_metadata={"dataset": "metadata"},
         )
 
@@ -527,13 +533,13 @@ def dataset_factory(dataset, store_session_factory):
     )
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def dataset_factory_alternative_table_name(
-    dataset_alternative_table_name, store_session_factory
+    dataset_alternative_table_name, store_factory
 ):
     return DatasetFactory(
         dataset_uuid=dataset_alternative_table_name.uuid,
-        store_factory=store_session_factory,
+        store_factory=store_factory,
         load_schema=True,
         load_all_indices=False,
         load_dataset_metadata=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -279,7 +279,9 @@ def df_not_nested():
     return get_dataframe_not_nested()
 
 
-def _get_meta_partitions_with_dataframe(metadata_version):
+def _get_meta_partitions_with_dataframe(
+    metadata_version, table_name=SINGLE_TABLE, table_name_2=SINGLE_TABLE
+):
     df = pd.DataFrame(
         OrderedDict(
             [
@@ -293,7 +295,7 @@ def _get_meta_partitions_with_dataframe(metadata_version):
     df_2 = pd.DataFrame(OrderedDict([("P", [1]), ("info", ["a"])]))
     mp = MetaPartition(
         label="cluster_1",
-        data={SINGLE_TABLE: df, "helper": df_2},
+        data={table_name: df, "helper": df_2},
         metadata_version=metadata_version,
     )
     df_3 = pd.DataFrame(
@@ -309,7 +311,7 @@ def _get_meta_partitions_with_dataframe(metadata_version):
     df_4 = pd.DataFrame(OrderedDict([("P", [2]), ("info", ["b"])]))
     mp2 = MetaPartition(
         label="cluster_2",
-        data={SINGLE_TABLE: df_3, "helper": df_4},
+        data={table_name_2: df_3, "helper": df_4},
         metadata_version=metadata_version,
     )
     return [mp, mp2]
@@ -454,9 +456,83 @@ def dataset(meta_partitions_files_only, store_session_factory):
 
 
 @pytest.fixture(scope="session")
+def alternative_table_name():
+    return "other_table"
+
+
+@pytest.fixture(scope="session")
+def meta_partitions_dataframe_alternative_table_name(
+    metadata_version, alternative_table_name
+):
+    """
+    Create a list of MetaPartitions for testing. The tables inside the
+    partitions have a non-standard table name.
+    """
+    with cm_frozen_time(TIME_TO_FREEZE):
+        return _get_meta_partitions_with_dataframe(
+            metadata_version,
+            table_name=alternative_table_name,
+            table_name_2=alternative_table_name,
+        )
+
+
+@pytest.fixture(scope="session")
+def meta_partitions_complete_alternative_table_name(
+    meta_partitions_dataframe_alternative_table_name, store_session
+):
+    return _store_metapartitions(
+        meta_partitions_dataframe_alternative_table_name, store_session
+    )
+
+
+@pytest.fixture(scope="session")
+def meta_partitions_files_only_alternative_table_name(
+    meta_partitions_complete_alternative_table_name,
+):
+    """
+    Create a list of MetaPartitions for testing. The partitions
+    only include external file references with data stored in store
+    """
+    result = []
+    for mp in meta_partitions_complete_alternative_table_name:
+        mp = mp.copy(data={})
+        result.append(mp)
+    return result
+
+
+@pytest.fixture(scope="session")
+def dataset_alternative_table_name(
+    meta_partitions_files_only_alternative_table_name, store_session_factory
+):
+    """
+    Create a proper kartothek dataset in store with two partitions
+    """
+    with cm_frozen_time(TIME_TO_FREEZE):
+        return store_dataset_from_partitions(
+            partition_list=meta_partitions_files_only_alternative_table_name,
+            dataset_uuid="dataset_uuid_alternative_name",
+            store=store_session_factory(),
+            dataset_metadata={"dataset": "metadata"},
+        )
+
+
+@pytest.fixture(scope="session")
 def dataset_factory(dataset, store_session_factory):
     return DatasetFactory(
         dataset_uuid=dataset.uuid,
+        store_factory=store_session_factory,
+        load_schema=True,
+        load_all_indices=False,
+        load_dataset_metadata=True,
+    )
+
+
+@pytest.fixture(scope="session")
+def dataset_factory_alternative_table_name(
+    dataset_alternative_table_name, store_session_factory
+):
+    return DatasetFactory(
+        dataset_uuid=dataset_alternative_table_name.uuid,
         store_factory=store_session_factory,
         load_schema=True,
         load_all_indices=False,

--- a/tests/io/dask/dataframe/test_update.py
+++ b/tests/io/dask/dataframe/test_update.py
@@ -21,18 +21,19 @@ def _unwrap_partition(part):
 def _update_dataset(partitions, *args, **kwargs):
     # TODO: Simplify once parse_input_to_metapartition is removed / obsolete
     if isinstance(partitions, pd.DataFrame):
-        table_name = "core"
+        if "table" not in kwargs.keys():
+            kwargs["table"] = "core"
         partitions = dd.from_pandas(partitions, npartitions=1)
     elif any(partitions):
-        table_name = next(iter(dict(partitions[0]["data"]).keys()))
+        kwargs["table"] = next(iter(dict(partitions[0]["data"]).keys()))
         delayed_partitions = [
             dask.delayed(_unwrap_partition)(part) for part in partitions
         ]
         partitions = dd.from_delayed(delayed_partitions)
     else:
-        table_name = "core"
+        kwargs["table"] = "core"
         partitions = None
-    ddf = update_dataset_from_ddf(partitions, *args, table=table_name, **kwargs)
+    ddf = update_dataset_from_ddf(partitions, *args, **kwargs)
 
     s = pickle.dumps(ddf, pickle.HIGHEST_PROTOCOL)
     ddf = pickle.loads(s)

--- a/tests/io/dask/delayed/test_update.py
+++ b/tests/io/dask/delayed/test_update.py
@@ -9,7 +9,7 @@ from kartothek.io.testing.update import *  # noqa
 
 @pytest.fixture
 def bound_update_dataset():
-    return _update_dataset
+    return _update_dataset_delayed
 
 
 @dask.delayed
@@ -17,7 +17,7 @@ def _unwrap_partition(part):
     return next(iter(dict(part["data"]).values()))
 
 
-def _update_dataset(partitions, *args, **kwargs):
+def _update_dataset_delayed(partitions, *args, **kwargs):
     if not isinstance(partitions, list):
         partitions = [partitions]
     tasks = update_dataset_from_delayed(partitions, *args, **kwargs)

--- a/tests/io/iter/test_update.py
+++ b/tests/io/iter/test_update.py
@@ -9,10 +9,10 @@ from kartothek.io.testing.update import *  # noqa
 
 @pytest.fixture()
 def bound_update_dataset():
-    return _update_dataset
+    return _update_dataset_iter
 
 
-def _update_dataset(df_list, *args, **kwargs):
+def _update_dataset_iter(df_list, *args, **kwargs):
     if isinstance(df_list, pd.DataFrame):
         df_list = [df_list]
     df_generator = (x for x in df_list)


### PR DESCRIPTION
# Description:

Added additional tests to test the behavior of read / update operations with non-standard table names (i.e., tables which are not named "table") within datasets. These tests can be used as regression tests, when the handling of table names changes.


- BY internal: Refers to #LDE-1325

