### PR TITLE
Fixed error of wrong type by removing warning for distinct categoricals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 Version 5.3.0 (2021-11-26)
 ==========================
 * Add Deprecation warnings and migration helpers in order to facilitate the Kartothek version 6.0.0 migration.
+* Removed warning for distinct categoricals (#501)
 
 
 Version 5.2.0 (2021-11-22)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-Version 5.3.0 (2021-11-26)
+Version 5.3.0 (2021-12-10)
 ==========================
 * Add Deprecation warnings and migration helpers in order to facilitate the Kartothek version 6.0.0 migration.
 * Removed warning for distinct categoricals (#501)

--- a/kartothek/io/dask/_utils.py
+++ b/kartothek/io/dask/_utils.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 
-import warnings
 from functools import partial
 
 import pandas as pd
@@ -11,8 +10,6 @@ try:
     from cytoolz import map
 except ImportError:
     pass
-
-CATEGORICAL_EFFICIENCY_WARN_LIMIT = 100000
 
 
 def _identity():
@@ -49,12 +46,6 @@ def _cast_categorical_to_index_cat(df, categories):
 def _construct_categorical(column, dataset_metadata_factory):
     dataset_metadata = dataset_metadata_factory.load_index(column)
     values = dataset_metadata.indices[column].index_dct.keys()
-    if len(values) > CATEGORICAL_EFFICIENCY_WARN_LIMIT:
-        warnings.warn(
-            "Column {} has {} distinct values, reading as categorical may increase memory consumption.",
-            column,
-            len(values),
-        )
     return pd.api.types.CategoricalDtype(values, ordered=False)
 
 


### PR DESCRIPTION
# Description:
Removing warning which could never have succeed because it was syntactically wrong

- [x] Closes #501
- [x] Changelog entry
