### PR TITLE
Handle pandas NA values in 'filter_array_like'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 5.3.1 (2022-1-18)
+==========================
+* Forced ``pandas.NA`` to always evaluate to ``False`` when compared in :meth:`~kartothek.serialization._generic.filter_array_like`. Stays aligned with numpy semantics.
+
+
 Version 5.3.0 (2021-12-10)
 ==========================
 * Add Deprecation warnings and migration helpers in order to facilitate the Kartothek version 6.0.0 migration.

--- a/kartothek/serialization/_generic.py
+++ b/kartothek/serialization/_generic.py
@@ -419,7 +419,7 @@ def _ensure_type_stability(
 
 def logical_and(comparison, mask, out):
     # To conform pandas behavior to numpy behavior, force any NA values
-    # to be `False`, ie differ from `value`
+    # to be `False`, ie differ from `value` whenever compared
     if isinstance(comparison, pd.api.extensions.ExtensionArray):
         res = comparison.fillna(False)
 


### PR DESCRIPTION
# Description:

A recent pandas bug fix https://github.com/pandas-dev/pandas/issues/45249 changed the way pandas handles NA values. The buggy way, which is not aligned with how pandas NA values work, was to treat it as 'None of the Above'. In other words, in `filter_array_like`, `pd.NA == True` and `pd.NA == False` would both return `False`. The correct pandas semantics is for `pd.NA == True` and `pd.NA == False` to equal `pd.NA`. That however diverges from numpy where numpy assumes the 'None of the Above' semantic. 

This patch forces pandas to use the 'None of the Above' semantic, to keep it inline with numpy semantics.


- [X] Closes #504 
- [x] Changelog entry
