### PR TITLE
Move to minimalkv

### DIFF
--- a/.github/workflows/ci-pre-commit.yml
+++ b/.github/workflows/ci-pre-commit.yml
@@ -6,6 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-    - uses: pre-commit/action@v2.0.3
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+    - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
       matrix:
         numfocus_nightly: [false]
         os: ["ubuntu-latest"]
-        pyarrow: ["0.17.1", "1.0.1", "2.0.0", "3.0.0", "4.0.1", "5.0.0", "6.0.1", "nightly"]
-        python: ["3.7", "3.8"]
+        pyarrow: ["2.0.0", "3.0.0", "4.0.1", "5.0.0", "6.0.1", "nightly"]
+        python: ["3.8"]
         include:
           - numfocus_nightly: true
             os: "ubuntu-latest"
@@ -33,7 +33,7 @@ jobs:
             python: "3.8"
           - numfocus_nightly: false
             os: "macos-latest"
-            pyarrow: "0.17.1"
+            pyarrow: "5.0.0"
             python: "3.8"
     continue-on-error: ${{ matrix.numfocus_nightly || matrix.pyarrow == 'nightly' }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,11 +9,12 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2.1.1
+      - name: Mamba Docs environment
+        uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: docs/environment-docs.yml
-          activate-environment: kartothek-docs
+          environment-name: kartothek-docs
+          cache-downloads: true
 
       - name: List conda
         shell: bash -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
-  - repo: https://github.com/ambv/black
-    rev: 19.10b0
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
     hooks:
       - id: black
         args:
           - --safe
-          - --target-version=py36
+          - --target-version=py38
 
   - repo: https://github.com/asottile/blacken-docs
     rev: v1.7.0
@@ -13,7 +13,7 @@ repos:
     -   id: blacken-docs
         additional_dependencies: [black==19.10b0]
         args:
-          - --target-version=py36
+          - --target-version=py38
 
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.3
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.21
+    rev: v5.10.1
     hooks:
     -   id: isort
         additional_dependencies: [toml]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+Version 5.4.0 (unreleased)
+==========================
+* Moved from storefact and simplekv to minimalkv. Previous stores and urls are compatible.
+
 Version 5.3.0 (2021-12-10)
 ==========================
 * Add Deprecation warnings and migration helpers in order to facilitate the Kartothek version 6.0.0 migration.

--- a/asv_bench/benchmarks/filter.py
+++ b/asv_bench/benchmarks/filter.py
@@ -26,7 +26,7 @@ class TimeFilterDF:
                 [("int32", "<", 321)],
                 [("int32", "<", 321)],
             ]
-        self.df = get_dataframe_not_nested(10 ** 5)
+        self.df = get_dataframe_not_nested(10**5)
 
     def time_filter_df_from_predicates(self, predicate):
         filter_df_from_predicates(self.df, self.predicate)
@@ -48,7 +48,7 @@ class TimeFilterArray:
         if column == "null":
             raise NotImplementedError()
         self.arr = (
-            get_dataframe_not_nested(10 ** 5)
+            get_dataframe_not_nested(10**5)
             .sample(frac=1.0)
             .reset_index(drop=True)[column]
             .values
@@ -69,7 +69,7 @@ class TimeFilterArrayIn:
     params = (
         cols_to_filter,
         [10, 100, 1000],
-        [10 ** 4, 10 ** 5, 10 ** 6],
+        [10**4, 10**5, 10**6],
     )
     param_names = ["column", "filter_size", "array_size", "enabled"]
 

--- a/asv_bench/benchmarks/index.py
+++ b/asv_bench/benchmarks/index.py
@@ -60,8 +60,8 @@ class IndexBase(AsvBenchmarkConfig):
 
 class Index(IndexBase):
     params = (
-        [10 * 1, 10 ** 3],  # values
-        [10 * 1, 10 ** 3],  # partitions
+        [10 * 1, 10**3],  # values
+        [10 * 1, 10**3],  # partitions
         [(int, pa.int64())],  # types
     )
     param_names = ["number_values", "number_partitions", "dtype"]
@@ -93,7 +93,7 @@ class Index(IndexBase):
 class SerializeIndex(IndexBase):
     timeout = 180
     params = (
-        [(10 ** 3, 10), (10 ** 4, 100)],  # (values, partitions)
+        [(10**3, 10), (10**4, 100)],  # (values, partitions)
         [(int, pa.int64())],  # types
     )
     param_names = ["number_values__number_partitions", "dtype"]
@@ -117,7 +117,7 @@ class SerializeIndex(IndexBase):
 
 
 class BuildIndex(AsvBenchmarkConfig):
-    params = ([-1, 1], [10 ** 3, 10 ** 4], [10, 100])
+    params = ([-1, 1], [10**3, 10**4], [10, 100])
     param_names = ["cardinality", "num_values", "partitions_to_merge"]
 
     def setup(self, cardinality, num_values, partitions_to_merge):

--- a/asv_bench/benchmarks/index.py
+++ b/asv_bench/benchmarks/index.py
@@ -9,10 +9,10 @@ import tempfile
 import uuid
 from functools import lru_cache
 
+import minimalkv
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-import storefact
 
 from kartothek.core.index import ExplicitSecondaryIndex
 from kartothek.io_components.metapartition import MetaPartition
@@ -44,7 +44,7 @@ class IndexBase(AsvBenchmarkConfig):
             column=self.column_name, index_dct=index_dct, dtype=arrow_type
         )
         self.tmp_dir = tempfile.mkdtemp()
-        self.store = storefact.get_store_from_url("hfs://{}".format(self.tmp_dir))
+        self.store = minimalkv.get_store_from_url("hfs://{}".format(self.tmp_dir))
         self.dataset_uuid = "some_uuid"
         self.storage_key = self.ktk_index.store(self.store, self.dataset_uuid)
 

--- a/asv_bench/benchmarks/metapartition.py
+++ b/asv_bench/benchmarks/metapartition.py
@@ -16,7 +16,7 @@ from .config import AsvBenchmarkConfig
 
 class TimeMetaPartition(AsvBenchmarkConfig):
     params = (
-        [10 ** 5, 10 ** 6],
+        [10**5, 10**6],
         [
             (np.int64, 123456789),
             (str, "abcdefgh"),

--- a/asv_bench/benchmarks/predicate_pushdown.py
+++ b/asv_bench/benchmarks/predicate_pushdown.py
@@ -10,7 +10,7 @@ class TimeRestore:
     of iterating over dictionaries in Python.
     """
 
-    params = [(10 ** 3, 10 ** 4), (10, 10 ** 2, 10 ** 3)]
+    params = [(10**3, 10**4), (10, 10**2, 10**3)]
     param_names = ["num_rows", "chunk_size"]
 
     def setup(self, num_rows, chunk_size):

--- a/asv_bench/benchmarks/predicate_pushdown.py
+++ b/asv_bench/benchmarks/predicate_pushdown.py
@@ -1,4 +1,4 @@
-from storefact import get_store_from_url
+from minimalkv import get_store_from_url
 
 from kartothek.serialization import ParquetSerializer
 from kartothek.serialization.testing import get_dataframe_not_nested

--- a/asv_bench/benchmarks/schema.py
+++ b/asv_bench/benchmarks/schema.py
@@ -23,7 +23,7 @@ class TimeMakeMeta(AsvBenchmarkConfig):
 
 class TimeValidateCompatible(AsvBenchmarkConfig):
 
-    params = ([2, 10 ** 2, 10 ** 3, 10 ** 4], [True, False])
+    params = ([2, 10**2, 10**3, 10**4], [True, False])
     timeout = 120.0
 
     param_names = ["num_schemas", "has_na"]
@@ -50,7 +50,7 @@ class TimeValidateCompatible(AsvBenchmarkConfig):
 
 
 class TimeValidateSharedColumns(AsvBenchmarkConfig):
-    params = [2, 10 ** 2]
+    params = [2, 10**2]
     timeout = 120.0
 
     param_names = ["num_schemas"]

--- a/asv_bench/benchmarks/write.py
+++ b/asv_bench/benchmarks/write.py
@@ -4,7 +4,7 @@
 import tempfile
 import uuid
 
-from storefact import get_store_from_url
+from minimalkv import get_store_from_url
 
 from kartothek.core.common_metadata import make_meta
 from kartothek.core.testing import get_dataframe_alltypes

--- a/asv_bench/benchmarks/write.py
+++ b/asv_bench/benchmarks/write.py
@@ -55,7 +55,7 @@ def generate_metadata(max_depth=7, num_leafs=5):
 
 class TimeStoreDataset(AsvBenchmarkConfig):
     timeout = 120
-    params = ([10, 10 ** 2, 10 ** 3], [4], [2, 4])
+    params = ([10, 10**2, 10**3], [4], [2, 4])
     param_names = ["num_partitions", "max_depth", "num_leafs"]
 
     def setup(self, num_partitions, max_depth, num_leafs):
@@ -76,7 +76,7 @@ class TimeStoreDataset(AsvBenchmarkConfig):
 
 class TimePersistMetadata(AsvBenchmarkConfig):
     timeout = 240
-    params = [1, 10 ** 2, 10 ** 3]
+    params = [1, 10**2, 10**3]
 
     def setup(self, num_partitions):
         self.store = get_store_from_url("hfs://{}".format(tempfile.mkdtemp()))

--- a/conda-requirements.txt
+++ b/conda-requirements.txt
@@ -7,8 +7,7 @@ numpy!=1.15.0,!=1.16.0
 pandas>=0.23.0, !=1.0.0
 pyarrow>=0.17.1,!=1.0.0, <7
 simplejson
-simplekv
-storefact
+minimalkv
 toolz
 typing_extensions # Some backports of the py3.8 typing module
 urlquote>=1.1.3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,13 +109,11 @@ nitpick_ignore = [
 
 intersphinx_mapping = {
     "pandas": ("https://pandas.pydata.org/docs/", None),
-    "simplekv": ("https://simplekv.readthedocs.io/en/stable/", None),
+    "minimalkv": ("https://minimalkv.readthedocs.io/en/stable/", None),
     "pyarrow": ("https://arrow.apache.org/docs/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
     "python": ("https://docs.python.org/3", None),
     "dask": ("https://docs.dask.org/en/stable/", None),
-    # Storefact isn't exposing any sphinx refs
-    # "storefact": ("https://storefact.readthedocs.io/en/stable", None),
 }
 
 # In particular type annotations are rendered as its full path to the class but

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -2,6 +2,7 @@ name: kartothek-docs
 channels:
   - conda-forge
 dependencies:
+  - python=3.8
   - dask[dataframe]
   - decorator
   - msgpack-python>=0.5.2
@@ -10,6 +11,7 @@ dependencies:
   - pandas>=0.23.0, !=1.0.0
   - pyarrow>=0.17.1,!=1.0.0, <4
   - simplejson
+  - jinja2<3.1
   - simplekv
   - storefact
   - toolz

--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -12,8 +12,7 @@ dependencies:
   - pyarrow>=0.17.1,!=1.0.0, <4
   - simplejson
   - jinja2<3.1
-  - simplekv
-  - storefact
+  - minimalkv
   - toolz
   - typing_extensions # Some backports of the py3.8 typing module
   - urlquote>=1.1.3

--- a/docs/guide/cube/command_line_features.rst
+++ b/docs/guide/cube/command_line_features.rst
@@ -17,7 +17,7 @@ Command Line Features
        </style>
 
 Kartothek Cube also features a command line interface (CLI) for some cube operations. To use it, create a ``skv.yml`` file that
-describes `storefact`_ stores:
+describes `minimalkv`_ stores:
 
 .. code-block:: yaml
 
@@ -147,5 +147,5 @@ Some information is not available when reading the schema information and requir
 
 Use ``kartothek_cube --help`` to get a list of all commands, or see :mod:`~kartothek.cli`.
 
-.. _storefact: https://github.com/blue-yonder/storefact
+.. _minimalkv: https://github.com/data-engineering-collective/minimalkv
 

--- a/docs/guide/cube/examples.rst
+++ b/docs/guide/cube/examples.rst
@@ -13,14 +13,14 @@ First, we want to create a cube for geodata:
 ...     partition_columns=["country"],
 ... )
 
-Apart from an abstract cube definition, we need a `simplekv`_-based storage backend:
+Apart from an abstract cube definition, we need a `minimalkv`_-based storage backend:
 
 >>> from functools import partial
 >>> import tempfile
->>> import storefact
+>>> import minimalkv
 >>> store_location = tempfile.mkdtemp()
 >>> store_factory = partial(
-...     storefact.get_store_from_url,
+...     minimalkv.get_store_from_url,
 ...     "hfs://" + store_location,
 ... )
 >>> store = store_factory()
@@ -424,4 +424,4 @@ geodata++time/table/_common_metadata
 .. _Dask: https://docs.dask.org/
 .. _Dask.Bag: https://docs.dask.org/en/latest/bag.html
 .. _Dask.DataFrame: https://docs.dask.org/en/latest/dataframe.html
-.. _simplekv: https://simplekv.readthedocs.io/
+.. _minimalkv: https://minimalkv.readthedocs.io/

--- a/docs/guide/cube/glossary.rst
+++ b/docs/guide/cube/glossary.rst
@@ -55,8 +55,8 @@ Glossary
         Dataset that provides the groundtruth about which :term:`Cell` are in a :term:`Cube`.
 
     Store Factory
-        A callable that does not take any arguments and creates a new `simplekv`_ store when being called. Its type is
-        ``Callable[[], simplekv.KeyValueStore]``.
+        A callable that does not take any arguments and creates a new `minimalkv`_ store when being called. Its type is
+        ``Callable[[], minimalkv.KeyValueStore]``.
 
     Query
         A request for data from the cube, including things like "payload columns", "conditions", and more.
@@ -76,4 +76,4 @@ Glossary
 
 .. _Data Cubes: https://en.wikipedia.org/wiki/Data_cube
 .. _Parquet: https://parquet.apache.org/
-.. _simplekv: https://simplekv.readthedocs.io/
+.. _minimalkv: https://minimalkv.readthedocs.io/

--- a/docs/guide/examples.rst
+++ b/docs/guide/examples.rst
@@ -8,7 +8,7 @@ Setup a store
     from tempfile import TemporaryDirectory
 
     # You can, of course, also directly use S3, ABS or anything else
-    # supported by :mod:`storefact`
+    # supported by :mod:`minimalkv`
     dataset_dir = TemporaryDirectory()
     store_url = f"hfs://{dataset_dir.name}"
 

--- a/docs/guide/getting_started.rst
+++ b/docs/guide/getting_started.rst
@@ -51,7 +51,7 @@ We want to store this DataFrame now as a dataset. Therefore, we first need
 to connect to a storage location.
 
 We define a store factory as a callable which contains the storage information.
-We will use `storefact`_ in this example to construct such a store factory
+We will use `minimalkv`_ in this example to construct such a store factory
 for the local filesystem (``hfs://`` indicates we are using the local filesystem and
 what follows is the filepath).
 
@@ -59,7 +59,7 @@ what follows is the filepath).
 
     from functools import partial
     from tempfile import TemporaryDirectory
-    from storefact import get_store_from_url
+    from minimalkv import get_store_from_url
 
     dataset_dir = TemporaryDirectory()
 
@@ -67,8 +67,8 @@ what follows is the filepath).
 
 .. admonition:: Storage locations
 
-    `storefact`_ offers support for several stores in Kartothek, these can be created using the
-    function `storefact.get_store_from_url` with one of the following prefixes:
+    `minimalkv`_ offers support for several stores in Kartothek, these can be created using the
+    function `minimalkv.get_store_from_url` with one of the following prefixes:
 
     - ``hfs``: Local filesystem
     - ``hazure``: AzureBlockBlobStorage
@@ -78,14 +78,13 @@ Interface
 ---------
 
 Kartothek can write to any location that
-fulfills the `simplekv.KeyValueStore interface
-<https://simplekv.readthedocs.io/en/latest/#simplekv.KeyValueStore>`_  as long as they
-support `ExtendedKeyspaceMixin
-<https://github.com/mbr/simplekv/search?q=%22class+ExtendedKeyspaceMixin%22&unscoped_q=%22class+ExtendedKeyspaceMixin%22>`_
+fulfills the `minimalkv.KeyValueStore interface
+<https://minimalkv.readthedocs.io/en/latest/#minimalkv.KeyValueStore>`_  as long as they
+support ``ExtendedKeyspaceMixin``
 (this is necessary so that ``/`` can be used in the storage key name).
 
-For more information, take a look out at the `storefact documentation
-<https://storefact.readthedocs.io/en/latest/reference/storefact.html>`_.
+For more information, take a look out at the `minimalkv documentation
+<https://minimalkv.readthedocs.io/en/latest/reference/minimalkv.html>`_.
 
 
 Writing data to storage
@@ -278,5 +277,5 @@ function but returns a collection of ``dask.delayed`` objects.
         # Read only values table `core-table` where `f` < 2.5
         read_table("two-tables", store_url, table="core-table", predicates=[[("f", "<", 2.5)]])
 
-.. _storefact: https://github.com/blue-yonder/storefact
+.. _minimalkv: https://github.com/data-engineering-collective/minimalkv
 .. _dask: https://docs.dask.org/en/latest/

--- a/docs/guide/mutating_datasets.rst
+++ b/docs/guide/mutating_datasets.rst
@@ -19,7 +19,7 @@ some data there with Kartothek.
     import pandas as pd
     from functools import partial
     from tempfile import TemporaryDirectory
-    from storefact import get_store_from_url
+    from minimalkv import get_store_from_url
 
     from kartothek.api.dataset import store_dataframes_as_dataset
 
@@ -315,7 +315,7 @@ When garbage collection is called, the files are removed.
 .. ipython:: python
 
     from kartothek.api.dataset import garbage_collect_dataset
-    from storefact import get_store_from_url
+    from minimalkv import get_store_from_url
 
     store = get_store_from_url(store_url)
 
@@ -325,7 +325,7 @@ When garbage collection is called, the files are removed.
 
     files_before.difference(store.keys())  # Show files removed
 
-.. _storefact: https://github.com/blue-yonder/storefact
+.. _minimalkv: https://github.com/data-engineering-collective/minimalkv
 
 
 Mutating indexed datasets

--- a/docs/guide/partitioning.rst
+++ b/docs/guide/partitioning.rst
@@ -30,7 +30,7 @@ first and store the data there with Kartothek:
     import pandas as pd
     from functools import partial
     from tempfile import TemporaryDirectory
-    from storefact import get_store_from_url
+    from minimalkv import get_store_from_url
 
     from kartothek.api.dataset import store_dataframes_as_dataset
 

--- a/docs/spec/store_interface.rst
+++ b/docs/spec/store_interface.rst
@@ -4,7 +4,7 @@
 KeyValueStore Interface
 =======================
 
-All storage interaction use ``simplekv.KeyValueStore`` as an storage layer
+All storage interaction use ``minimalkv.KeyValueStore`` as an storage layer
 abstraction. This allows convenient access to many different common Key-Value
 stores (ABS, S3, GCS, local filesystem, etc.) and allows an easy switch between
 the storage backends to facilitate a simpler test setup.
@@ -13,7 +13,7 @@ Generally, all of our public functions accepting a ``store`` argument accept a
 multitude of different input types and we generally accept all kinds of stores
 inheriting from ``KeyValueStore``, assuming they implement the pickle protocol.
 However, there are storages which simply cannot be distributed across processes
-or network nodes sensibly. A prime Example is the ``simplekv.memory.DictStore``
+or network nodes sensibly. A prime example is the ``minimalkv.memory.DictStore``
 which uses a simple python dictionary as a backend store. It is technically
 possible to (de-)serialize the store but once it is deserialized in another
 process, or another node, the store looses its meaning since the stores are
@@ -25,9 +25,8 @@ protocol, or some more complex logic is required to initialize it, kartothek
 also accepts _factories_ which must be a callable returning a ``KeyValueStore``
 (see also ``kartothek.core.typing.StoreFactory``).
 
-For convenience we also offer a `storefact`_ integration and accept store urls
+For convenience we also offer a `minimalkv`_ integration and accept store urls
 which proves another easy level of access and is well suited for ad-hoc
 investigations.
 
-.. _simplekv: https://simplekv.readthedocs.io/
-.. _storefact: https://storefact.readthedocs.io/
+.. _minimalkv: https://minimalkv.readthedocs.io/

--- a/kartothek/api/discover.py
+++ b/kartothek/api/discover.py
@@ -275,7 +275,8 @@ def discover_cube(
         if len(partition_keys) == 0:
             raise ValueError(
                 'Seed dataset ("{seed_dataset}") has no partition keys.'.format(  # type: ignore # noqa
-                    seed_dataset=seed_dataset, partition_keys=", ".join(partition_keys),
+                    seed_dataset=seed_dataset,
+                    partition_keys=", ".join(partition_keys),
                 )
             )
         elif len(partition_keys) < 2:

--- a/kartothek/cli/__init__.py
+++ b/kartothek/cli/__init__.py
@@ -4,7 +4,7 @@ Kartothek CLI code.
 .. important::
     This module does not contain any public APIs.
 
-Kartothek comes with a CLI tool named ``kartothek_cube``. To use it, create an YAML file that contains a dictionary of `storefact`_
+Kartothek comes with a CLI tool named ``kartothek_cube``. To use it, create an YAML file that contains a dictionary of `minimalkv`_
 stores (keys are names of the store and the values are dicts that contain the store config). ``Kartothek`` uses a `YAML`_
 file called ``skv.yml`` and a store called ``dataset`` by default, but you may pass ``--skv`` and ``--store`` to change
 these. An example file could look like:
@@ -30,7 +30,7 @@ In the following section you find a list description of all ``kartothek_cube`` o
 
 
 .. _Dask: https://docs.dask.org/
-.. _storefact: https://github.com/blue-yonder/storefact
+.. _minimalkv: https://github.com/data-engineering-collective/minimalkv
 .. _YAML: https://yaml.org/
 """
 import logging

--- a/kartothek/cli/_utils.py
+++ b/kartothek/cli/_utils.py
@@ -2,7 +2,7 @@ import fnmatch
 from functools import partial
 
 import click
-import storefact
+import minimalkv
 import yaml
 
 from kartothek.api.discover import discover_cube
@@ -18,7 +18,7 @@ def get_cube(store, uuid_prefix):
     ----------
     uuid_prefix: str
         Dataset UUID prefix.
-    store: Union[Callable[[], simplekv.KeyValueStore], simplekv.KeyValueStore]
+    store: Union[Callable[[], minimalkv.KeyValueStore], minimalkv.KeyValueStore]
         KV store.
 
     Returns
@@ -41,18 +41,18 @@ def get_cube(store, uuid_prefix):
 
 def get_store(skv, store):
     """
-    Get simplekv store from storefact config file.
+    Get minimalkv store from minimalkv config file.
 
     Parameters
     ----------
     skv: str
-        Name of the storefact yaml. Normally ``'skv.yml'``.
+        Name of the minimalkv yaml. Normally ``'skv.yml'``.
     store: str
         ID of the store.
 
     Returns
     -------
-    store_factory: Callable[[], simplekv.KeyValueStore]
+    store_factory: Callable[[], minimalkv.KeyValueStore]
         Store object.
 
     Raises
@@ -73,7 +73,7 @@ def get_store(skv, store):
             "Could not find store {store} in {skv}".format(store=store, skv=skv)
         )
 
-    return partial(storefact.get_store, **store_cfg[store])
+    return partial(minimalkv.get_store, **store_cfg[store])
 
 
 def _match_pattern(what, items, pattern):

--- a/kartothek/core/common_metadata.py
+++ b/kartothek/core/common_metadata.py
@@ -12,7 +12,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import simplejson
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.core import naming
 from kartothek.core._compat import load_json

--- a/kartothek/core/dataset.py
+++ b/kartothek/core/dataset.py
@@ -280,7 +280,8 @@ class DatasetMetadataBase(CopyMixin):
         return self.copy(indices=indices)
 
     @deprecate_parameters_if_set(
-        DEPRECATION_WARNING_REMOVE_PARAMETER, "load_partition_indices",
+        DEPRECATION_WARNING_REMOVE_PARAMETER,
+        "load_partition_indices",
     )
     def load_all_indices(
         self: T, store: StoreInput, load_partition_indices: bool = True
@@ -446,7 +447,9 @@ class DatasetMetadataBase(CopyMixin):
             )
         else:
             df = dm._evaluate_conjunction(
-                columns=columns, predicates=None, date_as_object=date_as_object,
+                columns=columns,
+                predicates=None,
+                date_as_object=date_as_object,
             )
         return df
 

--- a/kartothek/core/docs.py
+++ b/kartothek/core/docs.py
@@ -7,11 +7,11 @@ from io import StringIO
 
 _PARAMETER_MAPPING = {
     "store": """
-    store: Callable or str or simplekv.KeyValueStore
+    store: Callable or str or minimalkv.KeyValueStore
         The store where we can find or store the dataset.
 
-        Can be either ``simplekv.KeyValueStore``, a storefact store url or a
-        generic Callable producing a ``simplekv.KeyValueStore``""",
+        Can be either ``minimalkv.KeyValueStore``, a minimalkv store url or a
+        generic Callable producing a ``minimalkv.KeyValueStore``""",
     "overwrite": """
     overwrite: Optional[bool]
         If True, allow overwrite of an existing dataset.""",
@@ -68,12 +68,12 @@ _PARAMETER_MAPPING = {
         `merge_datasets__pipeline` key that contains the source dataset uuids for
         the merge.""",
     "output_store": """
-    output_store : Union[Callable, str, simplekv.KeyValueStore]
+    output_store : Union[Callable, str, minimalkv.KeyValueStore]
         If given, the resulting dataset is written to this store. By default
         the input store.
 
-        Can be either `simplekv.KeyValueStore`, a storefact store url or a
-        generic Callable producing a ``simplekv.KeyValueStore``""",
+        Can be either `minimalkv.KeyValueStore`, a minimalkv store url or a
+        generic Callable producing a ``minimalkv.KeyValueStore``""",
     "metadata": """
     metadata : Optional[Dict]
         A dictionary used to update the dataset metadata.""",

--- a/kartothek/core/factory.py
+++ b/kartothek/core/factory.py
@@ -12,7 +12,7 @@ from kartothek.utils.migration_helpers import (
 )
 
 if TYPE_CHECKING:
-    from simplekv import KeyValueStore
+    from minimalkv import KeyValueStore
 
 __all__ = ("DatasetFactory",)
 
@@ -49,7 +49,7 @@ class DatasetFactory(DatasetMetadataBase):
         .. code::
 
             from functools import partial
-            from storefact import get_store_from_url
+            from minimalkv import get_store_from_url
             from kartothek.io.eager import read_table
 
             ds_factory = DatasetFactory(

--- a/kartothek/core/factory.py
+++ b/kartothek/core/factory.py
@@ -165,7 +165,9 @@ class DatasetFactory(DatasetMetadataBase):
         "load_partition_indices",
     )
     def load_all_indices(
-        self: T, store: Any = None, load_partition_indices: bool = True,
+        self: T,
+        store: Any = None,
+        load_partition_indices: bool = True,
     ) -> T:
         self._cache_metadata = self.dataset_metadata.load_all_indices(
             self.store, load_partition_indices=load_partition_indices

--- a/kartothek/core/typing.py
+++ b/kartothek/core/typing.py
@@ -1,6 +1,6 @@
 from typing import Callable, Union
 
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 StoreFactory = Callable[[], KeyValueStore]
 StoreInput = Union[str, KeyValueStore, StoreFactory]

--- a/kartothek/core/utils.py
+++ b/kartothek/core/utils.py
@@ -2,8 +2,7 @@ import pickle
 from functools import partial
 from typing import Any, Union, cast
 
-from simplekv import KeyValueStore
-from storefact import get_store_from_url
+from minimalkv import KeyValueStore, get_store_from_url
 
 from kartothek.core.naming import MAX_METADATA_VERSION, MIN_METADATA_VERSION
 from kartothek.core.typing import StoreFactory, StoreInput
@@ -50,11 +49,11 @@ def ensure_string_type(obj: Union[bytes, str]) -> str:
         return str(obj)
 
 
-def _is_simplekv_key_value_store(obj: Any) -> bool:
+def _is_minimalkv_key_value_store(obj: Any) -> bool:
     """
-    Check whether ``obj`` is the ``simplekv.KeyValueStore``-like class.
+    Check whether ``obj`` is the ``minimalkv.KeyValueStore``-like class.
 
-    simplekv uses duck-typing, e.g. for decorators. Therefore,
+    minimalkv uses duck-typing, e.g. for decorators. Therefore,
     avoid `isinstance(store, KeyValueStore)`, as it would be unreliable. Instead,
     only roughly verify that `store` looks like a KeyValueStore.
     """
@@ -67,7 +66,7 @@ def ensure_store(store: StoreInput) -> KeyValueStore:
     """
     # This function is often used in an eager context where we may allow
     # non-serializable stores, so skip the pickle test.
-    if _is_simplekv_key_value_store(store):
+    if _is_minimalkv_key_value_store(store):
         return store
     return lazy_store(store)()
 
@@ -97,7 +96,7 @@ def lazy_store(store: StoreInput) -> StoreFactory:
         return ret_val
     else:
 
-        if not _is_simplekv_key_value_store(store):
+        if not _is_minimalkv_key_value_store(store):
             raise TypeError(
                 f"Provided incompatible store type. Got {type(store)} but expected {StoreInput}."
             )

--- a/kartothek/io/dask/_sizeof.py
+++ b/kartothek/io/dask/_sizeof.py
@@ -6,12 +6,12 @@ def _dct_sizeof(obj):
 
 
 def register_sizeof_ktk_classes():
+    from kartothek.core.common_metadata import SchemaWrapper
     from kartothek.core.dataset import DatasetMetadata
     from kartothek.core.factory import DatasetFactory
-    from kartothek.io_components.metapartition import MetaPartition
     from kartothek.core.index import ExplicitSecondaryIndex, PartitionIndex
     from kartothek.core.partition import Partition
-    from kartothek.core.common_metadata import SchemaWrapper
+    from kartothek.io_components.metapartition import MetaPartition
 
     dask_sizeof.register(DatasetMetadata, _dct_sizeof)
     dask_sizeof.register(DatasetFactory, _dct_sizeof)

--- a/kartothek/io/dask/bag_cube.py
+++ b/kartothek/io/dask/bag_cube.py
@@ -4,7 +4,7 @@ Dask.Bag IO.
 from typing import Any, Dict, Iterable, Optional, Union
 
 import dask.bag as db
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.api.discover import discover_datasets_unchecked
 from kartothek.core.cube.cube import Cube
@@ -167,7 +167,7 @@ def query_cube_bag(
     ----------
     cube: Cube
         Cube specification.
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         KV store that preserves the cube.
     conditions: Union[None, Condition, Iterable[Condition], Conjunction]
         Conditions that should be applied, optional.

--- a/kartothek/io/dask/common_cube.py
+++ b/kartothek/io/dask/common_cube.py
@@ -6,7 +6,7 @@ from functools import partial
 from typing import Any, Dict, Iterable, Mapping, Optional, Set
 
 import dask.bag as db
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.api.consistency import get_cube_payload
 from kartothek.api.discover import discover_datasets, discover_datasets_unchecked
@@ -297,7 +297,7 @@ def query_cube_bag_internal(
     ----------
     cube: Cube
         Cube specification.
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         KV store that preserves the cube.
     conditions: Union[None, Condition, Iterable[Condition], Conjunction]
         Conditions that should be applied, optional.

--- a/kartothek/io/dask/compression.py
+++ b/kartothek/io/dask/compression.py
@@ -10,8 +10,7 @@ _PAYLOAD_COL = "__ktk_shuffle_payload"
 
 try:
     # Technically distributed is an optional dependency
-    from distributed.protocol import serialize_bytes
-    from distributed.protocol import deserialize_bytes
+    from distributed.protocol import deserialize_bytes, serialize_bytes
 
     HAS_DISTRIBUTED = True
 except ImportError:

--- a/kartothek/io/dask/dataframe.py
+++ b/kartothek/io/dask/dataframe.py
@@ -281,7 +281,8 @@ def _shuffle_docs(func):
 @default_docs
 @_shuffle_docs
 @deprecate_parameters_if_set(
-    DEPRECATION_WARNING_REMOVE_PARAMETER, "delete_scope",
+    DEPRECATION_WARNING_REMOVE_PARAMETER,
+    "delete_scope",
 )
 def store_dataset_from_ddf(
     ddf: dd.DataFrame,

--- a/kartothek/io/dask/dataframe_cube.py
+++ b/kartothek/io/dask/dataframe_cube.py
@@ -7,7 +7,7 @@ import dask
 import dask.bag as db
 import dask.dataframe as dd
 from dask.delayed import Delayed
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.api.discover import discover_datasets_unchecked
 from kartothek.core.cube.cube import Cube
@@ -210,7 +210,7 @@ def query_cube_dataframe(
     ----------
     cube: Cube
         Cube specification.
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         KV store that preserves the cube.
     conditions: Union[None, Condition, Iterable[Condition], Conjunction]
         Conditions that should be applied, optional.

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union, 
 
 import deprecation
 import pandas as pd
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.core.common_metadata import (
     empty_dataframe_from_schema,
@@ -167,10 +167,10 @@ def read_dataset_as_dataframes(
 
     .. code ::
 
-        >>> import storefact
+        >>> import minimalkv
         >>> from kartothek.io.eager import read_dataset_as_dataframes
 
-        >>> store = storefact.get_store_from_url('s3://bucket_with_dataset')
+        >>> store = minimalkv.get_store_from_url('s3://bucket_with_dataset')
 
         >>> dfs = read_dataset_as_dataframes('dataset_uuid', store, 'core')
 
@@ -249,10 +249,10 @@ def read_dataset_as_metapartitions(
 
     .. code ::
 
-        >>> import storefact
+        >>> import minimalkv
         >>> from kartothek.io.eager import read_dataset_as_dataframe
 
-        >>> store = storefact.get_store_from_url('s3://bucket_with_dataset')
+        >>> store = minimalkv.get_store_from_url('s3://bucket_with_dataset')
 
         >>> list_mps = read_dataset_as_metapartitions('dataset_uuid', store, 'core')
 
@@ -374,10 +374,10 @@ def read_table(
 
     .. code ::
 
-        >>> import storefact
+        >>> import minimalkv
         >>> from kartothek.io.eager import read_table
 
-        >>> store = storefact.get_store_from_url('s3://bucket_with_dataset')
+        >>> store = minimalkv.get_store_from_url('s3://bucket_with_dataset')
 
         >>> df = read_table(store, 'dataset_uuid', 'core')
 
@@ -962,12 +962,12 @@ def copy_dataset(
     ----------
     source_dataset_uuid: str
         UUID of source dataset
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         Source store
     target_dataset_uuid: Optional[str]
         UUID of target dataset. May be the same as src_dataset_uuid, if store
         and tgt_store are different. If empty, src_dataset_uuid is used
-    target_store: Optional[simplekv.KeyValueStore]
+    target_store: Optional[minimalkv.KeyValueStore]
         Target Store. May be the same as store, if src_dataset_uuid and
         target_dataset_uuid are different. If empty, value from parameter store is
         used

--- a/kartothek/io/eager.py
+++ b/kartothek/io/eager.py
@@ -428,7 +428,9 @@ def read_table(
 @default_docs
 @normalize_args
 @deprecate_parameters_if_set(
-    DEPRECATION_WARNING_REMOVE_PARAMETER, "output_dataset_uuid", "df_serializer",
+    DEPRECATION_WARNING_REMOVE_PARAMETER,
+    "output_dataset_uuid",
+    "df_serializer",
 )
 def commit_dataset(
     store: Optional[StoreInput] = None,
@@ -712,7 +714,10 @@ def create_empty_dataset_header(
     "df_serializer",
 )
 @deprecate_parameters_if_set(
-    DEPRECATION_WARNING_REMOVE_PARAMETER, "metadata", "overwrite", "metadata_merger",
+    DEPRECATION_WARNING_REMOVE_PARAMETER,
+    "metadata",
+    "overwrite",
+    "metadata_merger",
 )
 def write_single_partition(
     store: Optional[KeyValueStore] = None,

--- a/kartothek/io/eager_cube.py
+++ b/kartothek/io/eager_cube.py
@@ -5,9 +5,9 @@ import logging
 from collections import defaultdict
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Union
 
+import minimalkv
 import pandas as pd
-import simplekv
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.api.consistency import get_cube_payload
 from kartothek.api.discover import discover_datasets, discover_datasets_unchecked
@@ -342,7 +342,7 @@ def query_cube(
     ----------
     cube: Cube
         Cube specification.
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         KV store that preserves the cube.
     conditions: Union[None, Condition, Iterable[Condition], Conjunction]
         Conditions that should be applied, optional.
@@ -398,7 +398,7 @@ def delete_cube(cube, store, datasets=None):
     ----------
     cube: Cube
         Cube specification.
-    store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         KV store.
     datasets: Union[None, Iterable[str], Dict[str, kartothek.core.dataset.DatasetMetadata]]
         Datasets to delete, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, a list
@@ -478,9 +478,9 @@ def copy_cube(
     ----------
     cube: Cube
         Cube specification.
-    src_store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    src_store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         Source KV store.
-    tgt_store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    tgt_store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         Target KV store.
     overwrite: bool
         If possibly existing datasets in the target store should be overwritten.
@@ -564,7 +564,7 @@ def collect_stats(cube, store, datasets=None):
     ----------
     cube: Cube
         Cube specification.
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         KV store that preserves the cube.
     datasets: Union[None, Iterable[str], Dict[str, kartothek.core.dataset.DatasetMetadata]]
         Datasets to query, must all be part of the cube. May be either the result of :func:`~kartothek.api.discover.discover_datasets`, a list
@@ -602,7 +602,7 @@ def cleanup_cube(cube, store):
     ----------
     cube: Cube
         Cube specification.
-    store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         KV store.
     """
     if callable(store):
@@ -617,7 +617,7 @@ def cleanup_cube(cube, store):
 
 def remove_partitions(
     cube: Cube,
-    store: Union[simplekv.KeyValueStore, StoreFactory],
+    store: Union[minimalkv.KeyValueStore, StoreFactory],
     conditions: Union[None, Condition, Sequence[Condition], Conjunction] = None,
     ktk_cube_dataset_ids: Optional[Union[Sequence[str], str]] = None,
     metadata: Optional[Dict[str, Dict[str, Any]]] = None,

--- a/kartothek/io/iter.py
+++ b/kartothek/io/iter.py
@@ -196,10 +196,10 @@ def read_dataset_as_dataframes__iterator(
 
     .. code ::
 
-        >>> import storefact
+        >>> import minimalkv
         >>> from kartothek.io.iter import read_dataset_as_dataframes__iterator
 
-        >>> store = storefact.get_store_from_url('s3://bucket_with_dataset')
+        >>> store = minimalkv.get_store_from_url('s3://bucket_with_dataset')
 
         >>> dataframes = read_dataset_as_dataframes__iterator('dataset_uuid', store)
         >>> next(dataframes)

--- a/kartothek/io/testing/append_cube.py
+++ b/kartothek/io/testing/append_cube.py
@@ -116,7 +116,10 @@ def test_rowgroups_are_applied_when_df_serializer_is_passed_to_append_cube(
     """
 
     # Build cube
-    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]}, columns=["x", "p"],)
+    df = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]},
+        columns=["x", "p"],
+    )
     cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
     build_cube(
         data=df,
@@ -127,7 +130,8 @@ def test_rowgroups_are_applied_when_df_serializer_is_passed_to_append_cube(
 
     # Append to cube
     df_append = pd.DataFrame(
-        data={"x": [0, 1, 2, 3], "p": [2, 3, 3, 3]}, columns=["x", "p"],
+        data={"x": [0, 1, 2, 3], "p": [2, 3, 3, 3]},
+        columns=["x", "p"],
     )
     result = driver(
         data={"seed": df_append},
@@ -157,17 +161,27 @@ def test_single_rowgroup_when_df_serializer_is_not_passed_to_append_cube(
     """
 
     # Build cube
-    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]}, columns=["x", "p"],)
+    df = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]},
+        columns=["x", "p"],
+    )
     cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
     build_cube(
-        data=df, cube=cube, store=function_store,
+        data=df,
+        cube=cube,
+        store=function_store,
     )
 
     # Append to cube
     df_append = pd.DataFrame(
-        data={"x": [0, 1, 2, 3], "p": [2, 3, 3, 3]}, columns=["x", "p"],
+        data={"x": [0, 1, 2, 3], "p": [2, 3, 3, 3]},
+        columns=["x", "p"],
     )
-    result = driver(data={"seed": df_append}, cube=cube, store=function_store,)
+    result = driver(
+        data={"seed": df_append},
+        cube=cube,
+        store=function_store,
+    )
     dataset = result["seed"].load_all_indices(function_store())
 
     part_num_rows = {0: 2, 1: 2, 2: 1, 3: 3}
@@ -187,7 +201,10 @@ def test_compression_is_compatible_on_append_cube(driver, function_store):
     unnecessarily.
     """
     # Build cube
-    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]}, columns=["x", "p"],)
+    df = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]},
+        columns=["x", "p"],
+    )
     cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
     build_cube(
         data=df,
@@ -198,7 +215,8 @@ def test_compression_is_compatible_on_append_cube(driver, function_store):
 
     # Append to cube
     df_append = pd.DataFrame(
-        data={"x": [0, 1, 2, 3], "p": [2, 3, 3, 3]}, columns=["x", "p"],
+        data={"x": [0, 1, 2, 3], "p": [2, 3, 3, 3]},
+        columns=["x", "p"],
     )
     result = driver(
         data={"seed": df_append},

--- a/kartothek/io/testing/build_cube.py
+++ b/kartothek/io/testing/build_cube.py
@@ -280,7 +280,10 @@ def test_rowgroups_are_applied_when_df_serializer_is_passed_to_build_cube(
     """
     Test that the dataset is split into row groups depending on the chunk size
     """
-    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]}, columns=["x", "p"],)
+    df = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]},
+        columns=["x", "p"],
+    )
 
     cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
     result = driver(
@@ -304,10 +307,17 @@ def test_single_rowgroup_when_df_serializer_is_not_passed_to_build_cube(
     """
     Test that the dataset has a single row group as default path
     """
-    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]}, columns=["x", "p"],)
+    df = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]},
+        columns=["x", "p"],
+    )
 
     cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
-    result = driver(data=df, cube=cube, store=function_store,)
+    result = driver(
+        data=df,
+        cube=cube,
+        store=function_store,
+    )
     dataset = result["seed"].load_all_indices(function_store())
 
     part_num_rows = {0: 1, 1: 3}

--- a/kartothek/io/testing/extend_cube.py
+++ b/kartothek/io/testing/extend_cube.py
@@ -92,7 +92,8 @@ def test_rowgroups_are_applied_when_df_serializer_is_passed_to_extend_cube(
     Test that the dataset is split into row groups depending on the chunk size
     """
     df_extra = pd.DataFrame(
-        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]}, columns=["x", "p"],
+        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]},
+        columns=["x", "p"],
     )
     result = driver(
         data={"extra": df_extra},
@@ -116,9 +117,14 @@ def test_single_rowgroup_when_df_serializer_is_not_passed_to_extend_cube(
     Test that the dataset has a single row group as default path
     """
     df_extra = pd.DataFrame(
-        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]}, columns=["x", "p"],
+        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]},
+        columns=["x", "p"],
     )
-    result = driver(data={"extra": df_extra}, cube=existing_cube, store=function_store,)
+    result = driver(
+        data={"extra": df_extra},
+        cube=existing_cube,
+        store=function_store,
+    )
     dataset = result["extra"].load_all_indices(function_store())
 
     part_num_rows = {0: 1, 1: 3}
@@ -138,7 +144,10 @@ def test_compression_is_compatible_on_extend_cube(driver, function_store):
     unnecessarily.
     """
     # Build cube
-    df = pd.DataFrame(data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]}, columns=["x", "p"],)
+    df = pd.DataFrame(
+        data={"x": [0, 1, 2, 3], "p": [0, 0, 1, 1]},
+        columns=["x", "p"],
+    )
     cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
     build_cube(
         data=df,
@@ -148,7 +157,8 @@ def test_compression_is_compatible_on_extend_cube(driver, function_store):
     )
 
     df_extra = pd.DataFrame(
-        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]}, columns=["x", "p"],
+        data={"x": [0, 1, 2, 3], "p": [0, 1, 1, 1]},
+        columns=["x", "p"],
     )
     result = driver(
         data={"extra": df_extra},

--- a/kartothek/io/testing/read.py
+++ b/kartothek/io/testing/read.py
@@ -39,7 +39,7 @@ import pandas as pd
 import pandas.testing as pdt
 import pyarrow as pa
 import pytest
-from storefact import get_store_from_url
+from minimalkv import get_store_from_url
 
 from kartothek.core.uuid import gen_uuid
 from kartothek.io.eager import store_dataframes_as_dataset

--- a/kartothek/io/testing/update_cube.py
+++ b/kartothek/io/testing/update_cube.py
@@ -133,7 +133,10 @@ def test_rowgroups_are_applied_when_df_serializer_is_passed_to_update_cube(
     ``chunk_size>0`` should be split into row groups accordingly.
     """
     # Build cube
-    df = pd.DataFrame(data={"x": [0, 1], "p": [0, 1]}, columns=["x", "p"],)
+    df = pd.DataFrame(
+        data={"x": [0, 1], "p": [0, 1]},
+        columns=["x", "p"],
+    )
     cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
     build_cube(
         data=df,
@@ -144,7 +147,8 @@ def test_rowgroups_are_applied_when_df_serializer_is_passed_to_update_cube(
 
     # Update cube - replace p=1 and append p=2 partitions
     df_update = pd.DataFrame(
-        data={"x": [0, 1, 2, 3], "p": [1, 1, 2, 2]}, columns=["x", "p"],
+        data={"x": [0, 1, 2, 3], "p": [1, 1, 2, 2]},
+        columns=["x", "p"],
     )
     result = driver(
         data={"seed": df_update},
@@ -173,15 +177,21 @@ def test_single_rowgroup_when_df_serializer_is_not_passed_to_update_cube(
     Test that the dataset has a single row group as default path
     """
     # Build cube
-    df = pd.DataFrame(data={"x": [0, 1], "p": [0, 1]}, columns=["x", "p"],)
+    df = pd.DataFrame(
+        data={"x": [0, 1], "p": [0, 1]},
+        columns=["x", "p"],
+    )
     cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
     build_cube(
-        data=df, cube=cube, store=function_store,
+        data=df,
+        cube=cube,
+        store=function_store,
     )
 
     # Update cube - replace p=1 and append p=2 partitions
     df_update = pd.DataFrame(
-        data={"x": [0, 1, 2, 3], "p": [1, 1, 2, 2]}, columns=["x", "p"],
+        data={"x": [0, 1, 2, 3], "p": [1, 1, 2, 2]},
+        columns=["x", "p"],
     )
     result = driver(
         data={"seed": df_update},
@@ -208,7 +218,10 @@ def test_compression_is_compatible_on_update_cube(driver, function_store):
     unnecessarily.
     """
     # Build cube
-    df = pd.DataFrame(data={"x": [0, 1], "p": [0, 1]}, columns=["x", "p"],)
+    df = pd.DataFrame(
+        data={"x": [0, 1], "p": [0, 1]},
+        columns=["x", "p"],
+    )
     cube = Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="rg-cube")
     build_cube(
         data=df,
@@ -219,7 +232,8 @@ def test_compression_is_compatible_on_update_cube(driver, function_store):
 
     # Update cube - replace p=1 and append p=2 partitions
     df_update = pd.DataFrame(
-        data={"x": [0, 1, 2, 3], "p": [1, 1, 2, 2]}, columns=["x", "p"],
+        data={"x": [0, 1, 2, 3], "p": [1, 1, 2, 2]},
+        columns=["x", "p"],
     )
     result = driver(
         data={"seed": df_update},

--- a/kartothek/io/testing/write.py
+++ b/kartothek/io/testing/write.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pytest
-from storefact import get_store_from_url
+from minimalkv import get_store_from_url
 
 from kartothek.core.dataset import DatasetMetadata
 from kartothek.core.index import ExplicitSecondaryIndex

--- a/kartothek/io_components/cube/cleanup.py
+++ b/kartothek/io_components/cube/cleanup.py
@@ -12,7 +12,7 @@ def get_keys_to_clean(cube_uuid_prefix, datasets, store):
 
     Parameters
     ----------
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         KV store.
     datasets: Dict[str, kartothek.core.dataset.DatasetMetadata]
         Datasets to scan for keys.

--- a/kartothek/io_components/cube/common.py
+++ b/kartothek/io_components/cube/common.py
@@ -29,13 +29,13 @@ def assert_stores_different(store1, store2, prefix):
     """
     Check that given stores are different.
 
-    This is a workaround for tha fact that simplekv stores normally do not implemenent some sane equality check.
+    This is a workaround for tha fact that minimalkv stores normally do not implemenent some sane equality check.
 
     Parameters
     ----------
-    store1: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    store1: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         First store.
-    store2: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    store2: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         Second store, will be used to write a test key to.
     prefix: str
         Prefix to be used for the temporary key used for the equality check.

--- a/kartothek/io_components/cube/copy.py
+++ b/kartothek/io_components/cube/copy.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from copy import copy
 from typing import Callable, Dict, Iterable, Optional, Union
 
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.api.discover import check_datasets, discover_datasets_unchecked
 from kartothek.core.cube.cube import Cube

--- a/kartothek/io_components/cube/query/__init__.py
+++ b/kartothek/io_components/cube/query/__init__.py
@@ -256,7 +256,13 @@ def _reduce_empty_dtype_sizes(df):
 
 
 def plan_query(
-    conditions, cube, datasets, dimension_columns, partition_by, payload_columns, store,
+    conditions,
+    cube,
+    datasets,
+    dimension_columns,
+    partition_by,
+    payload_columns,
+    store,
 ):
     """
     Plan cube query execution.

--- a/kartothek/io_components/cube/query/__init__.py
+++ b/kartothek/io_components/cube/query/__init__.py
@@ -60,7 +60,7 @@ def _load_required_explicit_indices(datasets, intention, store):
         Available datasets.
     intention: kartothek.io_components.cube.query._intention.QueryIntention
         Query intention.
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         Store to query from.
 
     Returns
@@ -286,7 +286,7 @@ def plan_query(
         By which column logical partitions should be formed.
     payload_columns: Optional[Iterable[str]]
         Which columns apart from ``dimension_columns`` and ``partition_by`` should be returned.
-    store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         Store to query from.
 
     Returns

--- a/kartothek/io_components/cube/query/_group.py
+++ b/kartothek/io_components/cube/query/_group.py
@@ -66,7 +66,7 @@ def _load_all_mps(mps, store, load_columns, predicates, empty):
     ----------
     mps: Iterable[MetaPartition]
         MetaPartitions to load.
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         Store to load data from.
     load_columns: List[str]
         Columns to load.
@@ -109,7 +109,7 @@ def _load_partition_dfs(cube, group, partition_mps, store):
         Query group.
     partition_mps: Dict[str, Iterable[MetaPartition]]
         MetaPartitions for every dataset in this partition.
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         Store to load data from.
 
     Returns
@@ -169,7 +169,7 @@ def _load_partition(cube, group, partition_mps, store):
         Query group.
     partition_mps: Dict[str, Iterable[MetaPartition]]
         MetaPartitions for every dataset in this partition.
-    store: simplekv.KeyValueStore
+    store: minimalkv.KeyValueStore
         Store to load data from.
 
     Returns
@@ -200,7 +200,7 @@ def load_group(group, store, cube):
     ----------
     group: QueryGroup
         Query group.
-    store: Union[Callable[[], simplekv.KeyValueStore], simplekv.KeyValueStore]
+    store: Union[Callable[[], minimalkv.KeyValueStore], minimalkv.KeyValueStore]
         Store to load data from.
     cube: kartothek.core.cube.cube.Cube
         Cube specification.

--- a/kartothek/io_components/cube/remove.py
+++ b/kartothek/io_components/cube/remove.py
@@ -22,7 +22,7 @@ def prepare_metapartitions_for_removal_action(
     ----------
     cube: kartothek.core.cube.cube.Cube
         Cube spec.
-    store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         Store.
     conditions: Union[None, Condition, Iterable[Condition], Conjunction]
         Conditions that should be applied, optional. Defaults to "entire cube".

--- a/kartothek/io_components/cube/stats.py
+++ b/kartothek/io_components/cube/stats.py
@@ -73,7 +73,7 @@ def collect_stats_block(metapartitions, store):
     ----------
     metapartitions: Tuple[Tuple[str, Tuple[kartothek.io_components.metapartition.MetaPartition, ...]], ...]
         Part of the result of :meth:`get_metapartitions_for_stats`.
-    store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         KV store.
 
     Returns

--- a/kartothek/io_components/cube/write.py
+++ b/kartothek/io_components/cube/write.py
@@ -417,7 +417,7 @@ def apply_postwrite_checks(datasets, cube, store, existing_datasets):
         Datasets that just got written.
     cube: kartothek.core.cube.cube.Cube
         Cube specification.
-    store: Union[Callable[[], simplekv.KeyValueStore], simplekv.KeyValueStore]
+    store: Union[Callable[[], minimalkv.KeyValueStore], minimalkv.KeyValueStore]
         KV store.
     existing_datasets: Dict[str, kartothek.core.dataset.DatasetMetadata]
         Datasets that were present before the write procedure started.
@@ -538,7 +538,7 @@ def _rollback_transaction(existing_datasets, new_datasets, store):
         Datasets that existings before the write process started.
     new_datasets: Dict[str, kartothek.core.dataset.DatasetMetadata]
         Datasets that where created / changed during the write process.
-    store: Union[Callable[[], simplekv.KeyValueStore], simplekv.KeyValueStore]
+    store: Union[Callable[[], minimalkv.KeyValueStore], minimalkv.KeyValueStore]
         KV store.
     """
     if callable(store):

--- a/kartothek/io_components/metapartition.py
+++ b/kartothek/io_components/metapartition.py
@@ -1285,8 +1285,7 @@ class MetaPartition(Iterable):
         return self.copy(data=new_data, table_meta=new_table_meta)
 
     def as_sentinel(self):
-        """
-        """
+        """ """
         return MetaPartition(
             None,
             metadata_version=self.metadata_version,
@@ -1798,7 +1797,8 @@ def partition_labels_from_mps(mps: List[MetaPartition]) -> List[str]:
 
 
 @deprecate_parameters_if_set(
-    DEPRECATION_WARNING_REMOVE_PARAMETER, "expected_secondary_indices",
+    DEPRECATION_WARNING_REMOVE_PARAMETER,
+    "expected_secondary_indices",
 )
 def parse_input_to_metapartition(
     obj: MetaPartitionInput,

--- a/kartothek/io_components/utils.py
+++ b/kartothek/io_components/utils.py
@@ -119,7 +119,8 @@ def _combine_metadata(dataset_metadata, append_to_list):
 
 
 def _ensure_compatible_indices(
-    dataset: Optional[DatasetMetadataBase], secondary_indices: Optional[Iterable[str]],
+    dataset: Optional[DatasetMetadataBase],
+    secondary_indices: Optional[Iterable[str]],
 ) -> InferredIndices:
     if dataset:
         ds_secondary_indices = list(dataset.secondary_indices.keys())

--- a/kartothek/io_components/write.py
+++ b/kartothek/io_components/write.py
@@ -244,7 +244,8 @@ def store_dataset_from_partitions(
 
 
 @deprecate_parameters_if_set(
-    DEPRECATION_WARNING_REMOVE_PARAMETER, "add_partitions",
+    DEPRECATION_WARNING_REMOVE_PARAMETER,
+    "add_partitions",
 )
 def update_metadata(dataset_builder, metadata_merger, add_partitions, dataset_metadata):
 

--- a/kartothek/serialization/_csv.py
+++ b/kartothek/serialization/_csv.py
@@ -10,8 +10,8 @@ from typing import Any, Dict, Iterable, Optional
 
 import pandas as pd
 import pyarrow as pa
+from minimalkv import KeyValueStore
 from pandas.errors import EmptyDataError
-from simplekv import KeyValueStore
 
 from ._generic import (
     DataFrameSerializer,

--- a/kartothek/serialization/_generic.py
+++ b/kartothek/serialization/_generic.py
@@ -19,8 +19,8 @@ from typing import Dict, Iterable, List, Optional, Set, Tuple, TypeVar
 
 import numpy as np
 import pandas as pd
+from minimalkv import KeyValueStore
 from pandas.api.types import is_list_like
-from simplekv import KeyValueStore
 
 from kartothek.serialization._util import _check_contains_null
 
@@ -37,7 +37,7 @@ PredicatesType = Optional[List[ConjunctionType]]
 class DataFrameSerializer:
     """
     Abstract class that supports serializing DataFrames to/from
-    simplekv stores.
+    minimalkv stores.
 
     :meta public:
     """
@@ -137,7 +137,7 @@ class DataFrameSerializer:
 
         Parameters
         ----------
-        store: simplekv.KeyValueStore
+        store: minimalkv.KeyValueStore
                 store engine
         key_prefix: str
                 Key prefix that specifies a path where object should be

--- a/kartothek/serialization/_generic.py
+++ b/kartothek/serialization/_generic.py
@@ -522,7 +522,9 @@ def filter_array_like(
                 matching_idx |= pd.isnull(array_like)
 
             np.logical_and(
-                matching_idx, mask, out=out,
+                matching_idx,
+                mask,
+                out=out,
             )
         else:
             raise NotImplementedError("op not supported")

--- a/kartothek/serialization/_generic.py
+++ b/kartothek/serialization/_generic.py
@@ -392,6 +392,7 @@ def _ensure_type_stability(
         ("i", "u"),
         # various string kinds
         ("O", "S"),
+        ("S", "O"),
         ("O", "U"),
         # bool w/ Nones
         ("b", "O"),

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -62,7 +62,10 @@ def _reset_dictionary_columns(table, exclude=None):
             continue
         if pa.types.is_dictionary(field.type):
             new_field = pa.field(
-                field.name, field.type.value_type, field.nullable, field.metadata,
+                field.name,
+                field.type.value_type,
+                field.nullable,
+                field.metadata,
             )
             schema = schema.remove(i).insert(i, new_field)
 
@@ -316,7 +319,7 @@ class ParquetSerializer(DataFrameSerializer):
                 )
                 # we don't sleep when we're done with the last attempt
                 if nb_retry < (MAX_NB_RETRIES - 1):
-                    time.sleep(BACKOFF_TIME * 2 ** nb_retry)
+                    time.sleep(BACKOFF_TIME * 2**nb_retry)
 
         raise ParquetReadError(
             f"Failed to restore dataframe after {MAX_NB_RETRIES} attempts. Parameters: "
@@ -632,4 +635,4 @@ def _epsilon(num):
     if epsilon_position < 0:
         epsilon_position += 1
 
-    return 10 ** epsilon_position
+    return 10**epsilon_position

--- a/kartothek/serialization/_parquet.py
+++ b/kartothek/serialization/_parquet.py
@@ -13,8 +13,8 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
+from minimalkv import KeyValueStore
 from pyarrow.parquet import ParquetFile
-from simplekv import KeyValueStore
 
 from ._generic import (
     DataFrameSerializer,
@@ -28,7 +28,7 @@ from ._util import ensure_unicode_string_type
 
 try:
     # Only check for BotoStore instance if boto is really installed
-    from simplekv.net.botostore import BotoStore
+    from minimalkv.net.botostore import BotoStore
 
     HAVE_BOTO = True
 except ImportError:

--- a/kartothek/utils/ktk_adapters.py
+++ b/kartothek/utils/ktk_adapters.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 import deprecation
 import pandas as pd
 import pyarrow.parquet as pq
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.core.factory import DatasetFactory
 from kartothek.core.index import ExplicitSecondaryIndex
@@ -134,7 +134,7 @@ def metadata_factory_from_dataset(dataset, with_schema=True, store=None):
         Already loaded dataset.
     with_schema: bool
         If dataset was loaded with ``load_schema``.
-    store: Optional[Callable[[], simplekv.KeyValueStore]]
+    store: Optional[Callable[[], minimalkv.KeyValueStore]]
         Optional store factory.
 
     Returns
@@ -163,7 +163,7 @@ def get_physical_partition_stats(metapartitions, store):
     ----------
     metapartitions: Iterable[kartothek.io_components.metapartition.MetaPartition]
         Iterable of metapartitions belonging to the same physical partition.
-    store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         KV store.
 
     Returns

--- a/kartothek/utils/migration_helpers.py
+++ b/kartothek/utils/migration_helpers.py
@@ -142,7 +142,9 @@ def get_specific_function_deprecation_warning(
 
 
 def get_specific_function_deprecation_warning_multi_table(
-    function_name: str, deprecated_in: str, removed_in: Optional[str] = None,
+    function_name: str,
+    deprecated_in: str,
+    removed_in: Optional[str] = None,
 ):
     return get_specific_function_deprecation_warning(
         function_name=function_name,
@@ -233,7 +235,9 @@ def raise_warning(
     # gets original trace message if deprecators have been stacked
     warnings.warn(
         _assemble_warning_message(
-            parameter=parameter, message=warning, func_name=func_name,
+            parameter=parameter,
+            message=warning,
+            func_name=func_name,
         ),
         DeprecationWarning,
         stacklevel=stacklevel,
@@ -241,7 +245,9 @@ def raise_warning(
 
 
 def _make_decorator_stackable(
-    wrapper_func: Callable, base_func: Callable, exclude_parameters: Tuple[str],
+    wrapper_func: Callable,
+    base_func: Callable,
+    exclude_parameters: Tuple[str],
 ) -> Callable:
     """
     Attaches neccessary meta info directly to the decorator function's objects making multiple instance of these
@@ -539,9 +545,11 @@ def deprecate_parameters_if_set(warning, *parameters: str) -> Callable:
             else list(inspect.signature(func).parameters.keys())
         )
 
-        parameters_mapping = {  # required for resolving optional parameters being passed as non-kwargs
-            parameter: func_args.index(parameter) for parameter in parameters
-        }
+        parameters_mapping = (
+            {  # required for resolving optional parameters being passed as non-kwargs
+                parameter: func_args.index(parameter) for parameter in parameters
+            }
+        )
         # _make_decorator_stackable required in order to be able to stack multiple of these decorators.
         return _make_decorator_stackable(
             wrapper_func=wraps_func, base_func=func, exclude_parameters=parameters

--- a/kartothek/utils/store.py
+++ b/kartothek/utils/store.py
@@ -1,13 +1,13 @@
 """
-Workarounds for limitations of the simplekv API.
+Workarounds for limitations of the minimalkv API.
 """
 import logging
 import time
 from typing import Callable, Dict, Iterable, Optional, Union
 from urllib.parse import quote
 
-from simplekv import KeyValueStore
-from simplekv.contrib import VALID_KEY_RE_EXTENDED
+from minimalkv import KeyValueStore
+from minimalkv.contrib import VALID_KEY_RE_EXTENDED
 
 from kartothek.core.dataset import DatasetMetadata
 
@@ -218,9 +218,9 @@ def _copy_naive(
     key_mappings: Dict[str, str]
         Mapping of source key names to target key names. May be equal if a key will
         not be renamed.
-    src_store: simplekv.KeyValueStore
+    src_store: minimalkv.KeyValueStore
         Source KV store–
-    tgt_store: simplekv.KeyValueStore
+    tgt_store: minimalkv.KeyValueStore
         Target KV store
     md_transformed: Dict[str, DatasetMetadata]
         Mapping containing {target dataset uuid: modified target metadata} values which will be written
@@ -246,9 +246,9 @@ def copy_rename_keys(
     ----------
     key_mappings: Dict[str, str]
         Dict with {old key: new key} mappings to rename keys during copying
-    src_store: simplekv.KeyValueStore
+    src_store: minimalkv.KeyValueStore
         Source KV store.
-    tgt_store: simplekv.KeyValueStore
+    tgt_store: minimalkv.KeyValueStore
         Target KV store.
     md_transformed:
         Mapping of the new target dataset uuid to the new and potentially renamed metadata of the copied dataset.
@@ -272,9 +272,9 @@ def copy_keys(
     ----------
     keys: Iterable[str]
         Set of keys to copy without renaming;
-    src_store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    src_store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         Source KV store.
-    tgt_store: Union[simplekv.KeyValueStore, Callable[[], simplekv.KeyValueStore]]
+    tgt_store: Union[minimalkv.KeyValueStore, Callable[[], minimalkv.KeyValueStore]]
         Target KV store.
     """
     if callable(src_store):

--- a/kartothek/utils/store.py
+++ b/kartothek/utils/store.py
@@ -13,10 +13,10 @@ from kartothek.core.dataset import DatasetMetadata
 
 try:
     # azure-storage-blob < 12
-    from azure.storage.blob import BlockBlobService as _BlockBlobService
     from azure.common import (
         AzureMissingResourceHttpError as _AzureMissingResourceHttpError,
     )
+    from azure.storage.blob import BlockBlobService as _BlockBlobService
 except ImportError:
 
     class _BlockBlobService:  # type: ignore
@@ -32,8 +32,8 @@ except ImportError:
 
 try:
     # azure-storage-blob >= 12
-    from azure.storage.blob import ContainerClient as _ContainerClient
     from azure.core.exceptions import ResourceNotFoundError as _ResourceNotFoundError
+    from azure.storage.blob import ContainerClient as _ContainerClient
 except ImportError:
 
     class _ContainerClient:  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ exclude = '''
 '''
 
 [tool.isort]
+profile = "black"
 multi_line_output = 3
 include_trailing_comma = true
 line_length = 88

--- a/reference-data/arrow-compat/generate_reference.py
+++ b/reference-data/arrow-compat/generate_reference.py
@@ -2,7 +2,7 @@
 import os
 
 import pyarrow as pa
-from storefact import get_store_from_url
+from minimalkv import get_store_from_url
 
 from kartothek.core.testing import get_dataframe_alltypes
 from kartothek.serialization import ParquetSerializer

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,7 @@ numpy!=1.15.0,!=1.16.0
 pandas>=0.23.0, !=1.0.0
 pyarrow>=0.17.1,!=1.0.0, <7
 simplejson
-simplekv
-storefact
+minimalkv
 toolz
 typing_extensions; python_version<"3.8"  # Some backports of the py3.8 typing module
 urlquote>=1.1.3

--- a/tests/api/test_discover.py
+++ b/tests/api/test_discover.py
@@ -2,7 +2,7 @@ from collections import Counter
 
 import pandas as pd
 import pytest
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.api.discover import (
     discover_cube,

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -3,10 +3,10 @@ import json
 import os
 from datetime import datetime
 
+import minimalkv
 import numpy as np
 import pandas as pd
 import pytest
-import storefact
 from click.testing import CliRunner
 from freezegun import freeze_time
 
@@ -67,7 +67,7 @@ def storecfg2():
 @pytest.fixture
 def azurestorecfg(azure_store_cfg_factory):
     cfg = azure_store_cfg_factory("cli")
-    store = storefact.get_store(**cfg)
+    store = minimalkv.get_store(**cfg)
     for k in list(store.keys()):
         store.delete(k)
     return cfg
@@ -76,7 +76,7 @@ def azurestorecfg(azure_store_cfg_factory):
 @pytest.fixture
 def azurestorecfg2(azure_store_cfg_factory):
     cfg = azure_store_cfg_factory("cli2")
-    store = storefact.get_store(**cfg)
+    store = minimalkv.get_store(**cfg)
     for k in list(store.keys()):
         store.delete(k)
     return cfg
@@ -84,17 +84,17 @@ def azurestorecfg2(azure_store_cfg_factory):
 
 @pytest.fixture
 def store(storecfg):
-    return storefact.get_store(**storecfg)
+    return minimalkv.get_store(**storecfg)
 
 
 @pytest.fixture
 def store2(storecfg2):
-    return storefact.get_store(**storecfg2)
+    return minimalkv.get_store(**storecfg2)
 
 
 @pytest.fixture
 def azurestore(azurestorecfg):
-    store = storefact.get_store(**azurestorecfg)
+    store = minimalkv.get_store(**azurestorecfg)
     yield store
     # prevent ResourceWarning
     gc.collect()
@@ -103,7 +103,7 @@ def azurestore(azurestorecfg):
 
 @pytest.fixture
 def azurestore2(azurestorecfg2):
-    store = storefact.get_store(**azurestorecfg2)
+    store = minimalkv.get_store(**azurestorecfg2)
     yield store
     # prevent ResourceWarning
     gc.collect()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from functools import partial
 
 import pandas as pd
 import pytest
-import storefact
+import minimalkv
 
 # fmt: off
 pytest.register_assert_rewrite("kartothek.io.testing")
@@ -115,7 +115,7 @@ def _refuse_write(*args, **kwargs):
 
 def _get_store(path):
     url = "hfs://{}".format(path)
-    store = storefact.get_store_from_url(url)
+    store = minimalkv.get_store_from_url(url)
     store.delete = partial(_check_and_delete, store=store, delete_orig=store.delete)
     return store
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,7 +300,11 @@ def _get_meta_partitions_with_dataframe(
             table_name: df,
         }
 
-    mp = MetaPartition(label="cluster_1", data=data, metadata_version=metadata_version,)
+    mp = MetaPartition(
+        label="cluster_1",
+        data=data,
+        metadata_version=metadata_version,
+    )
     df_3 = pd.DataFrame(
         OrderedDict(
             [
@@ -320,7 +324,9 @@ def _get_meta_partitions_with_dataframe(
         }
 
     mp2 = MetaPartition(
-        label="cluster_2", data=data, metadata_version=metadata_version,
+        label="cluster_2",
+        data=data,
+        metadata_version=metadata_version,
     )
     return [mp, mp2]
 
@@ -478,7 +484,9 @@ def meta_partitions_dataframe_alternative_table_name(
     """
     with cm_frozen_time(TIME_TO_FREEZE):
         return _get_meta_partitions_with_dataframe(
-            metadata_version, table_name=alternative_table_name, table_name_2=None,
+            metadata_version,
+            table_name=alternative_table_name,
+            table_name_2=None,
         )
 
 

--- a/tests/core/test_dataset_dyn_part.py
+++ b/tests/core/test_dataset_dyn_part.py
@@ -337,6 +337,7 @@ def test_dask_partitions(metadata_version):
     and check that it can be read with kartothek
     """
     import dask.dataframe
+
     partition_suffix = "suffix"
     bucket_dir = tempfile.mkdtemp()
     dataset_uuid = "uuid+namespace-attribute12_underscored"

--- a/tests/core/test_dataset_dyn_part.py
+++ b/tests/core/test_dataset_dyn_part.py
@@ -3,10 +3,10 @@ import random
 import tempfile
 from urllib.parse import quote
 
+import minimalkv
 import numpy as np
 import pandas as pd
 import simplejson
-import storefact
 
 from kartothek.core.common_metadata import (
     _get_common_metadata_key,
@@ -344,7 +344,7 @@ def test_dask_partitions(metadata_version):
     os.mkdir("{}/{}".format(bucket_dir, dataset_uuid))
     table_dir = "{}/{}/core".format(bucket_dir, dataset_uuid)
     os.mkdir(table_dir)
-    store = storefact.get_store_from_url("hfs://{}".format(bucket_dir))
+    store = minimalkv.get_store_from_url("hfs://{}".format(bucket_dir))
 
     locations = ["L-{}".format(i) for i in range(2)]
     df = pd.DataFrame()

--- a/tests/core/test_dataset_dyn_part.py
+++ b/tests/core/test_dataset_dyn_part.py
@@ -337,7 +337,7 @@ def test_dask_partitions(metadata_version):
     and check that it can be read with kartothek
     """
     import dask.dataframe
-
+    partition_suffix = "suffix"
     bucket_dir = tempfile.mkdtemp()
     dataset_uuid = "uuid+namespace-attribute12_underscored"
     os.mkdir("{}/{}".format(bucket_dir, dataset_uuid))
@@ -384,6 +384,15 @@ def test_dask_partitions(metadata_version):
 
     metadata.update(expected_partitions)
     metadata.update(expected_tables)
+    store_schema_metadata(
+        make_meta(
+            pd.DataFrame({"location": ["L-0/{}".format(partition_suffix)]}),
+            origin="stored",
+        ),
+        dataset_uuid,
+        store,
+        "core",
+    )
     dmd = DatasetMetadata.load_from_store(dataset_uuid, store)
     actual_partitions = dmd.to_dict()["partitions"]
     # we partition on location ID which has two values

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,9 +1,8 @@
 from functools import partial
 
 import pytest
-from simplekv import KeyValueStore
-from simplekv.decorator import PrefixDecorator
-from storefact import get_store_from_url
+from minimalkv import KeyValueStore, get_store_from_url
+from minimalkv.decorator import PrefixDecorator
 
 from kartothek.core.utils import ensure_store, lazy_store
 

--- a/tests/io/cube/test_append.py
+++ b/tests/io/cube/test_append.py
@@ -1,10 +1,10 @@
 import pytest
-from tests.io.cube.utils import wrap_bag_write, wrap_ddf_write
 
 from kartothek.io.dask.bag_cube import append_to_cube_from_bag
 from kartothek.io.dask.dataframe_cube import append_to_cube_from_dataframe
 from kartothek.io.eager_cube import append_to_cube
 from kartothek.io.testing.append_cube import *  # noqa
+from tests.io.cube.utils import wrap_bag_write, wrap_ddf_write
 
 
 @pytest.fixture

--- a/tests/io/cube/test_build.py
+++ b/tests/io/cube/test_build.py
@@ -5,13 +5,13 @@ import dask.bag as db
 import dask.core
 import pandas as pd
 import pytest
-from tests.io.cube.utils import wrap_bag_write, wrap_ddf_write
 
 from kartothek.core.cube.cube import Cube
 from kartothek.io.dask.bag_cube import build_cube_from_bag
 from kartothek.io.dask.dataframe_cube import build_cube_from_dataframe
 from kartothek.io.eager_cube import build_cube
 from kartothek.io.testing.build_cube import *  # noqa
+from tests.io.cube.utils import wrap_bag_write, wrap_ddf_write
 
 
 @pytest.fixture

--- a/tests/io/cube/test_cleanup.py
+++ b/tests/io/cube/test_cleanup.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import pytest
-from tests.io.cube.utils import wrap_bag_delete
 
 from kartothek.io.dask.bag_cube import cleanup_cube_bag
 from kartothek.io.eager_cube import cleanup_cube
 from kartothek.io.testing.cleanup_cube import *  # noqa
+from tests.io.cube.utils import wrap_bag_delete
 
 
 @pytest.fixture

--- a/tests/io/cube/test_copy.py
+++ b/tests/io/cube/test_copy.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
-from tests.io.cube.utils import wrap_bag_copy
 
 from kartothek.io.dask.bag_cube import copy_cube_bag
 from kartothek.io.eager_cube import copy_cube
 from kartothek.io.testing.copy_cube import *  # noqa
+from tests.io.cube.utils import wrap_bag_copy
 
 
 @pytest.fixture

--- a/tests/io/cube/test_delete.py
+++ b/tests/io/cube/test_delete.py
@@ -1,9 +1,9 @@
 import pytest
-from tests.io.cube.utils import wrap_bag_delete
 
 from kartothek.io.dask.bag_cube import delete_cube_bag
 from kartothek.io.eager_cube import delete_cube
 from kartothek.io.testing.delete_cube import *  # noqa
+from tests.io.cube.utils import wrap_bag_delete
 
 
 @pytest.fixture

--- a/tests/io/cube/test_extend.py
+++ b/tests/io/cube/test_extend.py
@@ -5,13 +5,13 @@ import dask.bag as db
 import dask.core
 import pandas as pd
 import pytest
-from tests.io.cube.utils import wrap_bag_write, wrap_ddf_write
 
 from kartothek.core.cube.cube import Cube
 from kartothek.io.dask.bag_cube import extend_cube_from_bag
 from kartothek.io.dask.dataframe_cube import extend_cube_from_dataframe
 from kartothek.io.eager_cube import extend_cube
 from kartothek.io.testing.extend_cube import *  # noqa
+from tests.io.cube.utils import wrap_bag_write, wrap_ddf_write
 
 
 @pytest.fixture

--- a/tests/io/cube/test_query.py
+++ b/tests/io/cube/test_query.py
@@ -1,10 +1,10 @@
 import pytest
-from tests.io.cube.utils import wrap_bag_read, wrap_ddf_read
 
 from kartothek.io.dask.bag_cube import query_cube_bag
 from kartothek.io.dask.dataframe_cube import query_cube_dataframe
 from kartothek.io.eager_cube import query_cube
 from kartothek.io.testing.query_cube import *  # noqa
+from tests.io.cube.utils import wrap_bag_read, wrap_ddf_read
 
 
 @pytest.fixture(scope="session")

--- a/tests/io/cube/test_stats.py
+++ b/tests/io/cube/test_stats.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
-from tests.io.cube.utils import wrap_bag_stats
 
 from kartothek.io.dask.bag_cube import collect_stats_bag
 from kartothek.io.eager_cube import collect_stats
 from kartothek.io.testing.stats_cube import *  # noqa
+from tests.io.cube.utils import wrap_bag_stats
 
 
 @pytest.fixture

--- a/tests/io/cube/test_update.py
+++ b/tests/io/cube/test_update.py
@@ -1,8 +1,8 @@
 import pytest
-from tests.io.cube.utils import wrap_bag_write
 
 from kartothek.io.dask.bag_cube import update_cube_from_bag
 from kartothek.io.testing.update_cube import *  # noqa
+from tests.io.cube.utils import wrap_bag_write
 
 
 @pytest.fixture

--- a/tests/io/dask/dataframe/test_stats.py
+++ b/tests/io/dask/dataframe/test_stats.py
@@ -83,7 +83,10 @@ def test_collect_dataset_metadata_predicates_on_index(store_factory):
         data={"P": range(10), "L": ["a", "a", "a", "a", "a", "b", "b", "b", "b", "b"]}
     )
     store_dataframes_as_dataset(
-        store=store_factory, dataset_uuid="dataset_uuid", partition_on=["L"], dfs=[df],
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        partition_on=["L"],
+        dfs=[df],
     )
     predicates = [[("L", "==", "b")]]
 
@@ -211,7 +214,9 @@ def test_collect_dataset_metadata_empty_dataset(store_factory):
         store=store_factory, dataset_uuid="dataset_uuid", dfs=[df], partition_on=["A"]
     )
     df_stats = collect_dataset_metadata(
-        store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table",
     ).compute()
     expected = pd.DataFrame(columns=_METADATA_SCHEMA.keys())
     expected = expected.astype(_METADATA_SCHEMA)
@@ -225,7 +230,9 @@ def test_collect_dataset_metadata_concat(store_factory):
         store=store_factory, dataset_uuid="dataset_uuid", dfs=[df], partition_on=["A"]
     )
     df_stats1 = collect_dataset_metadata(
-        store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table",
     ).compute()
 
     # Remove all partitions of the dataset
@@ -234,7 +241,9 @@ def test_collect_dataset_metadata_concat(store_factory):
     )
 
     df_stats2 = collect_dataset_metadata(
-        store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table",
     ).compute()
     pd.concat([df_stats1, df_stats2])
 
@@ -250,7 +259,9 @@ def test_collect_dataset_metadata_delete_dataset(store_factory):
     )
 
     df_stats = collect_dataset_metadata(
-        store=store_factory, dataset_uuid="dataset_uuid", table_name="table",
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table",
     ).compute()
     expected = pd.DataFrame(columns=_METADATA_SCHEMA)
     expected = expected.astype(_METADATA_SCHEMA)
@@ -261,7 +272,10 @@ def test_collect_dataset_metadata_fraction_precision(store_factory):
     df = pd.DataFrame(data={"A": range(100), "B": range(100)})
 
     store_dataframes_as_dataset(
-        store=store_factory, dataset_uuid="dataset_uuid", dfs=[df], partition_on=["A"],
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        dfs=[df],
+        partition_on=["A"],
     )  # Creates 100 partitions
 
     df_stats = collect_dataset_metadata(
@@ -277,7 +291,10 @@ def test_collect_dataset_metadata_at_least_one_partition(store_factory):
     df = pd.DataFrame(data={"A": range(100), "B": range(100)})
 
     store_dataframes_as_dataset(
-        store=store_factory, dataset_uuid="dataset_uuid", dfs=[df], partition_on=["A"],
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        dfs=[df],
+        partition_on=["A"],
     )  # Creates 100 partitions
 
     df_stats = collect_dataset_metadata(
@@ -302,7 +319,9 @@ def test_collect_dataset_metadata_table_without_partition(store_factory):
     )
 
     df_stats = collect_dataset_metadata(
-        store=store_factory, dataset_uuid="dataset_uuid", table_name="table2",
+        store=store_factory,
+        dataset_uuid="dataset_uuid",
+        table_name="table2",
     ).compute()
     actual = df_stats.drop(
         columns=[

--- a/tests/io/eager/test_copy.py
+++ b/tests/io/eager/test_copy.py
@@ -26,7 +26,10 @@ def assert_target_ktk_readable(tgt_store, tgt_ds):
     """
     Try to read the target dataset using high level KTK functionality
     """
-    df_result = read_table(store=tgt_store, dataset_uuid=tgt_ds,)
+    df_result = read_table(
+        store=tgt_store,
+        dataset_uuid=tgt_ds,
+    )
     assert df_result is not None
     assert len(df_result) == 10
     df_result = read_table(
@@ -45,11 +48,13 @@ def assert_target_keys(src_store, src_uuid, tgt_store, tgt_uuid):
     values are equal to the source data set (or modified as expected)
     """
     df_source = DatasetFactory(
-        dataset_uuid=src_uuid, store_factory=lazy_store(src_store),
+        dataset_uuid=src_uuid,
+        store_factory=lazy_store(src_store),
     )
     src_keys = get_dataset_keys(df_source.dataset_metadata)
     df_target = DatasetFactory(
-        dataset_uuid=tgt_uuid, store_factory=lazy_store(tgt_store),
+        dataset_uuid=tgt_uuid,
+        store_factory=lazy_store(tgt_store),
     )
     tgt_keys = get_dataset_keys(df_target.dataset_metadata)
 

--- a/tests/io_components/test_dataset_metadata_factory.py
+++ b/tests/io_components/test_dataset_metadata_factory.py
@@ -3,7 +3,7 @@ from copy import copy
 from functools import partial
 
 import pytest
-from simplekv import KeyValueStore
+from minimalkv import KeyValueStore
 
 from kartothek.core.factory import DatasetFactory
 

--- a/tests/io_components/test_metapartition.py
+++ b/tests/io_components/test_metapartition.py
@@ -1676,8 +1676,14 @@ def test_parse_input_schema_formats():
 
 def test_get_parquet_metadata(store):
     df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
-    mp = MetaPartition(label="test_label", data={"core": df},)
-    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
+    mp = MetaPartition(
+        label="test_label",
+        data={"core": df},
+    )
+    meta_partition = mp.store_dataframes(
+        store=store,
+        dataset_uuid="dataset_uuid",
+    )
 
     actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
     actual.drop(labels="serialized_size", axis=1, inplace=True)
@@ -1698,8 +1704,14 @@ def test_get_parquet_metadata(store):
 
 def test_get_parquet_metadata_empty_df(store):
     df = pd.DataFrame()
-    mp = MetaPartition(label="test_label", data={"core": df},)
-    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
+    mp = MetaPartition(
+        label="test_label",
+        data={"core": df},
+    )
+    meta_partition = mp.store_dataframes(
+        store=store,
+        dataset_uuid="dataset_uuid",
+    )
 
     actual = meta_partition.get_parquet_metadata(store=store, table_name="core")
     actual.drop(
@@ -1727,7 +1739,10 @@ def test_get_parquet_metadata_empty_df(store):
 
 def test_get_parquet_metadata_row_group_size(store):
     df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
-    mp = MetaPartition(label="test_label", data={"core": df},)
+    mp = MetaPartition(
+        label="test_label",
+        data={"core": df},
+    )
     ps = ParquetSerializer(chunk_size=5)
 
     meta_partition = mp.store_dataframes(
@@ -1758,8 +1773,14 @@ def test_get_parquet_metadata_row_group_size(store):
 
 def test_get_parquet_metadata_table_name_not_str(store):
     df = pd.DataFrame({"P": np.arange(0, 10), "L": np.arange(0, 10)})
-    mp = MetaPartition(label="test_label", data={"core": df, "another_table": df},)
-    meta_partition = mp.store_dataframes(store=store, dataset_uuid="dataset_uuid",)
+    mp = MetaPartition(
+        label="test_label",
+        data={"core": df, "another_table": df},
+    )
+    meta_partition = mp.store_dataframes(
+        store=store,
+        dataset_uuid="dataset_uuid",
+    )
 
     with pytest.raises(TypeError):
         meta_partition.get_parquet_metadata(

--- a/tests/io_components/test_utils.py
+++ b/tests/io_components/test_utils.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pandas.testing as pdt
 import pyarrow as pa
 import pytest
-from storefact import get_store_from_url
+from minimalkv import get_store_from_url
 
 from kartothek.io_components.utils import (
     align_categories,
@@ -92,7 +92,7 @@ def test_normalize_args(test_input, expected):
     assert (expected[0], expected[1], []) == func(test_arg1, test_partition_on)
 
 
-@pytest.mark.parametrize("_type", ["callable", "url", "simplekv"])
+@pytest.mark.parametrize("_type", ["callable", "url", "minimalkv"])
 def test_normalize_store(tmpdir, _type):
 
     store_url = f"hfs://{tmpdir}"
@@ -108,7 +108,7 @@ def test_normalize_store(tmpdir, _type):
         store_test = partial(get_store_from_url, store_url)
     elif _type == "url":
         store_test = store_url
-    elif _type == "simplekv":
+    elif _type == "minimalkv":
         store_test = store
     else:
         raise AssertionError(f"unknown parametrization {_type}")

--- a/tests/serialization/test_arrow_compat.py
+++ b/tests/serialization/test_arrow_compat.py
@@ -6,7 +6,7 @@ import uuid
 
 import pandas.testing as pdt
 import pytest
-from storefact import get_store_from_url
+from minimalkv import get_store_from_url
 
 from kartothek.core.testing import get_dataframe_alltypes
 from kartothek.serialization import ParquetSerializer

--- a/tests/serialization/test_io_buffer.py
+++ b/tests/serialization/test_io_buffer.py
@@ -280,10 +280,10 @@ def test_empty(blocksize):
 
 
 def test_giga():
-    raw_size = 100 * 1024 ** 3  # 100 GB
+    raw_size = 100 * 1024**3  # 100 GB
     raw_inner = _ZeroFile(raw_size)
     raw = _ReadRecordWrapper(raw_inner)
-    blocksize = 4 * 1024 ** 2  # 4MB
+    blocksize = 4 * 1024**2  # 4MB
     b = BlockBuffer(raw, blocksize)
 
     assert b.size == raw_size

--- a/tests/serialization/test_parquet.py
+++ b/tests/serialization/test_parquet.py
@@ -1,12 +1,12 @@
 import os
 from datetime import date, datetime
 
+import minimalkv
 import numpy as np
 import pandas as pd
 import pandas.testing as pdt
 import pyarrow as pa
 import pytest
-import storefact
 from pyarrow.parquet import ParquetFile
 
 from kartothek.serialization import DataFrameSerializer, ParquetSerializer
@@ -27,7 +27,7 @@ def reference_store():
         "reference-data",
         "pyarrow-bugs",
     )
-    return storefact.get_store_from_url("hfs://{}".format(path))
+    return minimalkv.get_store_from_url("hfs://{}".format(path))
 
 
 def test_timestamp_us(store):

--- a/tests/serialization/test_parquet.py
+++ b/tests/serialization/test_parquet.py
@@ -388,7 +388,7 @@ def test_int64_statistics_overflow(reference_store, predicate_pushdown_to_io):
         ([0, 4, 1], True),
         ([-2, 44], False),
         ([-3, 0], True),
-        ([-1, 10 ** 4], False),
+        ([-1, 10**4], False),
         ([2, 3], True),
         ([-1, 20], True),
         ([-30, -5, 50, 10], True),

--- a/tests/utils/test_ktk_adapters.py
+++ b/tests/utils/test_ktk_adapters.py
@@ -30,7 +30,11 @@ def cube_has_ts_col(request):
 
 @pytest.fixture
 def cube():
-    return Cube(dimension_columns=["x"], partition_columns=["p"], uuid_prefix="cube",)
+    return Cube(
+        dimension_columns=["x"],
+        partition_columns=["p"],
+        uuid_prefix="cube",
+    )
 
 
 @pytest.fixture

--- a/tests/utils/test_migration_helpers.py
+++ b/tests/utils/test_migration_helpers.py
@@ -38,7 +38,8 @@ def default_parameter_deprecation_texts_generic(request) -> str:
 
 
 @pytest.fixture(
-    scope="class", params=[DEPRECATION_WARNING_REMOVE_FUNCTION_GENERIC_VERSION],
+    scope="class",
+    params=[DEPRECATION_WARNING_REMOVE_FUNCTION_GENERIC_VERSION],
 )
 def default_function_deprecation_texts_generic(request) -> str:
     return request.param
@@ -279,7 +280,9 @@ def test_deprecate_parameter_stacked_nested(
     # check: Only the first stacked deprecator construct in the callstack should raise warnings.
     with pytest.warns(DeprecationWarning) as warn_record:
         result = func_non_optional_params_multiple_params_stacked_nested(
-            func_non_optional_params_multiple_params_stacked_nested_counterparts, 0, 1,
+            func_non_optional_params_multiple_params_stacked_nested_counterparts,
+            0,
+            1,
         )
 
     # ensures, that the second - nested - deprecator construct does not raise warnings
@@ -298,7 +301,9 @@ def test_deprecate_parameter_stacked_nested_inverse(
     # check: Only the first stacked deprecator construct in the callstack should raise warnings.
     with pytest.warns(DeprecationWarning) as warn_record:
         result = func_non_optional_params_multiple_params_stacked_nested_inverse(
-            func_non_optional_params_multiple_params_stacked_nested_counterparts, 0, 1,
+            func_non_optional_params_multiple_params_stacked_nested_counterparts,
+            0,
+            1,
         )
 
     # ensures, that the second - nested - deprecator construct does not raise warnings
@@ -422,7 +427,8 @@ def test_generic_deprecation_warning(default_deprecation_texts_generic: str):
 
 
 @pytest.fixture(
-    scope="class", params=[False, True],
+    scope="class",
+    params=[False, True],
 )
 def is_test_optional_parameters(request) -> bool:
     return request.param

--- a/tests/utils/test_store.py
+++ b/tests/utils/test_store.py
@@ -2,8 +2,8 @@
 import base64
 import hashlib
 
+import minimalkv
 import pytest
-import storefact
 
 from kartothek.utils.store import (
     _azure_bbs_content_md5,
@@ -33,7 +33,7 @@ def _gen_store(store_type, tmpdir, suffix, azure_store_cfg_factory):
     else:
         raise ValueError("Unknown store type: {}".format(store_type))
 
-    store = storefact.get_store(**cfg)
+    store = minimalkv.get_store(**cfg)
     for k in store.keys():
         store.delete(k)
 
@@ -67,7 +67,7 @@ def store2(request, tmpdir, azure_store_cfg_factory):
 )
 def test_azure_implementation(azure_store_cfg_factory):
     cfg = azure_store_cfg_factory("ts")
-    store = storefact.get_store(**cfg)
+    store = minimalkv.get_store(**cfg)
     assert _has_azure_bbs(store)
     content = b"foo"
     store.put("key0", content)
@@ -85,7 +85,7 @@ def test_azure_implementation(azure_store_cfg_factory):
 )
 def test_azure12_implementation(azure_store_cfg_factory):
     cfg = azure_store_cfg_factory("ts")
-    store = storefact.get_store(**cfg)
+    store = minimalkv.get_store(**cfg)
     assert _has_azure_cc(store)
     content = b"foobar"
     store.put("key0", content)


### PR DESCRIPTION
# Description:
Some time ago in #462 it was discussed that a move to minimalkv is not required as repo access to simplekv will be transfered. As of today the simplekv repository is dead. This is therefore another attempt to move kartothek to minimalkv. I recreated the previous PR as the codebase has changed a bit since the last PR.

Still, this PR should also be credited to @xhochy , because he basically did the same work some time ago.

Functionally nothing should change as minimalkv stores and storefact api are unchanged between the two packages.

Consumers of kartothek will be able to have both minimalkv and storefact and simplekv in the same python environment and use them interchangeably. This PR allows those projects to switch to minimalkv and abandon simplekv gracefully.

The two additional commits part of this PR should be reviewed very carefully: I added them to fix unit tests before starting development. Especially the added type compatibility in serialization/_generic should be reviewed very carefully.

- [ ] Closes #462
- [x] Changelog entry
- [ ] Somebody not @timostrunk checked type compatibility in serialization/_generic
- [ ] Somebody not @timostrunk checked the metadata fix in test_dataset_dyn_part
- [ ] Depends on #532 